### PR TITLE
Add 50 OpenAPI specs from public-apis directory (popular APIs batch 005)

### DIFF
--- a/apis/openapi/abstractapi.com/ip-geolocation/1.0.0/openapi.json
+++ b/apis/openapi/abstractapi.com/ip-geolocation/1.0.0/openapi.json
@@ -1,0 +1,242 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Abstract IP Geolocation API",
+    "description": "Abstract's IP Geolocation API allows you to look up the location, timezone, country details, currency, security data, and more for any IPv4 or IPv6 address. Covers 4 billion+ IPs across 2.25+ million unique locations and 250,000+ cities worldwide. Data is updated at least weekly.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Abstract API",
+      "url": "https://www.abstractapi.com"
+    },
+    "x-jentic-source-url": "https://www.abstractapi.com/ip-geolocation-api"
+  },
+  "servers": [
+    {
+      "url": "https://ipgeolocation.abstractapi.com/v1",
+      "description": "Production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geolocation",
+      "description": "IP geolocation lookup operations"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["Geolocation"],
+        "summary": "Geolocate an IP address",
+        "description": "Takes an IP address (IPv4 or IPv6) and returns location, timezone, country details, currency, ASN, security flags, and more.",
+        "operationId": "geolocateIp",
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "description": "Your unique API key for authentication",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "ip_address",
+            "in": "query",
+            "required": true,
+            "description": "The IPv4 or IPv6 address to geolocate",
+            "schema": { "type": "string" },
+            "example": "166.171.248.255"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of response fields to include (returns all if omitted)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GeolocationResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid IP address or parameters",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API key"
+          },
+          "422": {
+            "description": "Unprocessable entity - request understood but cannot be processed"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "description": "API key for authentication, obtained from Abstract API dashboard"
+      }
+    },
+    "schemas": {
+      "GeolocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip_address": {
+            "type": "string",
+            "description": "The IP address that was looked up"
+          },
+          "city": {
+            "type": "string",
+            "description": "City name"
+          },
+          "city_geoname_id": {
+            "type": "integer",
+            "description": "GeoNames city ID"
+          },
+          "region": {
+            "type": "string",
+            "description": "Region/state name"
+          },
+          "region_iso_code": {
+            "type": "string",
+            "description": "ISO region code"
+          },
+          "region_geoname_id": {
+            "type": "integer",
+            "description": "GeoNames region ID"
+          },
+          "postal_code": {
+            "type": "string",
+            "description": "Postal/ZIP code"
+          },
+          "country": {
+            "type": "string",
+            "description": "Country name"
+          },
+          "country_code": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code"
+          },
+          "country_geoname_id": {
+            "type": "integer",
+            "description": "GeoNames country ID"
+          },
+          "country_is_eu": {
+            "type": "boolean",
+            "description": "Whether the country is in the EU"
+          },
+          "continent": {
+            "type": "string",
+            "description": "Continent name"
+          },
+          "continent_code": {
+            "type": "string",
+            "description": "Continent code"
+          },
+          "continent_geoname_id": {
+            "type": "integer",
+            "description": "GeoNames continent ID"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude"
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude"
+          },
+          "security": { "$ref": "#/components/schemas/SecurityInfo" },
+          "timezone": { "$ref": "#/components/schemas/TimezoneInfo" },
+          "flag": { "$ref": "#/components/schemas/FlagInfo" },
+          "currency": { "$ref": "#/components/schemas/CurrencyInfo" },
+          "connection": { "$ref": "#/components/schemas/ConnectionInfo" }
+        }
+      },
+      "SecurityInfo": {
+        "type": "object",
+        "properties": {
+          "is_vpn": { "type": "boolean", "description": "Whether the IP is a known VPN" },
+          "is_proxy": { "type": "boolean", "description": "Whether the IP is a known proxy" },
+          "is_tor": { "type": "boolean", "description": "Whether the IP is a Tor exit node" },
+          "is_hosting": { "type": "boolean", "description": "Whether the IP belongs to a hosting provider" },
+          "is_relay": { "type": "boolean", "description": "Whether the IP is a known relay" },
+          "is_mobile": { "type": "boolean", "description": "Whether the IP is a mobile connection" },
+          "is_abuse": { "type": "boolean", "description": "Whether the IP has been flagged for abuse" }
+        }
+      },
+      "TimezoneInfo": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "IANA timezone name" },
+          "abbreviation": { "type": "string", "description": "Timezone abbreviation" },
+          "gmt_offset": { "type": "integer", "description": "GMT offset in hours" },
+          "current_time": { "type": "string", "description": "Current local time" },
+          "is_dst": { "type": "boolean", "description": "Whether DST is active" }
+        }
+      },
+      "FlagInfo": {
+        "type": "object",
+        "properties": {
+          "emoji": { "type": "string", "description": "Country flag emoji" },
+          "unicode": { "type": "string", "description": "Flag emoji unicode" },
+          "png": { "type": "string", "format": "uri", "description": "URL to PNG flag image" },
+          "svg": { "type": "string", "format": "uri", "description": "URL to SVG flag image" }
+        }
+      },
+      "CurrencyInfo": {
+        "type": "object",
+        "properties": {
+          "currency_name": { "type": "string", "description": "Currency name" },
+          "currency_code": { "type": "string", "description": "ISO currency code" }
+        }
+      },
+      "ConnectionInfo": {
+        "type": "object",
+        "properties": {
+          "autonomous_system_number": { "type": "integer", "description": "ASN number" },
+          "autonomous_system_organization": { "type": "string", "description": "ASN organization name" },
+          "connection_type": { "type": "string", "description": "Connection type" },
+          "isp_name": { "type": "string", "description": "ISP name" },
+          "organization_name": { "type": "string", "description": "Organization name" }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "message": { "type": "string", "description": "Error message" },
+              "code": { "type": "string", "description": "Error code" },
+              "details": { "type": "string", "description": "Error details" }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/abstractapi.com/ip-geolocation/meta.json
+++ b/apis/openapi/abstractapi.com/ip-geolocation/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "497459ba4724e71ef96820d04ce9effb",
+    "format": "openapi",
+    "vendor": "abstractapi.com",
+    "api_name": "ip-geolocation",
+    "friendly_id": "abstractapi.com/ip-geolocation"
+  }
+}

--- a/apis/openapi/apiip.net/apiip/1.0.0/openapi.json
+++ b/apis/openapi/apiip.net/apiip/1.0.0/openapi.json
@@ -1,0 +1,506 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Apiip - IP Geolocation API",
+    "description": "Apiip provides a fast and accurate IP geolocation API. Locate and identify website visitors by IP address, returning detailed location data including city, region, country, coordinates, timezone, currency, and more.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Apiip Support",
+      "url": "https://apiip.net/contact"
+    },
+    "x-jentic-source-url": "https://apiip.net/"
+  },
+  "servers": [
+    {
+      "url": "https://apiip.net",
+      "description": "Apiip Production API"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "IP Lookup",
+      "description": "IP address geolocation lookups"
+    },
+    {
+      "name": "Bulk Lookup",
+      "description": "Bulk IP address lookups"
+    }
+  ],
+  "paths": {
+    "/api/check": {
+      "get": {
+        "operationId": "lookupRequesterIp",
+        "summary": "Requester IP Lookup",
+        "description": "Look up geolocation data for the IP address of the client making the API request.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/check/{ip}": {
+      "get": {
+        "operationId": "lookupSingleIp",
+        "summary": "Single IP Lookup",
+        "description": "Look up geolocation data for a specific IPv4 or IPv6 address.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "path",
+            "required": true,
+            "description": "IPv4 or IPv6 address to look up.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "67.250.186.196"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "IP address not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/check/{ips}": {
+      "get": {
+        "operationId": "lookupBulkIps",
+        "summary": "Bulk IP Lookup",
+        "description": "Look up geolocation data for multiple IP addresses at once (comma-separated).",
+        "tags": ["Bulk Lookup"],
+        "parameters": [
+          {
+            "name": "ips",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of IPv4 or IPv6 addresses.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "67.250.186.196,188.45.33.1"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful bulk geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeolocationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "accessKey",
+        "description": "API access key obtained from the Apiip dashboard."
+      }
+    },
+    "parameters": {
+      "AccessKey": {
+        "name": "accessKey",
+        "in": "query",
+        "required": true,
+        "description": "Your Apiip API access key.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Fields": {
+        "name": "fields",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated list of response fields to return.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Language": {
+        "name": "language",
+        "in": "query",
+        "required": false,
+        "description": "2-letter language code to localize output (e.g. 'en', 'de').",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Output": {
+        "name": "output",
+        "in": "query",
+        "required": false,
+        "description": "Response format: json or xml.",
+        "schema": {
+          "type": "string",
+          "enum": ["json", "xml"]
+        }
+      }
+    },
+    "schemas": {
+      "GeolocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "description": "The requested IP address."
+          },
+          "type": {
+            "type": "string",
+            "description": "IP address type (ipv4 or ipv6).",
+            "enum": ["ipv4", "ipv6"]
+          },
+          "continentCode": {
+            "type": "string",
+            "description": "2-letter continent code."
+          },
+          "continentName": {
+            "type": "string",
+            "description": "Full continent name."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "2-letter country code (ISO 3166-1 alpha-2)."
+          },
+          "countryName": {
+            "type": "string",
+            "description": "Full country name."
+          },
+          "countryNameNative": {
+            "type": "string",
+            "description": "Country name in native language."
+          },
+          "officialCountryName": {
+            "type": "string",
+            "description": "Official full country name."
+          },
+          "regionCode": {
+            "type": "string",
+            "description": "Region/state code."
+          },
+          "regionName": {
+            "type": "string",
+            "description": "Full region/state name."
+          },
+          "city": {
+            "type": "string",
+            "description": "City name."
+          },
+          "postalCode": {
+            "type": "string",
+            "description": "Postal/ZIP code."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude coordinate."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude coordinate."
+          },
+          "capital": {
+            "type": "string",
+            "description": "Capital city of the country."
+          },
+          "phoneCode": {
+            "type": "string",
+            "description": "International dialing code."
+          },
+          "countryFlagEmoj": {
+            "type": "string",
+            "description": "Country flag emoji."
+          },
+          "countryFlagEmojUnicode": {
+            "type": "string",
+            "description": "Country flag emoji unicode."
+          },
+          "isEu": {
+            "type": "boolean",
+            "description": "Whether the country is in the European Union."
+          },
+          "borders": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of bordering country ISO codes."
+          },
+          "topLevelDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Country top-level domains."
+          },
+          "languages": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Languages spoken (code to name mapping)."
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "timezone": {
+            "$ref": "#/components/schemas/Timezone"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/Connection"
+          },
+          "security": {
+            "$ref": "#/components/schemas/SecurityInfo"
+          }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "3-letter currency code (ISO 4217)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Currency name."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Currency symbol."
+          },
+          "number": {
+            "type": "string",
+            "description": "ISO 4217 numeric code."
+          },
+          "exchangeRate": {
+            "type": "number",
+            "description": "Exchange rate to USD."
+          }
+        }
+      },
+      "Timezone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "IANA timezone identifier."
+          },
+          "currentTime": {
+            "type": "string",
+            "description": "Current local date and time."
+          },
+          "code": {
+            "type": "string",
+            "description": "Timezone abbreviation."
+          },
+          "isDaylightSaving": {
+            "type": "boolean",
+            "description": "Whether DST is active."
+          },
+          "gmtOffset": {
+            "type": "integer",
+            "description": "GMT offset in seconds."
+          }
+        }
+      },
+      "Connection": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "type": "integer",
+            "description": "Autonomous System Number."
+          },
+          "isp": {
+            "type": "string",
+            "description": "Internet Service Provider name."
+          }
+        }
+      },
+      "SecurityInfo": {
+        "type": "object",
+        "properties": {
+          "isProxy": {
+            "type": "boolean",
+            "description": "Whether the IP is a known proxy."
+          },
+          "isCrawler": {
+            "type": "boolean",
+            "description": "Whether the IP is a known crawler."
+          },
+          "isTor": {
+            "type": "boolean",
+            "description": "Whether the IP is a Tor exit node."
+          },
+          "isBot": {
+            "type": "boolean",
+            "description": "Whether the IP is a known bot."
+          },
+          "threatLevel": {
+            "type": "string",
+            "description": "Assessed threat level.",
+            "enum": ["low", "medium", "high"]
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Error status.",
+            "example": "fail"
+          },
+          "message": {
+            "type": "string",
+            "description": "Human-readable error description."
+          },
+          "code": {
+            "type": "integer",
+            "description": "Error code."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/apiip.net/apiip/meta.json
+++ b/apis/openapi/apiip.net/apiip/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "ba47c3ae1adc9d9d3d703dd4a1196a5d",
+    "format": "openapi",
+    "vendor": "apiip.net",
+    "api_name": "apiip",
+    "friendly_id": "apiip.net/apiip"
+  }
+}

--- a/apis/openapi/code.gov/code-gov/2.0.0/openapi.json
+++ b/apis/openapi/code.gov/code-gov/2.0.0/openapi.json
@@ -1,0 +1,764 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Code.gov API",
+    "description": "The Code.gov API provides access to the U.S. Federal Government's open source software inventory. It allows searching and retrieving metadata about code repositories published by federal agencies under the Federal Source Code Policy.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "Code.gov",
+      "url": "https://code.gov"
+    },
+    "license": {
+      "name": "Creative Commons Zero v1.0 Universal",
+      "url": "https://creativecommons.org/publicdomain/zero/1.0/"
+    },
+    "x-jentic-source-url": "https://code.gov"
+  },
+  "servers": [
+    {
+      "url": "https://api.code.gov/api",
+      "description": "Code.gov API production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "repos",
+      "description": "Federal source code repositories"
+    },
+    {
+      "name": "terms",
+      "description": "Indexed terms from repository data"
+    },
+    {
+      "name": "agencies",
+      "description": "Federal agencies with code inventories"
+    },
+    {
+      "name": "languages",
+      "description": "Programming languages used across the inventory"
+    },
+    {
+      "name": "status",
+      "description": "Agency compliance status information"
+    },
+    {
+      "name": "version",
+      "description": "API version information"
+    }
+  ],
+  "paths": {
+    "/repos": {
+      "get": {
+        "summary": "Search and list repositories",
+        "description": "Retrieve indexed code repositories with full-text search and filtering capabilities.",
+        "operationId": "listRepos",
+        "tags": ["repos"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Full-text search query across all indexed repository properties.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Offset for pagination.",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "agency.name",
+            "in": "query",
+            "description": "Filter by agency name.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "agency.acronym",
+            "in": "query",
+            "description": "Filter by agency acronym.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "agency.website",
+            "in": "query",
+            "description": "Filter by agency website URL.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "description": "Filter by repository status.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "vcs",
+            "in": "query",
+            "description": "Filter by version control system.",
+            "schema": { "type": "string", "enum": ["git", "svn"] }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Filter by repository name.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "organization",
+            "in": "query",
+            "description": "Filter by organization.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "tags",
+            "in": "query",
+            "description": "Filter by repository tags.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "languages",
+            "in": "query",
+            "description": "Filter by programming languages.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "contact.name",
+            "in": "query",
+            "description": "Filter by contact name.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "contact.email",
+            "in": "query",
+            "description": "Filter by contact email.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "permissions.licenses.name",
+            "in": "query",
+            "description": "Filter by license name.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "permissions.usageType",
+            "in": "query",
+            "description": "Filter by usage type.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["openSource", "governmentWideReuse", "exemptByLaw", "exemptByNationalSecurity", "exemptByAgencySystem", "exemptByAgencyMission", "exemptByCIO", "exemptByPolicyDate"]
+              }
+            }
+          },
+          {
+            "name": "laborHours",
+            "in": "query",
+            "description": "Filter by labor hours dedicated.",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "date.created",
+            "in": "query",
+            "description": "Filter by creation date. Supports range operators (_gte, _lte, _gt, _lt).",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "date.lastModified",
+            "in": "query",
+            "description": "Filter by last modification date. Supports range operators (_gte, _lte, _gt, _lt).",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of repositories.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepoListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repos/{repoId}": {
+      "get": {
+        "summary": "Get a specific repository",
+        "description": "Retrieve details for a specific code repository by its unique identifier.",
+        "operationId": "getRepo",
+        "tags": ["repos"],
+        "parameters": [
+          {
+            "name": "repoId",
+            "in": "path",
+            "required": true,
+            "description": "Unique identifier for the repository.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with repository details.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Repo" }
+              }
+            }
+          },
+          "404": {
+            "description": "Repository not found.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/terms": {
+      "get": {
+        "summary": "List indexed terms",
+        "description": "Extract indexed terms from the repository data for faceting and filtering.",
+        "operationId": "listTerms",
+        "tags": ["terms"],
+        "parameters": [
+          {
+            "name": "term",
+            "in": "query",
+            "description": "Filter by term value (partial matching supported).",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "term_type",
+            "in": "query",
+            "description": "Filter by term type.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Offset for pagination.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of terms.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Term" }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agencies": {
+      "get": {
+        "summary": "List all agencies",
+        "description": "Retrieve all federal agencies that have code inventories in the system.",
+        "operationId": "listAgencies",
+        "tags": ["agencies"],
+        "parameters": [
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of agencies to return.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Offset for pagination.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort direction by agency name.",
+            "schema": { "type": "string", "enum": ["asc", "desc"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of agencies.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Agency" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/agencies/{agency_acronym}": {
+      "get": {
+        "summary": "Get a specific agency",
+        "description": "Retrieve information about a specific federal agency by its acronym.",
+        "operationId": "getAgency",
+        "tags": ["agencies"],
+        "parameters": [
+          {
+            "name": "agency_acronym",
+            "in": "path",
+            "required": true,
+            "description": "Agency acronym (e.g., GSA, DOD, NASA).",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with agency details.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Agency" }
+              }
+            }
+          },
+          "404": {
+            "description": "Agency not found.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/languages": {
+      "get": {
+        "summary": "List programming languages",
+        "description": "Retrieve a list of programming languages used across the federal code inventory.",
+        "operationId": "listLanguages",
+        "tags": ["languages"],
+        "parameters": [
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of languages to return.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Offset for pagination.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of languages.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Language" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/repo.json": {
+      "get": {
+        "summary": "Get repository JSON schema",
+        "description": "Access the repository JSON schema definition used for code inventory validation.",
+        "operationId": "getRepoJson",
+        "tags": ["repos"],
+        "responses": {
+          "200": {
+            "description": "Successful response with JSON schema.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status.json": {
+      "get": {
+        "summary": "Get compliance status data",
+        "description": "Retrieve agency compliance status data in JSON format.",
+        "operationId": "getStatusJson",
+        "tags": ["status"],
+        "responses": {
+          "200": {
+            "description": "Successful response with compliance status data.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "summary": "Get compliance dashboard",
+        "description": "View an HTML-rendered compliance dashboard showing agency compliance with the Federal Source Code Policy.",
+        "operationId": "getStatus",
+        "tags": ["status"],
+        "responses": {
+          "200": {
+            "description": "HTML page showing compliance status.",
+            "content": {
+              "text/html": {
+                "schema": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status/{agencyName}/issues": {
+      "get": {
+        "summary": "Get agency compliance issues",
+        "description": "List grouped repository validation issues for a specific agency.",
+        "operationId": "getAgencyIssues",
+        "tags": ["status"],
+        "parameters": [
+          {
+            "name": "agencyName",
+            "in": "path",
+            "required": true,
+            "description": "Agency name.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "HTML page listing agency issues.",
+            "content": {
+              "text/html": {
+                "schema": { "type": "string" }
+              }
+            }
+          },
+          "404": {
+            "description": "Agency not found.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/status/{agencyName}/fetched": {
+      "get": {
+        "summary": "Get agency fetched repositories",
+        "description": "Display indexed repositories for a specific agency.",
+        "operationId": "getAgencyFetched",
+        "tags": ["status"],
+        "parameters": [
+          {
+            "name": "agencyName",
+            "in": "path",
+            "required": true,
+            "description": "Agency name.",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with agency repositories.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Repo" }
+              }
+            }
+          },
+          "404": {
+            "description": "Agency not found.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "summary": "Get API version",
+        "description": "Retrieve the current API version and build information.",
+        "operationId": "getVersion",
+        "tags": ["version"],
+        "responses": {
+          "200": {
+            "description": "Successful response with version information.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Version" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Repo": {
+        "type": "object",
+        "properties": {
+          "repoID": {
+            "type": "string",
+            "description": "Unique identifier for the repository."
+          },
+          "name": {
+            "type": "string",
+            "description": "Repository name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the repository."
+          },
+          "tags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Tags associated with the repository."
+          },
+          "contact": {
+            "$ref": "#/components/schemas/Contact"
+          },
+          "agency": {
+            "$ref": "#/components/schemas/Agency"
+          },
+          "laborHours": {
+            "type": "number",
+            "description": "Labor hours dedicated to the project."
+          },
+          "repositoryURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the source code repository."
+          },
+          "homepageURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the project homepage."
+          },
+          "permissions": {
+            "$ref": "#/components/schemas/Permissions"
+          },
+          "vcs": {
+            "type": "string",
+            "description": "Version control system type."
+          },
+          "disclaimerText": {
+            "type": "string",
+            "description": "Disclaimer text for the repository."
+          },
+          "disclaimerURL": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to full disclaimer."
+          },
+          "relatedCode": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "URL": { "type": "string", "format": "uri" }
+              }
+            },
+            "description": "Related code repositories."
+          },
+          "reusedCode": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "URL": { "type": "string", "format": "uri" }
+              }
+            },
+            "description": "Code reused from other sources."
+          },
+          "date": {
+            "type": "object",
+            "properties": {
+              "created": { "type": "string", "format": "date-time" },
+              "lastModified": { "type": "string", "format": "date-time" },
+              "metadataLastUpdated": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      },
+      "RepoListResponse": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching repositories."
+          },
+          "repos": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Repo" }
+          }
+        }
+      },
+      "Contact": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "email": { "type": "string", "format": "email" },
+          "twitter": { "type": "string" },
+          "phone": { "type": "string" }
+        }
+      },
+      "Agency": {
+        "type": "object",
+        "properties": {
+          "acronym": {
+            "type": "string",
+            "description": "Agency acronym."
+          },
+          "name": {
+            "type": "string",
+            "description": "Full agency name."
+          },
+          "website": {
+            "type": "string",
+            "format": "uri",
+            "description": "Agency website URL."
+          },
+          "codeUrl": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the agency's code.json file."
+          },
+          "numRepos": {
+            "type": "integer",
+            "description": "Number of repositories indexed for this agency."
+          }
+        }
+      },
+      "Permissions": {
+        "type": "object",
+        "properties": {
+          "usageType": {
+            "type": "string",
+            "enum": ["openSource", "governmentWideReuse", "exemptByLaw", "exemptByNationalSecurity", "exemptByAgencySystem", "exemptByAgencyMission", "exemptByCIO", "exemptByPolicyDate"],
+            "description": "Type of usage permission."
+          },
+          "exemptionText": {
+            "type": "string",
+            "description": "Text explaining the exemption, if applicable."
+          },
+          "licenses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "URL": { "type": "string", "format": "uri" },
+                "name": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "Term": {
+        "type": "object",
+        "properties": {
+          "term_key": { "type": "string" },
+          "term": { "type": "string" },
+          "term_type": { "type": "string" },
+          "count": { "type": "integer" },
+          "count_normalized": { "type": "number" },
+          "score": { "type": "number" }
+        }
+      },
+      "Language": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Programming language name."
+          },
+          "numRepos": {
+            "type": "integer",
+            "description": "Number of repositories using this language."
+          }
+        }
+      },
+      "Version": {
+        "type": "object",
+        "properties": {
+          "version": { "type": "string" },
+          "git-hash": { "type": "string" },
+          "git-repository": { "type": "string" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/code.gov/code-gov/meta.json
+++ b/apis/openapi/code.gov/code-gov/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "48ef54e6b5eaa5510e5d19f17914c1bc",
+    "format": "openapi",
+    "vendor": "code.gov",
+    "api_name": "code-gov",
+    "friendly_id": "code.gov/code-gov"
+  }
+}

--- a/apis/openapi/company-information.service.gov.uk/uk-companies-house/1.0.0/openapi.json
+++ b/apis/openapi/company-information.service.gov.uk/uk-companies-house/1.0.0/openapi.json
@@ -1,0 +1,1540 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "UK Companies House Public Data API",
+    "description": "The Companies House API provides read-only access to search and retrieve public company data for companies registered in the United Kingdom. It includes company profiles, officer details, filing history, charges, insolvency data, persons with significant control, and more.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Companies House",
+      "url": "https://developer.company-information.service.gov.uk/"
+    },
+    "x-jentic-source-url": "https://developer.company-information.service.gov.uk/"
+  },
+  "servers": [
+    {
+      "url": "https://api.company-information.service.gov.uk",
+      "description": "Companies House API production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    { "name": "search", "description": "Search across companies, officers, and disqualified officers" },
+    { "name": "company", "description": "Company profile and registered office" },
+    { "name": "officers", "description": "Company officers and appointments" },
+    { "name": "filing-history", "description": "Company filing history" },
+    { "name": "charges", "description": "Company charges and security interests" },
+    { "name": "insolvency", "description": "Company insolvency information" },
+    { "name": "registers", "description": "Company registers" },
+    { "name": "exemptions", "description": "Company exemptions" },
+    { "name": "disqualifications", "description": "Disqualified officers" },
+    { "name": "appointments", "description": "Officer appointments" },
+    { "name": "uk-establishments", "description": "UK establishments of overseas companies" },
+    { "name": "psc", "description": "Persons with significant control" }
+  ],
+  "paths": {
+    "/search": {
+      "get": {
+        "summary": "Search all",
+        "description": "Search across all indexed resources including companies, officers, and disqualified officers.",
+        "operationId": "searchAll",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/search/companies": {
+      "get": {
+        "summary": "Search companies",
+        "description": "Search for companies by name or company number.",
+        "operationId": "searchCompanies",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful company search response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanySearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/search/officers": {
+      "get": {
+        "summary": "Search officers",
+        "description": "Search for company officers by name.",
+        "operationId": "searchOfficers",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful officer search response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/search/disqualified-officers": {
+      "get": {
+        "summary": "Search disqualified officers",
+        "description": "Search for disqualified officers by name.",
+        "operationId": "searchDisqualifiedOfficers",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/alphabetical-search/companies": {
+      "get": {
+        "summary": "Alphabetical company search",
+        "description": "Search for a company alphabetically.",
+        "operationId": "alphabeticalSearchCompanies",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Company name to search for.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "search_above",
+            "in": "query",
+            "description": "Company name to search above in alphabetical order.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "search_below",
+            "in": "query",
+            "description": "Company name to search below in alphabetical order.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of results to return.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanySearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/dissolved-search/companies": {
+      "get": {
+        "summary": "Search dissolved companies",
+        "description": "Search for dissolved companies.",
+        "operationId": "searchDissolvedCompanies",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Company name to search for.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "search_type",
+            "in": "query",
+            "description": "Type of search.",
+            "schema": { "type": "string", "enum": ["alphabetical", "best-match", "previous-name-dissolved"] }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Start index for results.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanySearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/advanced-search/companies": {
+      "get": {
+        "summary": "Advanced company search",
+        "description": "Advanced search for companies with multiple filter criteria.",
+        "operationId": "advancedSearchCompanies",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "company_name_includes",
+            "in": "query",
+            "description": "Company name must include these terms.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "company_name_excludes",
+            "in": "query",
+            "description": "Company name must not include these terms.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "description": "Registered office address location.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "incorporated_from",
+            "in": "query",
+            "description": "Incorporation date from (yyyy-MM-dd).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "incorporated_to",
+            "in": "query",
+            "description": "Incorporation date to (yyyy-MM-dd).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "company_status",
+            "in": "query",
+            "description": "Company status filter.",
+            "schema": { "type": "string", "enum": ["active", "dissolved", "open", "closed", "converted-closed", "receivership", "liquidation", "administration", "insolvency-proceedings", "voluntary-arrangement"] }
+          },
+          {
+            "name": "company_type",
+            "in": "query",
+            "description": "Company type filter.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "company_subtype",
+            "in": "query",
+            "description": "Company subtype filter.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "sic_codes",
+            "in": "query",
+            "description": "SIC code filter.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "dissolved_from",
+            "in": "query",
+            "description": "Dissolved date from (yyyy-MM-dd).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "dissolved_to",
+            "in": "query",
+            "description": "Dissolved date to (yyyy-MM-dd).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Number of results to return.",
+            "schema": { "type": "integer", "default": 20 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanySearchResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/company/{companyNumber}": {
+      "get": {
+        "summary": "Get company profile",
+        "description": "Retrieve the full profile for a company by its company number.",
+        "operationId": "getCompanyProfile",
+        "tags": ["company"],
+        "parameters": [
+          { "$ref": "#/components/parameters/companyNumber" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with company profile.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CompanyProfile" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{companyNumber}/registered-office-address": {
+      "get": {
+        "summary": "Get registered office address",
+        "description": "Retrieve the registered office address for a company.",
+        "operationId": "getRegisteredOfficeAddress",
+        "tags": ["company"],
+        "parameters": [
+          { "$ref": "#/components/parameters/companyNumber" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with address.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RegisteredOfficeAddress" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/officers": {
+      "get": {
+        "summary": "List company officers",
+        "description": "Retrieve a list of officers for a company.",
+        "operationId": "listCompanyOfficers",
+        "tags": ["officers"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "description": "The company number.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "description": "Number of results per page.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "description": "Index of the first result to return.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "order_by",
+            "in": "query",
+            "description": "Field to sort results by.",
+            "schema": { "type": "string", "enum": ["appointed_on", "resigned_on", "surname"] }
+          },
+          {
+            "name": "register_type",
+            "in": "query",
+            "description": "Register type to filter by.",
+            "schema": { "type": "string", "enum": ["directors", "secretaries", "llp-members"] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/OfficerList" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/appointments/{appointment_id}": {
+      "get": {
+        "summary": "Get officer appointment",
+        "description": "Retrieve details of a specific officer appointment.",
+        "operationId": "getOfficerAppointment",
+        "tags": ["officers"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "appointment_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/filing-history": {
+      "get": {
+        "summary": "List filing history",
+        "description": "Retrieve the filing history for a company.",
+        "operationId": "listFilingHistory",
+        "tags": ["filing-history"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "Filing category filter.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 25 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FilingHistoryList" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/filing-history/{transaction_id}": {
+      "get": {
+        "summary": "Get filing history item",
+        "description": "Retrieve a specific filing history transaction.",
+        "operationId": "getFilingHistoryItem",
+        "tags": ["filing-history"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "transaction_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/FilingHistoryItem" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/charges": {
+      "get": {
+        "summary": "List company charges",
+        "description": "Retrieve a list of charges (mortgages/security interests) for a company.",
+        "operationId": "listCharges",
+        "tags": ["charges"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 25 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ChargeList" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/charges/{charge_id}": {
+      "get": {
+        "summary": "Get charge details",
+        "description": "Retrieve details of a specific charge.",
+        "operationId": "getCharge",
+        "tags": ["charges"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "charge_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/insolvency": {
+      "get": {
+        "summary": "Get insolvency information",
+        "description": "Retrieve insolvency information for a company.",
+        "operationId": "getInsolvency",
+        "tags": ["insolvency"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/InsolvencyResource" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/registers": {
+      "get": {
+        "summary": "Get company registers",
+        "description": "Retrieve register information for a company.",
+        "operationId": "getRegisters",
+        "tags": ["registers"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/exemptions": {
+      "get": {
+        "summary": "Get company exemptions",
+        "description": "Retrieve exemption information for a company.",
+        "operationId": "getExemptions",
+        "tags": ["exemptions"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/uk-establishments": {
+      "get": {
+        "summary": "List UK establishments",
+        "description": "Retrieve UK establishments for an overseas company.",
+        "operationId": "listUkEstablishments",
+        "tags": ["uk-establishments"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/persons-with-significant-control": {
+      "get": {
+        "summary": "List persons with significant control",
+        "description": "Retrieve persons with significant control (PSC) for a company.",
+        "operationId": "listPSC",
+        "tags": ["psc"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "schema": { "type": "integer", "default": 25 }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "register_view",
+            "in": "query",
+            "description": "Display register view.",
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PSCList" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/persons-with-significant-control/individual/{psc_id}": {
+      "get": {
+        "summary": "Get individual PSC",
+        "description": "Retrieve details of an individual person with significant control.",
+        "operationId": "getIndividualPSC",
+        "tags": ["psc"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "psc_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/persons-with-significant-control/corporate-entity/{psc_id}": {
+      "get": {
+        "summary": "Get corporate entity PSC",
+        "description": "Retrieve details of a corporate entity with significant control.",
+        "operationId": "getCorporateEntityPSC",
+        "tags": ["psc"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "psc_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/persons-with-significant-control/legal-person/{psc_id}": {
+      "get": {
+        "summary": "Get legal person PSC",
+        "description": "Retrieve details of a legal person with significant control.",
+        "operationId": "getLegalPersonPSC",
+        "tags": ["psc"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "psc_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/company/{company_number}/persons-with-significant-control-statements": {
+      "get": {
+        "summary": "List PSC statements",
+        "description": "Retrieve PSC statements for a company.",
+        "operationId": "listPSCStatements",
+        "tags": ["psc"],
+        "parameters": [
+          {
+            "name": "company_number",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "type": "object" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/disqualified-officers/natural/{officer_id}": {
+      "get": {
+        "summary": "Get natural disqualified officer",
+        "description": "Retrieve details of a natural person who is disqualified.",
+        "operationId": "getNaturalDisqualifiedOfficer",
+        "tags": ["disqualifications"],
+        "parameters": [
+          {
+            "name": "officer_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DisqualifiedOfficer" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/disqualified-officers/corporate/{officer_id}": {
+      "get": {
+        "summary": "Get corporate disqualified officer",
+        "description": "Retrieve details of a corporate entity that is disqualified.",
+        "operationId": "getCorporateDisqualifiedOfficer",
+        "tags": ["disqualifications"],
+        "parameters": [
+          {
+            "name": "officer_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/DisqualifiedOfficer" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/officers/{officer_id}/appointments": {
+      "get": {
+        "summary": "List officer appointments",
+        "description": "Retrieve a list of appointments for an officer.",
+        "operationId": "listOfficerAppointments",
+        "tags": ["appointments"],
+        "parameters": [
+          {
+            "name": "officer_id",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "items_per_page",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "start_index",
+            "in": "query",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AppointmentList" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "API key passed as Basic authentication in the Authorization header. Use your API key as the username with an empty password."
+      }
+    },
+    "parameters": {
+      "companyNumber": {
+        "name": "companyNumber",
+        "in": "path",
+        "required": true,
+        "description": "The company number (e.g., '00000006').",
+        "schema": { "type": "string" }
+      }
+    },
+    "schemas": {
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "etag": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "type": "object" }
+          },
+          "kind": { "type": "string" },
+          "page_number": { "type": "integer" },
+          "items_per_page": { "type": "integer" },
+          "start_index": { "type": "integer" },
+          "total_results": { "type": "integer" }
+        }
+      },
+      "CompanySearchResponse": {
+        "type": "object",
+        "properties": {
+          "etag": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/CompanySearchItem" }
+          },
+          "kind": { "type": "string" },
+          "page_number": { "type": "integer" },
+          "items_per_page": { "type": "integer" },
+          "start_index": { "type": "integer" },
+          "total_results": { "type": "integer" }
+        }
+      },
+      "CompanySearchItem": {
+        "type": "object",
+        "properties": {
+          "company_number": { "type": "string" },
+          "company_status": { "type": "string" },
+          "company_type": { "type": "string" },
+          "date_of_creation": { "type": "string", "format": "date" },
+          "date_of_cessation": { "type": "string", "format": "date" },
+          "description": { "type": "string" },
+          "description_identifier": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "kind": { "type": "string" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": { "type": "string" }
+            }
+          },
+          "matches": { "type": "object" },
+          "snippet": { "type": "string" },
+          "title": { "type": "string" },
+          "address": { "$ref": "#/components/schemas/RegisteredOfficeAddress" },
+          "address_snippet": { "type": "string" }
+        }
+      },
+      "CompanyProfile": {
+        "type": "object",
+        "properties": {
+          "accounts": {
+            "type": "object",
+            "properties": {
+              "accounting_reference_date": {
+                "type": "object",
+                "properties": {
+                  "day": { "type": "string" },
+                  "month": { "type": "string" }
+                }
+              },
+              "last_accounts": {
+                "type": "object",
+                "properties": {
+                  "made_up_to": { "type": "string", "format": "date" },
+                  "type": { "type": "string" }
+                }
+              },
+              "next_accounts": {
+                "type": "object",
+                "properties": {
+                  "due_on": { "type": "string", "format": "date" },
+                  "period_end_on": { "type": "string", "format": "date" },
+                  "period_start_on": { "type": "string", "format": "date" }
+                }
+              },
+              "next_due": { "type": "string", "format": "date" },
+              "next_made_up_to": { "type": "string", "format": "date" },
+              "overdue": { "type": "boolean" }
+            }
+          },
+          "annual_return": {
+            "type": "object",
+            "properties": {
+              "last_made_up_to": { "type": "string", "format": "date" },
+              "next_due": { "type": "string", "format": "date" },
+              "next_made_up_to": { "type": "string", "format": "date" },
+              "overdue": { "type": "boolean" }
+            }
+          },
+          "can_file": { "type": "boolean" },
+          "company_name": { "type": "string" },
+          "company_number": { "type": "string" },
+          "company_status": { "type": "string" },
+          "company_status_detail": { "type": "string" },
+          "confirmation_statement": {
+            "type": "object",
+            "properties": {
+              "last_made_up_to": { "type": "string", "format": "date" },
+              "next_due": { "type": "string", "format": "date" },
+              "next_made_up_to": { "type": "string", "format": "date" },
+              "overdue": { "type": "boolean" }
+            }
+          },
+          "date_of_creation": { "type": "string", "format": "date" },
+          "date_of_cessation": { "type": "string", "format": "date" },
+          "etag": { "type": "string" },
+          "has_been_liquidated": { "type": "boolean" },
+          "has_charges": { "type": "boolean" },
+          "has_insolvency_history": { "type": "boolean" },
+          "is_community_interest_company": { "type": "boolean" },
+          "jurisdiction": { "type": "string" },
+          "last_full_members_list_date": { "type": "string", "format": "date" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "charges": { "type": "string" },
+              "filing_history": { "type": "string" },
+              "insolvency": { "type": "string" },
+              "officers": { "type": "string" },
+              "persons_with_significant_control": { "type": "string" },
+              "persons_with_significant_control_statements": { "type": "string" },
+              "registers": { "type": "string" },
+              "self": { "type": "string" }
+            }
+          },
+          "registered_office_address": { "$ref": "#/components/schemas/RegisteredOfficeAddress" },
+          "registered_office_is_in_dispute": { "type": "boolean" },
+          "sic_codes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "type": { "type": "string" },
+          "undeliverable_registered_office_address": { "type": "boolean" }
+        }
+      },
+      "RegisteredOfficeAddress": {
+        "type": "object",
+        "properties": {
+          "address_line_1": { "type": "string" },
+          "address_line_2": { "type": "string" },
+          "care_of": { "type": "string" },
+          "country": { "type": "string" },
+          "locality": { "type": "string" },
+          "po_box": { "type": "string" },
+          "postal_code": { "type": "string" },
+          "premises": { "type": "string" },
+          "region": { "type": "string" }
+        }
+      },
+      "OfficerList": {
+        "type": "object",
+        "properties": {
+          "active_count": { "type": "integer" },
+          "etag": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Officer" }
+          },
+          "items_per_page": { "type": "integer" },
+          "kind": { "type": "string" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": { "type": "string" }
+            }
+          },
+          "resigned_count": { "type": "integer" },
+          "start_index": { "type": "integer" },
+          "total_results": { "type": "integer" }
+        }
+      },
+      "Officer": {
+        "type": "object",
+        "properties": {
+          "address": { "$ref": "#/components/schemas/RegisteredOfficeAddress" },
+          "appointed_on": { "type": "string", "format": "date" },
+          "country_of_residence": { "type": "string" },
+          "date_of_birth": {
+            "type": "object",
+            "properties": {
+              "month": { "type": "integer" },
+              "year": { "type": "integer" }
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "officer": {
+                "type": "object",
+                "properties": {
+                  "appointments": { "type": "string" }
+                }
+              },
+              "self": { "type": "string" }
+            }
+          },
+          "name": { "type": "string" },
+          "nationality": { "type": "string" },
+          "occupation": { "type": "string" },
+          "officer_role": { "type": "string" },
+          "resigned_on": { "type": "string", "format": "date" }
+        }
+      },
+      "FilingHistoryList": {
+        "type": "object",
+        "properties": {
+          "etag": { "type": "string" },
+          "filing_history_status": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FilingHistoryItem" }
+          },
+          "items_per_page": { "type": "integer" },
+          "kind": { "type": "string" },
+          "start_index": { "type": "integer" },
+          "total_count": { "type": "integer" }
+        }
+      },
+      "FilingHistoryItem": {
+        "type": "object",
+        "properties": {
+          "category": { "type": "string" },
+          "date": { "type": "string", "format": "date" },
+          "description": { "type": "string" },
+          "description_values": { "type": "object" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "document_metadata": { "type": "string" },
+              "self": { "type": "string" }
+            }
+          },
+          "pages": { "type": "integer" },
+          "paper_filed": { "type": "boolean" },
+          "transaction_id": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      },
+      "ChargeList": {
+        "type": "object",
+        "properties": {
+          "etag": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "type": "object" }
+          },
+          "part_satisfied_count": { "type": "integer" },
+          "satisfied_count": { "type": "integer" },
+          "total_count": { "type": "integer" },
+          "unfiltered_count": { "type": "integer" }
+        }
+      },
+      "InsolvencyResource": {
+        "type": "object",
+        "properties": {
+          "etag": { "type": "string" },
+          "cases": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "dates": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "date": { "type": "string", "format": "date" },
+                      "type": { "type": "string" }
+                    }
+                  }
+                },
+                "notes": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                },
+                "number": { "type": "integer" },
+                "practitioners": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "address": { "type": "object" },
+                      "appointed_on": { "type": "string", "format": "date" },
+                      "ceased_to_act_on": { "type": "string", "format": "date" },
+                      "name": { "type": "string" },
+                      "role": { "type": "string" }
+                    }
+                  }
+                },
+                "type": { "type": "string" }
+              }
+            }
+          },
+          "status": {
+            "type": "array",
+            "items": { "type": "string" }
+          }
+        }
+      },
+      "PSCList": {
+        "type": "object",
+        "properties": {
+          "active_count": { "type": "integer" },
+          "ceased_count": { "type": "integer" },
+          "etag": { "type": "string" },
+          "items": {
+            "type": "array",
+            "items": { "type": "object" }
+          },
+          "items_per_page": { "type": "integer" },
+          "kind": { "type": "string" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": { "type": "string" }
+            }
+          },
+          "start_index": { "type": "integer" },
+          "total_results": { "type": "integer" }
+        }
+      },
+      "DisqualifiedOfficer": {
+        "type": "object",
+        "properties": {
+          "date_of_birth": { "type": "string", "format": "date" },
+          "disqualifications": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "case_identifier": { "type": "string" },
+                "disqualified_from": { "type": "string", "format": "date" },
+                "disqualified_until": { "type": "string", "format": "date" },
+                "reason": {
+                  "type": "object",
+                  "properties": {
+                    "act": { "type": "string" },
+                    "article": { "type": "string" },
+                    "description_identifier": { "type": "string" },
+                    "section": { "type": "string" }
+                  }
+                },
+                "company_names": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          },
+          "etag": { "type": "string" },
+          "forename": { "type": "string" },
+          "honours": { "type": "string" },
+          "kind": { "type": "string" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": { "type": "string" }
+            }
+          },
+          "nationality": { "type": "string" },
+          "other_forenames": { "type": "string" },
+          "surname": { "type": "string" },
+          "title": { "type": "string" }
+        }
+      },
+      "AppointmentList": {
+        "type": "object",
+        "properties": {
+          "date_of_birth": {
+            "type": "object",
+            "properties": {
+              "month": { "type": "integer" },
+              "year": { "type": "integer" }
+            }
+          },
+          "etag": { "type": "string" },
+          "is_corporate_officer": { "type": "boolean" },
+          "items": {
+            "type": "array",
+            "items": { "type": "object" }
+          },
+          "items_per_page": { "type": "integer" },
+          "kind": { "type": "string" },
+          "links": {
+            "type": "object",
+            "properties": {
+              "self": { "type": "string" }
+            }
+          },
+          "name": { "type": "string" },
+          "start_index": { "type": "integer" },
+          "total_results": { "type": "integer" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "error": { "type": "string" },
+                "error_values": { "type": "object" },
+                "location": { "type": "string" },
+                "location_type": { "type": "string" },
+                "type": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - authentication required.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/company-information.service.gov.uk/uk-companies-house/meta.json
+++ b/apis/openapi/company-information.service.gov.uk/uk-companies-house/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "24a6877c13b8944a76cdf7061332f05d",
+    "format": "openapi",
+    "vendor": "company-information.service.gov.uk",
+    "api_name": "uk-companies-house",
+    "friendly_id": "company-information.service.gov.uk/uk-companies-house"
+  }
+}

--- a/apis/openapi/countrystatecity.in/countrystatecity/1.0.0/openapi.json
+++ b/apis/openapi/countrystatecity.in/countrystatecity/1.0.0/openapi.json
@@ -1,0 +1,650 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Country State City API",
+    "description": "A comprehensive REST API providing data on world countries, states/provinces, and cities. Covers 247+ countries, 5000+ states/provinces, and 151,000+ cities with sub-100ms response times globally.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Country State City",
+      "url": "https://countrystatecity.in"
+    },
+    "x-jentic-source-url": "https://countrystatecity.in/"
+  },
+  "servers": [
+    {
+      "url": "https://api.countrystatecity.in/v1",
+      "description": "Production API"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyHeader": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Countries",
+      "description": "Operations for retrieving country data"
+    },
+    {
+      "name": "States",
+      "description": "Operations for retrieving state/province data"
+    },
+    {
+      "name": "Cities",
+      "description": "Operations for retrieving city data"
+    }
+  ],
+  "paths": {
+    "/countries": {
+      "get": {
+        "operationId": "getAllCountries",
+        "summary": "Get All Countries",
+        "description": "Retrieve a list of all countries with basic details including ISO codes, phone codes, capital, currency, and flag emojis.",
+        "tags": ["Countries"],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of countries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Country"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - missing or invalid API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries/{iso2}": {
+      "get": {
+        "operationId": "getCountryByIso2",
+        "summary": "Get Country by ISO2 Code",
+        "description": "Retrieve detailed information for a specific country by its ISO2 code.",
+        "tags": ["Countries"],
+        "parameters": [
+          {
+            "name": "iso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code (e.g. 'IN', 'US').",
+            "schema": {
+              "type": "string"
+            },
+            "example": "IN"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with country details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CountryDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Country not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/states": {
+      "get": {
+        "operationId": "getAllStates",
+        "summary": "Get All States",
+        "description": "Retrieve a list of all states/provinces across all countries. Returns a large dataset (5000+ states).",
+        "tags": ["States"],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of all states",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/StateDetail"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries/{iso2}/states": {
+      "get": {
+        "operationId": "getStatesByCountry",
+        "summary": "Get States by Country",
+        "description": "Retrieve all states/provinces for a specific country.",
+        "tags": ["States"],
+        "parameters": [
+          {
+            "name": "iso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "IN"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of states",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/State"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No states found for the given country",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries/{iso2}/states/{stateIso2}": {
+      "get": {
+        "operationId": "getStateByCode",
+        "summary": "Get State by ISO2 Code",
+        "description": "Retrieve details for a specific state/province within a country.",
+        "tags": ["States"],
+        "parameters": [
+          {
+            "name": "iso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "IN"
+          },
+          {
+            "name": "stateIso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO2 state/province code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "MH"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with state details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/StateDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "State not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries/{iso2}/cities": {
+      "get": {
+        "operationId": "getCitiesByCountry",
+        "summary": "Get Cities by Country",
+        "description": "Retrieve all cities for a specific country.",
+        "tags": ["Cities"],
+        "parameters": [
+          {
+            "name": "iso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "IN"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of cities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/City"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cities found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/countries/{iso2}/states/{stateIso2}/cities": {
+      "get": {
+        "operationId": "getCitiesByState",
+        "summary": "Get Cities by State",
+        "description": "Retrieve all cities for a specific state/province within a country.",
+        "tags": ["Cities"],
+        "parameters": [
+          {
+            "name": "iso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO 3166-1 alpha-2 country code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "IN"
+          },
+          {
+            "name": "stateIso2",
+            "in": "path",
+            "required": true,
+            "description": "ISO2 state/province code.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "MH"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of cities",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/City"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No cities found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-CSCAPI-KEY",
+        "description": "API key for authentication, passed in the X-CSCAPI-KEY header."
+      }
+    },
+    "schemas": {
+      "Country": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique country identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official country name in English."
+          },
+          "iso2": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 code."
+          },
+          "iso3": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-3 code."
+          },
+          "phonecode": {
+            "type": "string",
+            "description": "International dialing code."
+          },
+          "capital": {
+            "type": "string",
+            "description": "Capital city name."
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code."
+          },
+          "native": {
+            "type": "string",
+            "description": "Country name in native language."
+          },
+          "emoji": {
+            "type": "string",
+            "description": "Flag emoji."
+          }
+        }
+      },
+      "CountryDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique country identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official country name."
+          },
+          "iso2": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 code."
+          },
+          "iso3": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-3 code."
+          },
+          "phonecode": {
+            "type": "string",
+            "description": "International dialing code."
+          },
+          "capital": {
+            "type": "string",
+            "description": "Capital city name."
+          },
+          "currency": {
+            "type": "string",
+            "description": "ISO 4217 currency code."
+          },
+          "currency_name": {
+            "type": "string",
+            "description": "Full currency name."
+          },
+          "currency_symbol": {
+            "type": "string",
+            "description": "Currency symbol."
+          },
+          "native": {
+            "type": "string",
+            "description": "Country name in native language."
+          },
+          "region": {
+            "type": "string",
+            "description": "World region."
+          },
+          "subregion": {
+            "type": "string",
+            "description": "World sub-region."
+          },
+          "latitude": {
+            "type": "string",
+            "description": "Latitude of the country center."
+          },
+          "longitude": {
+            "type": "string",
+            "description": "Longitude of the country center."
+          },
+          "emoji": {
+            "type": "string",
+            "description": "Flag emoji."
+          },
+          "emojiU": {
+            "type": "string",
+            "description": "Flag emoji unicode."
+          },
+          "tld": {
+            "type": "string",
+            "description": "Top-level domain."
+          },
+          "timezones": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Timezone"
+            },
+            "description": "Timezones in the country."
+          }
+        }
+      },
+      "Timezone": {
+        "type": "object",
+        "properties": {
+          "zoneName": {
+            "type": "string",
+            "description": "IANA timezone name."
+          },
+          "gmtOffset": {
+            "type": "integer",
+            "description": "GMT offset in seconds."
+          },
+          "gmtOffsetName": {
+            "type": "string",
+            "description": "Human-readable GMT offset."
+          },
+          "abbreviation": {
+            "type": "string",
+            "description": "Timezone abbreviation."
+          },
+          "tzName": {
+            "type": "string",
+            "description": "Full timezone name."
+          }
+        }
+      },
+      "State": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique state identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official state/province name."
+          },
+          "iso2": {
+            "type": "string",
+            "description": "ISO2 state code."
+          }
+        }
+      },
+      "StateDetail": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique state identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Official state/province name."
+          },
+          "country_id": {
+            "type": "integer",
+            "description": "Parent country identifier."
+          },
+          "country_code": {
+            "type": "string",
+            "description": "ISO2 country code."
+          },
+          "iso2": {
+            "type": "string",
+            "description": "ISO2 state code."
+          },
+          "type": {
+            "type": "string",
+            "description": "Administrative division type (e.g. state, province, region)."
+          },
+          "latitude": {
+            "type": "string",
+            "description": "Geographic center latitude."
+          },
+          "longitude": {
+            "type": "string",
+            "description": "Geographic center longitude."
+          }
+        }
+      },
+      "City": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique city identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "City name."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message.",
+            "example": "Unauthorized. You shouldn't be here."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/countrystatecity.in/countrystatecity/meta.json
+++ b/apis/openapi/countrystatecity.in/countrystatecity/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "72a3d1584e276cc956de398eec6696ec",
+    "format": "openapi",
+    "vendor": "countrystatecity.in",
+    "api_name": "countrystatecity",
+    "friendly_id": "countrystatecity.in/countrystatecity"
+  }
+}

--- a/apis/openapi/developer.marvel.com/marvel/1.0.0/openapi.json
+++ b/apis/openapi/developer.marvel.com/marvel/1.0.0/openapi.json
@@ -1,0 +1,1218 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Marvel Comics API",
+    "description": "The Marvel Comics API allows developers to access information about Marvel's vast library of comics, characters, stories, events, creators, and series. Authentication requires a public API key and for server-side applications, an MD5 hash of a timestamp, private key, and public key.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Marvel Developer Portal",
+      "url": "https://developer.marvel.com"
+    },
+    "termsOfService": "https://developer.marvel.com/terms",
+    "x-jentic-source-url": "https://developer.marvel.com"
+  },
+  "servers": [
+    {
+      "url": "https://gateway.marvel.com/v1/public",
+      "description": "Marvel Comics API Production"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": [],
+      "timestamp": [],
+      "hash": []
+    }
+  ],
+  "tags": [
+    { "name": "Characters", "description": "Marvel character resources" },
+    { "name": "Comics", "description": "Marvel comic resources" },
+    { "name": "Creators", "description": "Marvel creator resources" },
+    { "name": "Events", "description": "Marvel event resources" },
+    { "name": "Series", "description": "Marvel series resources" },
+    { "name": "Stories", "description": "Marvel story resources" }
+  ],
+  "paths": {
+    "/characters": {
+      "get": {
+        "operationId": "getCharacters",
+        "summary": "List characters",
+        "description": "Fetches lists of comic characters with optional filters.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "name", "in": "query", "schema": { "type": "string" }, "description": "Return only characters matching the specified full character name" },
+          { "name": "nameStartsWith", "in": "query", "schema": { "type": "string" }, "description": "Return characters with names that begin with the specified string" },
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" }, "description": "Return only characters which have been modified since the specified date" },
+          { "name": "comics", "in": "query", "schema": { "type": "string" }, "description": "Return only characters which appear in the specified comics (comma-separated list of IDs)" },
+          { "name": "series", "in": "query", "schema": { "type": "string" }, "description": "Return only characters which appear in the specified series (comma-separated list of IDs)" },
+          { "name": "events", "in": "query", "schema": { "type": "string" }, "description": "Return only characters which appear in the specified events (comma-separated list of IDs)" },
+          { "name": "stories", "in": "query", "schema": { "type": "string" }, "description": "Return only characters which appear in the specified stories (comma-separated list of IDs)" },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["name", "-name", "modified", "-modified"] }, "description": "Order the result set by a field or fields" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "409": { "$ref": "#/components/responses/MissingParameter" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/characters/{characterId}": {
+      "get": {
+        "operationId": "getCharacterById",
+        "summary": "Get character by ID",
+        "description": "Fetches a single character by ID.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "characterId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "A single character ID" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/characters/{characterId}/comics": {
+      "get": {
+        "operationId": "getCharacterComics",
+        "summary": "Get comics for a character",
+        "description": "Fetches lists of comics containing a specific character.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "characterId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "format", "in": "query", "schema": { "type": "string", "enum": ["comic", "magazine", "trade paperback", "hardcover", "digest", "graphic novel", "digital comic", "infinite comic"] } },
+          { "name": "formatType", "in": "query", "schema": { "type": "string", "enum": ["comic", "collection"] } },
+          { "name": "noVariants", "in": "query", "schema": { "type": "boolean" } },
+          { "name": "dateDescriptor", "in": "query", "schema": { "type": "string", "enum": ["lastWeek", "thisWeek", "nextWeek", "thisMonth"] } },
+          { "name": "dateRange", "in": "query", "schema": { "type": "string" }, "description": "Return comics within a predefined date range (comma-separated dates)" },
+          { "name": "title", "in": "query", "schema": { "type": "string" } },
+          { "name": "titleStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["focDate", "-focDate", "onsaleDate", "-onsaleDate", "title", "-title", "issueNumber", "-issueNumber", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ComicDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/characters/{characterId}/events": {
+      "get": {
+        "operationId": "getCharacterEvents",
+        "summary": "Get events for a character",
+        "description": "Fetches lists of events in which a specific character appears.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "characterId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "name", "in": "query", "schema": { "type": "string" } },
+          { "name": "nameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["name", "-name", "startDate", "-startDate", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/EventDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/characters/{characterId}/series": {
+      "get": {
+        "operationId": "getCharacterSeries",
+        "summary": "Get series for a character",
+        "description": "Fetches lists of comic series in which a specific character appears.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "characterId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "title", "in": "query", "schema": { "type": "string" } },
+          { "name": "titleStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["title", "-title", "startYear", "-startYear", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/characters/{characterId}/stories": {
+      "get": {
+        "operationId": "getCharacterStories",
+        "summary": "Get stories for a character",
+        "description": "Fetches lists of comic stories featuring a specific character.",
+        "tags": ["Characters"],
+        "parameters": [
+          { "name": "characterId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["id", "-id", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/StoryDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/comics": {
+      "get": {
+        "operationId": "getComics",
+        "summary": "List comics",
+        "description": "Fetches lists of comics with optional filters.",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "format", "in": "query", "schema": { "type": "string", "enum": ["comic", "magazine", "trade paperback", "hardcover", "digest", "graphic novel", "digital comic", "infinite comic"] } },
+          { "name": "formatType", "in": "query", "schema": { "type": "string", "enum": ["comic", "collection"] } },
+          { "name": "noVariants", "in": "query", "schema": { "type": "boolean" } },
+          { "name": "dateDescriptor", "in": "query", "schema": { "type": "string", "enum": ["lastWeek", "thisWeek", "nextWeek", "thisMonth"] } },
+          { "name": "dateRange", "in": "query", "schema": { "type": "string" } },
+          { "name": "title", "in": "query", "schema": { "type": "string" } },
+          { "name": "titleStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "startYear", "in": "query", "schema": { "type": "integer" } },
+          { "name": "issueNumber", "in": "query", "schema": { "type": "integer" } },
+          { "name": "diamondCode", "in": "query", "schema": { "type": "string" } },
+          { "name": "digitalId", "in": "query", "schema": { "type": "integer" } },
+          { "name": "upc", "in": "query", "schema": { "type": "string" } },
+          { "name": "isbn", "in": "query", "schema": { "type": "string" } },
+          { "name": "ean", "in": "query", "schema": { "type": "string" } },
+          { "name": "issn", "in": "query", "schema": { "type": "string" } },
+          { "name": "hasDigitalIssue", "in": "query", "schema": { "type": "boolean" } },
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "creators", "in": "query", "schema": { "type": "string" } },
+          { "name": "characters", "in": "query", "schema": { "type": "string" } },
+          { "name": "series", "in": "query", "schema": { "type": "string" } },
+          { "name": "events", "in": "query", "schema": { "type": "string" } },
+          { "name": "stories", "in": "query", "schema": { "type": "string" } },
+          { "name": "sharedAppearances", "in": "query", "schema": { "type": "string" } },
+          { "name": "collaborators", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["focDate", "-focDate", "onsaleDate", "-onsaleDate", "title", "-title", "issueNumber", "-issueNumber", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ComicDataWrapper" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/comics/{comicId}": {
+      "get": {
+        "operationId": "getComicById",
+        "summary": "Get comic by ID",
+        "description": "Fetches a single comic resource.",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "comicId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ComicDataWrapper" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/comics/{comicId}/characters": {
+      "get": {
+        "operationId": "getComicCharacters",
+        "summary": "Get characters in a comic",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "comicId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "name": "name", "in": "query", "schema": { "type": "string" } },
+          { "name": "nameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["name", "-name", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/comics/{comicId}/creators": {
+      "get": {
+        "operationId": "getComicCreators",
+        "summary": "Get creators of a comic",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "comicId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/comics/{comicId}/events": {
+      "get": {
+        "operationId": "getComicEvents",
+        "summary": "Get events for a comic",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "comicId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/comics/{comicId}/stories": {
+      "get": {
+        "operationId": "getComicStories",
+        "summary": "Get stories in a comic",
+        "tags": ["Comics"],
+        "parameters": [
+          { "name": "comicId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/creators": {
+      "get": {
+        "operationId": "getCreators",
+        "summary": "List creators",
+        "description": "Fetches lists of comic creators with optional filters.",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "firstName", "in": "query", "schema": { "type": "string" } },
+          { "name": "middleName", "in": "query", "schema": { "type": "string" } },
+          { "name": "lastName", "in": "query", "schema": { "type": "string" } },
+          { "name": "suffix", "in": "query", "schema": { "type": "string" } },
+          { "name": "nameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "firstNameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "middleNameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "lastNameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "comics", "in": "query", "schema": { "type": "string" } },
+          { "name": "series", "in": "query", "schema": { "type": "string" } },
+          { "name": "events", "in": "query", "schema": { "type": "string" } },
+          { "name": "stories", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["lastName", "-lastName", "firstName", "-firstName", "middleName", "-middleName", "suffix", "-suffix", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/creators/{creatorId}": {
+      "get": {
+        "operationId": "getCreatorById",
+        "summary": "Get creator by ID",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "creatorId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/creators/{creatorId}/comics": {
+      "get": {
+        "operationId": "getCreatorComics",
+        "summary": "Get comics by creator",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "creatorId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ComicDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/creators/{creatorId}/events": {
+      "get": {
+        "operationId": "getCreatorEvents",
+        "summary": "Get events for creator",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "creatorId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/creators/{creatorId}/series": {
+      "get": {
+        "operationId": "getCreatorSeries",
+        "summary": "Get series by creator",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "creatorId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/creators/{creatorId}/stories": {
+      "get": {
+        "operationId": "getCreatorStories",
+        "summary": "Get stories by creator",
+        "tags": ["Creators"],
+        "parameters": [
+          { "name": "creatorId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events": {
+      "get": {
+        "operationId": "getEvents",
+        "summary": "List events",
+        "description": "Fetches lists of events with optional filters.",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "name", "in": "query", "schema": { "type": "string" } },
+          { "name": "nameStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "creators", "in": "query", "schema": { "type": "string" } },
+          { "name": "characters", "in": "query", "schema": { "type": "string" } },
+          { "name": "series", "in": "query", "schema": { "type": "string" } },
+          { "name": "comics", "in": "query", "schema": { "type": "string" } },
+          { "name": "stories", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["name", "-name", "startDate", "-startDate", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/events/{eventId}": {
+      "get": {
+        "operationId": "getEventById",
+        "summary": "Get event by ID",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events/{eventId}/characters": {
+      "get": {
+        "operationId": "getEventCharacters",
+        "summary": "Get characters in an event",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events/{eventId}/comics": {
+      "get": {
+        "operationId": "getEventComics",
+        "summary": "Get comics for an event",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ComicDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events/{eventId}/creators": {
+      "get": {
+        "operationId": "getEventCreators",
+        "summary": "Get creators in an event",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events/{eventId}/series": {
+      "get": {
+        "operationId": "getEventSeries",
+        "summary": "Get series for an event",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/events/{eventId}/stories": {
+      "get": {
+        "operationId": "getEventStories",
+        "summary": "Get stories for an event",
+        "tags": ["Events"],
+        "parameters": [
+          { "name": "eventId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series": {
+      "get": {
+        "operationId": "getSeries",
+        "summary": "List series",
+        "description": "Fetches lists of comic series with optional filters.",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "title", "in": "query", "schema": { "type": "string" } },
+          { "name": "titleStartsWith", "in": "query", "schema": { "type": "string" } },
+          { "name": "startYear", "in": "query", "schema": { "type": "integer" } },
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "comics", "in": "query", "schema": { "type": "string" } },
+          { "name": "stories", "in": "query", "schema": { "type": "string" } },
+          { "name": "events", "in": "query", "schema": { "type": "string" } },
+          { "name": "creators", "in": "query", "schema": { "type": "string" } },
+          { "name": "characters", "in": "query", "schema": { "type": "string" } },
+          { "name": "seriesType", "in": "query", "schema": { "type": "string", "enum": ["collection", "one shot", "limited", "ongoing"] } },
+          { "name": "contains", "in": "query", "schema": { "type": "string", "enum": ["comic", "magazine", "trade paperback", "hardcover", "digest", "graphic novel", "digital comic", "infinite comic"] } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["title", "-title", "startYear", "-startYear", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/series/{seriesId}": {
+      "get": {
+        "operationId": "getSeriesById",
+        "summary": "Get series by ID",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{seriesId}/characters": {
+      "get": {
+        "operationId": "getSeriesCharacters",
+        "summary": "Get characters in a series",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{seriesId}/comics": {
+      "get": {
+        "operationId": "getSeriesComics",
+        "summary": "Get comics in a series",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ComicDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{seriesId}/creators": {
+      "get": {
+        "operationId": "getSeriesCreators",
+        "summary": "Get creators in a series",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{seriesId}/events": {
+      "get": {
+        "operationId": "getSeriesEvents",
+        "summary": "Get events in a series",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{seriesId}/stories": {
+      "get": {
+        "operationId": "getSeriesStories",
+        "summary": "Get stories in a series",
+        "tags": ["Series"],
+        "parameters": [
+          { "name": "seriesId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories": {
+      "get": {
+        "operationId": "getStories",
+        "summary": "List stories",
+        "description": "Fetches lists of comic stories with optional filters.",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "modifiedSince", "in": "query", "schema": { "type": "string", "format": "date-time" } },
+          { "name": "comics", "in": "query", "schema": { "type": "string" } },
+          { "name": "series", "in": "query", "schema": { "type": "string" } },
+          { "name": "events", "in": "query", "schema": { "type": "string" } },
+          { "name": "creators", "in": "query", "schema": { "type": "string" } },
+          { "name": "characters", "in": "query", "schema": { "type": "string" } },
+          { "name": "orderBy", "in": "query", "schema": { "type": "string", "enum": ["id", "-id", "modified", "-modified"] } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/stories/{storyId}": {
+      "get": {
+        "operationId": "getStoryById",
+        "summary": "Get story by ID",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/StoryDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories/{storyId}/characters": {
+      "get": {
+        "operationId": "getStoryCharacters",
+        "summary": "Get characters in a story",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CharacterDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories/{storyId}/comics": {
+      "get": {
+        "operationId": "getStoryComics",
+        "summary": "Get comics in a story",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ComicDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories/{storyId}/creators": {
+      "get": {
+        "operationId": "getStoryCreators",
+        "summary": "Get creators of a story",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatorDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories/{storyId}/events": {
+      "get": {
+        "operationId": "getStoryEvents",
+        "summary": "Get events for a story",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/stories/{storyId}/series": {
+      "get": {
+        "operationId": "getStorySeries",
+        "summary": "Get series for a story",
+        "tags": ["Stories"],
+        "parameters": [
+          { "name": "storyId", "in": "path", "required": true, "schema": { "type": "integer" } },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/offset" }
+        ],
+        "responses": {
+          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SeriesDataWrapper" } } } },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apikey",
+        "description": "Your Marvel API public key"
+      },
+      "timestamp": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "ts",
+        "description": "A timestamp (or other long string which can change on a request-by-request basis)"
+      },
+      "hash": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "hash",
+        "description": "MD5 digest of the ts parameter, your private key, and your public key (ts+privateKey+publicKey)"
+      }
+    },
+    "parameters": {
+      "limit": {
+        "name": "limit",
+        "in": "query",
+        "schema": { "type": "integer", "default": 20, "maximum": 100 },
+        "description": "Limit the result set to the specified number of resources"
+      },
+      "offset": {
+        "name": "offset",
+        "in": "query",
+        "schema": { "type": "integer", "default": 0 },
+        "description": "Skip the specified number of resources in the result set"
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Invalid or missing API key / hash / timestamp",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden - referrer not authorized",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "MissingParameter": {
+        "description": "Missing required parameter",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      },
+      "CharacterDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer", "description": "HTTP status code" },
+          "status": { "type": "string", "description": "Status description" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/CharacterDataContainer" }
+        }
+      },
+      "CharacterDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Character" } }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "modified": { "type": "string", "format": "date-time" },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "urls": { "type": "array", "items": { "$ref": "#/components/schemas/Url" } },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "comics": { "$ref": "#/components/schemas/ResourceList" },
+          "stories": { "$ref": "#/components/schemas/ResourceList" },
+          "events": { "$ref": "#/components/schemas/ResourceList" },
+          "series": { "$ref": "#/components/schemas/ResourceList" }
+        }
+      },
+      "ComicDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/ComicDataContainer" }
+        }
+      },
+      "ComicDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Comic" } }
+        }
+      },
+      "Comic": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "digitalId": { "type": "integer" },
+          "title": { "type": "string" },
+          "issueNumber": { "type": "number" },
+          "variantDescription": { "type": "string" },
+          "description": { "type": "string" },
+          "modified": { "type": "string", "format": "date-time" },
+          "isbn": { "type": "string" },
+          "upc": { "type": "string" },
+          "diamondCode": { "type": "string" },
+          "ean": { "type": "string" },
+          "issn": { "type": "string" },
+          "format": { "type": "string" },
+          "pageCount": { "type": "integer" },
+          "textObjects": { "type": "array", "items": { "$ref": "#/components/schemas/TextObject" } },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "urls": { "type": "array", "items": { "$ref": "#/components/schemas/Url" } },
+          "series": { "$ref": "#/components/schemas/ResourceSummary" },
+          "variants": { "type": "array", "items": { "$ref": "#/components/schemas/ResourceSummary" } },
+          "collections": { "type": "array", "items": { "$ref": "#/components/schemas/ResourceSummary" } },
+          "collectedIssues": { "type": "array", "items": { "$ref": "#/components/schemas/ResourceSummary" } },
+          "dates": { "type": "array", "items": { "$ref": "#/components/schemas/ComicDate" } },
+          "prices": { "type": "array", "items": { "$ref": "#/components/schemas/ComicPrice" } },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "images": { "type": "array", "items": { "$ref": "#/components/schemas/Image" } },
+          "creators": { "$ref": "#/components/schemas/ResourceList" },
+          "characters": { "$ref": "#/components/schemas/ResourceList" },
+          "stories": { "$ref": "#/components/schemas/ResourceList" },
+          "events": { "$ref": "#/components/schemas/ResourceList" }
+        }
+      },
+      "CreatorDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/CreatorDataContainer" }
+        }
+      },
+      "CreatorDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Creator" } }
+        }
+      },
+      "Creator": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "firstName": { "type": "string" },
+          "middleName": { "type": "string" },
+          "lastName": { "type": "string" },
+          "suffix": { "type": "string" },
+          "fullName": { "type": "string" },
+          "modified": { "type": "string", "format": "date-time" },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "urls": { "type": "array", "items": { "$ref": "#/components/schemas/Url" } },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "comics": { "$ref": "#/components/schemas/ResourceList" },
+          "stories": { "$ref": "#/components/schemas/ResourceList" },
+          "series": { "$ref": "#/components/schemas/ResourceList" },
+          "events": { "$ref": "#/components/schemas/ResourceList" }
+        }
+      },
+      "EventDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/EventDataContainer" }
+        }
+      },
+      "EventDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Event" } }
+        }
+      },
+      "Event": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "urls": { "type": "array", "items": { "$ref": "#/components/schemas/Url" } },
+          "modified": { "type": "string", "format": "date-time" },
+          "start": { "type": "string", "format": "date-time" },
+          "end": { "type": "string", "format": "date-time" },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "comics": { "$ref": "#/components/schemas/ResourceList" },
+          "stories": { "$ref": "#/components/schemas/ResourceList" },
+          "series": { "$ref": "#/components/schemas/ResourceList" },
+          "characters": { "$ref": "#/components/schemas/ResourceList" },
+          "creators": { "$ref": "#/components/schemas/ResourceList" },
+          "next": { "$ref": "#/components/schemas/ResourceSummary" },
+          "previous": { "$ref": "#/components/schemas/ResourceSummary" }
+        }
+      },
+      "SeriesDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/SeriesDataContainer" }
+        }
+      },
+      "SeriesDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Series" } }
+        }
+      },
+      "Series": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "urls": { "type": "array", "items": { "$ref": "#/components/schemas/Url" } },
+          "startYear": { "type": "integer" },
+          "endYear": { "type": "integer" },
+          "rating": { "type": "string" },
+          "modified": { "type": "string", "format": "date-time" },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "comics": { "$ref": "#/components/schemas/ResourceList" },
+          "stories": { "$ref": "#/components/schemas/ResourceList" },
+          "events": { "$ref": "#/components/schemas/ResourceList" },
+          "characters": { "$ref": "#/components/schemas/ResourceList" },
+          "creators": { "$ref": "#/components/schemas/ResourceList" },
+          "next": { "$ref": "#/components/schemas/ResourceSummary" },
+          "previous": { "$ref": "#/components/schemas/ResourceSummary" }
+        }
+      },
+      "StoryDataWrapper": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "integer" },
+          "status": { "type": "string" },
+          "copyright": { "type": "string" },
+          "attributionText": { "type": "string" },
+          "attributionHTML": { "type": "string" },
+          "etag": { "type": "string" },
+          "data": { "$ref": "#/components/schemas/StoryDataContainer" }
+        }
+      },
+      "StoryDataContainer": {
+        "type": "object",
+        "properties": {
+          "offset": { "type": "integer" },
+          "limit": { "type": "integer" },
+          "total": { "type": "integer" },
+          "count": { "type": "integer" },
+          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Story" } }
+        }
+      },
+      "Story": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "resourceURI": { "type": "string", "format": "uri" },
+          "type": { "type": "string" },
+          "modified": { "type": "string", "format": "date-time" },
+          "thumbnail": { "$ref": "#/components/schemas/Image" },
+          "comics": { "$ref": "#/components/schemas/ResourceList" },
+          "series": { "$ref": "#/components/schemas/ResourceList" },
+          "events": { "$ref": "#/components/schemas/ResourceList" },
+          "characters": { "$ref": "#/components/schemas/ResourceList" },
+          "creators": { "$ref": "#/components/schemas/ResourceList" },
+          "originalissue": { "$ref": "#/components/schemas/ResourceSummary" }
+        }
+      },
+      "Image": {
+        "type": "object",
+        "properties": {
+          "path": { "type": "string", "description": "The directory path to the image" },
+          "extension": { "type": "string", "description": "The file extension (e.g., jpg, png)" }
+        }
+      },
+      "Url": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "description": "URL type (detail, wiki, comiclink)" },
+          "url": { "type": "string", "format": "uri" }
+        }
+      },
+      "ResourceList": {
+        "type": "object",
+        "properties": {
+          "available": { "type": "integer" },
+          "returned": { "type": "integer" },
+          "collectionURI": { "type": "string", "format": "uri" },
+          "items": { "type": "array", "items": { "$ref": "#/components/schemas/ResourceSummary" } }
+        }
+      },
+      "ResourceSummary": {
+        "type": "object",
+        "properties": {
+          "resourceURI": { "type": "string", "format": "uri" },
+          "name": { "type": "string" },
+          "role": { "type": "string" },
+          "type": { "type": "string" }
+        }
+      },
+      "TextObject": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "language": { "type": "string" },
+          "text": { "type": "string" }
+        }
+      },
+      "ComicDate": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "description": "Date type (onsaleDate, focDate)" },
+          "date": { "type": "string", "format": "date-time" }
+        }
+      },
+      "ComicPrice": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "description": "Price type (printPrice, digitalPurchasePrice)" },
+          "price": { "type": "number", "format": "float" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/developer.marvel.com/marvel/meta.json
+++ b/apis/openapi/developer.marvel.com/marvel/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "944ae1a128b1de6f1f141d23ab597c64",
+    "format": "openapi",
+    "vendor": "developer.marvel.com",
+    "api_name": "marvel",
+    "friendly_id": "developer.marvel.com/marvel"
+  }
+}

--- a/apis/openapi/developer.riotgames.com/riot-games/1.0.0/openapi.json
+++ b/apis/openapi/developer.riotgames.com/riot-games/1.0.0/openapi.json
@@ -1,0 +1,921 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Riot Games API",
+    "description": "The Riot Games Developer API provides access to game data for League of Legends, Teamfight Tactics, Legends of Runeterra, and VALORANT. Retrieve summoner profiles, match history, ranked statistics, champion mastery, league standings, and more.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Riot Games Developer Relations",
+      "url": "https://developer.riotgames.com"
+    },
+    "x-jentic-source-url": "https://developer.riotgames.com/"
+  },
+  "servers": [
+    {
+      "url": "https://{region}.api.riotgames.com",
+      "description": "Regional routing",
+      "variables": {
+        "region": {
+          "default": "americas",
+          "enum": ["americas", "europe", "asia", "sea"],
+          "description": "Regional routing value"
+        }
+      }
+    },
+    {
+      "url": "https://{platform}.api.riotgames.com",
+      "description": "Platform routing",
+      "variables": {
+        "platform": {
+          "default": "na1",
+          "enum": ["na1", "euw1", "eun1", "kr", "br1", "jp1", "la1", "la2", "oc1", "tr1", "ru", "ph2", "sg2", "th2", "tw2", "vn2"],
+          "description": "Platform routing value"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {"name": "Account", "description": "Riot Account endpoints (regional routing)"},
+    {"name": "Summoner", "description": "Summoner profile data (platform routing)"},
+    {"name": "Champion Mastery", "description": "Champion mastery data (platform routing)"},
+    {"name": "Champion", "description": "Champion rotation data (platform routing)"},
+    {"name": "League", "description": "Ranked league data (platform routing)"},
+    {"name": "Match", "description": "Match history and details (regional routing)"},
+    {"name": "Spectator", "description": "Active game / spectator data (platform routing)"},
+    {"name": "Status", "description": "Platform status (platform routing)"},
+    {"name": "Clash", "description": "Clash tournament data (platform routing)"}
+  ],
+  "paths": {
+    "/riot/account/v1/accounts/by-puuid/{puuid}": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Get account by PUUID",
+        "description": "Retrieve a Riot account by PUUID.",
+        "operationId": "getAccountByPuuid",
+        "parameters": [
+          {"name": "puuid", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Encrypted PUUID"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Account data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Account"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "403": {"$ref": "#/components/responses/Forbidden"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/riot/account/v1/accounts/by-riot-id/{gameName}/{tagLine}": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Get account by Riot ID",
+        "description": "Retrieve a Riot account by game name and tag line.",
+        "operationId": "getAccountByRiotId",
+        "parameters": [
+          {"name": "gameName", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Game name"},
+          {"name": "tagLine", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Tag line"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Account data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Account"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/riot/account/v1/accounts/me": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Get current account",
+        "description": "Retrieve the Riot account of the currently authenticated user (RSO).",
+        "operationId": "getAccountMe",
+        "security": [{"rso": []}],
+        "responses": {
+          "200": {
+            "description": "Account data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Account"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/summoner/v4/summoners/by-puuid/{encryptedPUUID}": {
+      "get": {
+        "tags": ["Summoner"],
+        "summary": "Get summoner by PUUID",
+        "description": "Retrieve a summoner by their encrypted PUUID.",
+        "operationId": "getSummonerByPuuid",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Summoner data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Summoner"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/summoner/v4/summoners/{encryptedSummonerId}": {
+      "get": {
+        "tags": ["Summoner"],
+        "summary": "Get summoner by ID",
+        "description": "Retrieve a summoner by their encrypted summoner ID.",
+        "operationId": "getSummonerById",
+        "parameters": [
+          {"name": "encryptedSummonerId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Summoner data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Summoner"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/champion-mastery/v4/champion-masteries/by-puuid/{encryptedPUUID}": {
+      "get": {
+        "tags": ["Champion Mastery"],
+        "summary": "Get all champion mastery entries",
+        "description": "Retrieve all champion mastery entries for a summoner sorted by number of champion points descending.",
+        "operationId": "getChampionMasteries",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Champion mastery list",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/ChampionMastery"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/champion-mastery/v4/champion-masteries/by-puuid/{encryptedPUUID}/by-champion/{championId}": {
+      "get": {
+        "tags": ["Champion Mastery"],
+        "summary": "Get champion mastery by champion ID",
+        "description": "Retrieve champion mastery for a specific champion for a summoner.",
+        "operationId": "getChampionMasteryByChampion",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "championId", "in": "path", "required": true, "schema": {"type": "integer", "format": "int64"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Champion mastery entry",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ChampionMastery"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/champion-mastery/v4/champion-masteries/by-puuid/{encryptedPUUID}/top": {
+      "get": {
+        "tags": ["Champion Mastery"],
+        "summary": "Get top champion masteries",
+        "description": "Retrieve the top champion mastery entries for a summoner.",
+        "operationId": "getTopChampionMasteries",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "count", "in": "query", "schema": {"type": "integer", "default": 3}, "description": "Number of entries to retrieve"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Top champion mastery entries",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/ChampionMastery"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/champion-mastery/v4/scores/by-puuid/{encryptedPUUID}": {
+      "get": {
+        "tags": ["Champion Mastery"],
+        "summary": "Get total champion mastery score",
+        "description": "Retrieve the total champion mastery score (sum of all champions' levels) for a summoner.",
+        "operationId": "getChampionMasteryScore",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Total mastery score",
+            "content": {"application/json": {"schema": {"type": "integer"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/platform/v3/champion-rotations": {
+      "get": {
+        "tags": ["Champion"],
+        "summary": "Get champion rotations",
+        "description": "Retrieve the current free champion rotation.",
+        "operationId": "getChampionRotations",
+        "responses": {
+          "200": {
+            "description": "Champion rotation info",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/ChampionInfo"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/league/v4/entries/by-summoner/{encryptedSummonerId}": {
+      "get": {
+        "tags": ["League"],
+        "summary": "Get league entries by summoner",
+        "description": "Retrieve league entries for a summoner across all queues.",
+        "operationId": "getLeagueEntriesBySummoner",
+        "parameters": [
+          {"name": "encryptedSummonerId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "League entries",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/LeagueEntry"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/league/v4/entries/{queue}/{tier}/{division}": {
+      "get": {
+        "tags": ["League"],
+        "summary": "Get league entries",
+        "description": "Retrieve league entries for a given queue, tier, and division.",
+        "operationId": "getLeagueEntries",
+        "parameters": [
+          {"name": "queue", "in": "path", "required": true, "schema": {"type": "string", "enum": ["RANKED_SOLO_5x5", "RANKED_FLEX_SR"]}},
+          {"name": "tier", "in": "path", "required": true, "schema": {"type": "string", "enum": ["IRON", "BRONZE", "SILVER", "GOLD", "PLATINUM", "EMERALD", "DIAMOND"]}},
+          {"name": "division", "in": "path", "required": true, "schema": {"type": "string", "enum": ["I", "II", "III", "IV"]}},
+          {"name": "page", "in": "query", "schema": {"type": "integer", "default": 1}}
+        ],
+        "responses": {
+          "200": {
+            "description": "League entries",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/LeagueEntry"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/league/v4/challengerleagues/by-queue/{queue}": {
+      "get": {
+        "tags": ["League"],
+        "summary": "Get challenger league",
+        "description": "Retrieve the challenger league for a specific queue.",
+        "operationId": "getChallengerLeague",
+        "parameters": [
+          {"name": "queue", "in": "path", "required": true, "schema": {"type": "string", "enum": ["RANKED_SOLO_5x5", "RANKED_FLEX_SR"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Challenger league data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/LeagueList"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/league/v4/grandmasterleagues/by-queue/{queue}": {
+      "get": {
+        "tags": ["League"],
+        "summary": "Get grandmaster league",
+        "description": "Retrieve the grandmaster league for a specific queue.",
+        "operationId": "getGrandmasterLeague",
+        "parameters": [
+          {"name": "queue", "in": "path", "required": true, "schema": {"type": "string", "enum": ["RANKED_SOLO_5x5", "RANKED_FLEX_SR"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Grandmaster league data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/LeagueList"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/league/v4/masterleagues/by-queue/{queue}": {
+      "get": {
+        "tags": ["League"],
+        "summary": "Get master league",
+        "description": "Retrieve the master league for a specific queue.",
+        "operationId": "getMasterLeague",
+        "parameters": [
+          {"name": "queue", "in": "path", "required": true, "schema": {"type": "string", "enum": ["RANKED_SOLO_5x5", "RANKED_FLEX_SR"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Master league data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/LeagueList"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/match/v5/matches/by-puuid/{puuid}/ids": {
+      "get": {
+        "tags": ["Match"],
+        "summary": "Get match IDs by PUUID",
+        "description": "Retrieve a list of match IDs for a player.",
+        "operationId": "getMatchIdsByPuuid",
+        "parameters": [
+          {"name": "puuid", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "startTime", "in": "query", "schema": {"type": "integer", "format": "int64"}, "description": "Epoch timestamp in seconds"},
+          {"name": "endTime", "in": "query", "schema": {"type": "integer", "format": "int64"}, "description": "Epoch timestamp in seconds"},
+          {"name": "queue", "in": "query", "schema": {"type": "integer"}, "description": "Queue ID filter"},
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["ranked", "normal", "tourney", "tutorial"]}},
+          {"name": "start", "in": "query", "schema": {"type": "integer", "default": 0}},
+          {"name": "count", "in": "query", "schema": {"type": "integer", "default": 20, "maximum": 100}}
+        ],
+        "responses": {
+          "200": {
+            "description": "List of match IDs",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"type": "string"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/match/v5/matches/{matchId}": {
+      "get": {
+        "tags": ["Match"],
+        "summary": "Get match by ID",
+        "description": "Retrieve match details by match ID.",
+        "operationId": "getMatch",
+        "parameters": [
+          {"name": "matchId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Match ID (e.g., NA1_1234567890)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Match details",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Match"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/match/v5/matches/{matchId}/timeline": {
+      "get": {
+        "tags": ["Match"],
+        "summary": "Get match timeline",
+        "description": "Retrieve match timeline data (frame-by-frame events).",
+        "operationId": "getMatchTimeline",
+        "parameters": [
+          {"name": "matchId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Match timeline",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/MatchTimeline"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/spectator/v5/active-games/by-summoner/{encryptedPUUID}": {
+      "get": {
+        "tags": ["Spectator"],
+        "summary": "Get current game",
+        "description": "Retrieve the current active game for a summoner.",
+        "operationId": "getCurrentGame",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Active game data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CurrentGameInfo"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"description": "Summoner not in an active game"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/spectator/v5/featured-games": {
+      "get": {
+        "tags": ["Spectator"],
+        "summary": "Get featured games",
+        "description": "Retrieve the list of featured (spectatable) games.",
+        "operationId": "getFeaturedGames",
+        "responses": {
+          "200": {
+            "description": "Featured games",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/FeaturedGames"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/status/v4/platform-data": {
+      "get": {
+        "tags": ["Status"],
+        "summary": "Get platform status",
+        "description": "Retrieve the status of the League of Legends platform.",
+        "operationId": "getPlatformStatus",
+        "responses": {
+          "200": {
+            "description": "Platform status",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PlatformData"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/clash/v1/players/by-puuid/{encryptedPUUID}": {
+      "get": {
+        "tags": ["Clash"],
+        "summary": "Get clash players by PUUID",
+        "description": "Retrieve clash registration for a player.",
+        "operationId": "getClashPlayersByPuuid",
+        "parameters": [
+          {"name": "encryptedPUUID", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clash player entries",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/ClashPlayer"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/clash/v1/teams/{teamId}": {
+      "get": {
+        "tags": ["Clash"],
+        "summary": "Get clash team",
+        "description": "Retrieve a clash team by ID.",
+        "operationId": "getClashTeam",
+        "parameters": [
+          {"name": "teamId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clash team data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ClashTeam"}}}
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/lol/clash/v1/tournaments": {
+      "get": {
+        "tags": ["Clash"],
+        "summary": "Get clash tournaments",
+        "description": "Retrieve all active and upcoming clash tournaments.",
+        "operationId": "getClashTournaments",
+        "responses": {
+          "200": {
+            "description": "Tournament list",
+            "content": {
+              "application/json": {
+                "schema": {"type": "array", "items": {"$ref": "#/components/schemas/ClashTournament"}}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Riot-Token",
+        "description": "Riot API key passed in the X-Riot-Token header."
+      },
+      "rso": {
+        "type": "oauth2",
+        "description": "Riot Sign On (RSO) OAuth 2.0 for user-specific endpoints.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://auth.riotgames.com/authorize",
+            "tokenUrl": "https://auth.riotgames.com/token",
+            "scopes": {
+              "openid": "OpenID Connect",
+              "cpid": "Retrieve PUUID"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "properties": {
+          "puuid": {"type": "string"},
+          "gameName": {"type": "string"},
+          "tagLine": {"type": "string"}
+        }
+      },
+      "Summoner": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string", "description": "Encrypted summoner ID"},
+          "accountId": {"type": "string", "description": "Encrypted account ID"},
+          "puuid": {"type": "string", "description": "Encrypted PUUID"},
+          "profileIconId": {"type": "integer"},
+          "revisionDate": {"type": "integer", "format": "int64"},
+          "summonerLevel": {"type": "integer", "format": "int64"}
+        }
+      },
+      "ChampionMastery": {
+        "type": "object",
+        "properties": {
+          "puuid": {"type": "string"},
+          "championId": {"type": "integer", "format": "int64"},
+          "championLevel": {"type": "integer"},
+          "championPoints": {"type": "integer"},
+          "lastPlayTime": {"type": "integer", "format": "int64"},
+          "championPointsSinceLastLevel": {"type": "integer", "format": "int64"},
+          "championPointsUntilNextLevel": {"type": "integer", "format": "int64"},
+          "markRequiredForNextLevel": {"type": "integer"},
+          "tokensEarned": {"type": "integer"},
+          "championSeasonMilestone": {"type": "integer"}
+        }
+      },
+      "ChampionInfo": {
+        "type": "object",
+        "properties": {
+          "freeChampionIds": {"type": "array", "items": {"type": "integer"}},
+          "freeChampionIdsForNewPlayers": {"type": "array", "items": {"type": "integer"}},
+          "maxNewPlayerLevel": {"type": "integer"}
+        }
+      },
+      "LeagueEntry": {
+        "type": "object",
+        "properties": {
+          "leagueId": {"type": "string"},
+          "summonerId": {"type": "string"},
+          "queueType": {"type": "string"},
+          "tier": {"type": "string"},
+          "rank": {"type": "string"},
+          "leaguePoints": {"type": "integer"},
+          "wins": {"type": "integer"},
+          "losses": {"type": "integer"},
+          "hotStreak": {"type": "boolean"},
+          "veteran": {"type": "boolean"},
+          "freshBlood": {"type": "boolean"},
+          "inactive": {"type": "boolean"},
+          "miniSeries": {"$ref": "#/components/schemas/MiniSeries"}
+        }
+      },
+      "MiniSeries": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "losses": {"type": "integer"},
+          "progress": {"type": "string"},
+          "target": {"type": "integer"},
+          "wins": {"type": "integer"}
+        }
+      },
+      "LeagueList": {
+        "type": "object",
+        "properties": {
+          "leagueId": {"type": "string"},
+          "entries": {"type": "array", "items": {"$ref": "#/components/schemas/LeagueEntry"}},
+          "tier": {"type": "string"},
+          "name": {"type": "string"},
+          "queue": {"type": "string"}
+        }
+      },
+      "Match": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "dataVersion": {"type": "string"},
+              "matchId": {"type": "string"},
+              "participants": {"type": "array", "items": {"type": "string"}}
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "gameCreation": {"type": "integer", "format": "int64"},
+              "gameDuration": {"type": "integer"},
+              "gameId": {"type": "integer", "format": "int64"},
+              "gameMode": {"type": "string"},
+              "gameType": {"type": "string"},
+              "gameVersion": {"type": "string"},
+              "mapId": {"type": "integer"},
+              "queueId": {"type": "integer"},
+              "platformId": {"type": "string"},
+              "participants": {
+                "type": "array",
+                "items": {"$ref": "#/components/schemas/Participant"}
+              },
+              "teams": {
+                "type": "array",
+                "items": {"$ref": "#/components/schemas/Team"}
+              }
+            }
+          }
+        }
+      },
+      "Participant": {
+        "type": "object",
+        "properties": {
+          "puuid": {"type": "string"},
+          "summonerId": {"type": "string"},
+          "summonerName": {"type": "string"},
+          "riotIdGameName": {"type": "string"},
+          "riotIdTagline": {"type": "string"},
+          "championId": {"type": "integer"},
+          "championName": {"type": "string"},
+          "teamId": {"type": "integer"},
+          "win": {"type": "boolean"},
+          "kills": {"type": "integer"},
+          "deaths": {"type": "integer"},
+          "assists": {"type": "integer"},
+          "totalDamageDealtToChampions": {"type": "integer"},
+          "goldEarned": {"type": "integer"},
+          "totalMinionsKilled": {"type": "integer"},
+          "visionScore": {"type": "integer"},
+          "item0": {"type": "integer"},
+          "item1": {"type": "integer"},
+          "item2": {"type": "integer"},
+          "item3": {"type": "integer"},
+          "item4": {"type": "integer"},
+          "item5": {"type": "integer"},
+          "item6": {"type": "integer"}
+        }
+      },
+      "Team": {
+        "type": "object",
+        "properties": {
+          "teamId": {"type": "integer"},
+          "win": {"type": "boolean"},
+          "bans": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "championId": {"type": "integer"},
+                "pickTurn": {"type": "integer"}
+              }
+            }
+          },
+          "objectives": {"type": "object"}
+        }
+      },
+      "MatchTimeline": {
+        "type": "object",
+        "properties": {
+          "metadata": {
+            "type": "object",
+            "properties": {
+              "dataVersion": {"type": "string"},
+              "matchId": {"type": "string"},
+              "participants": {"type": "array", "items": {"type": "string"}}
+            }
+          },
+          "info": {
+            "type": "object",
+            "properties": {
+              "frameInterval": {"type": "integer"},
+              "frames": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {"type": "integer"},
+                    "participantFrames": {"type": "object"},
+                    "events": {"type": "array", "items": {"type": "object"}}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "CurrentGameInfo": {
+        "type": "object",
+        "properties": {
+          "gameId": {"type": "integer", "format": "int64"},
+          "gameType": {"type": "string"},
+          "gameStartTime": {"type": "integer", "format": "int64"},
+          "mapId": {"type": "integer", "format": "int64"},
+          "gameLength": {"type": "integer", "format": "int64"},
+          "platformId": {"type": "string"},
+          "gameMode": {"type": "string"},
+          "bannedChampions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "championId": {"type": "integer", "format": "int64"},
+                "teamId": {"type": "integer", "format": "int64"},
+                "pickTurn": {"type": "integer"}
+              }
+            }
+          },
+          "participants": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "puuid": {"type": "string"},
+                "teamId": {"type": "integer", "format": "int64"},
+                "championId": {"type": "integer", "format": "int64"},
+                "summonerId": {"type": "string"},
+                "riotId": {"type": "string"}
+              }
+            }
+          }
+        }
+      },
+      "FeaturedGames": {
+        "type": "object",
+        "properties": {
+          "gameList": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/CurrentGameInfo"}
+          },
+          "clientRefreshInterval": {"type": "integer", "format": "int64"}
+        }
+      },
+      "PlatformData": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "locales": {"type": "array", "items": {"type": "string"}},
+          "maintenances": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/StatusEntry"}
+          },
+          "incidents": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/StatusEntry"}
+          }
+        }
+      },
+      "StatusEntry": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "maintenance_status": {"type": "string"},
+          "incident_severity": {"type": "string"},
+          "titles": {"type": "array", "items": {"type": "object", "properties": {"locale": {"type": "string"}, "content": {"type": "string"}}}},
+          "updates": {"type": "array", "items": {"type": "object"}},
+          "created_at": {"type": "string", "format": "date-time"},
+          "updated_at": {"type": "string", "format": "date-time"},
+          "platforms": {"type": "array", "items": {"type": "string"}}
+        }
+      },
+      "ClashPlayer": {
+        "type": "object",
+        "properties": {
+          "summonerId": {"type": "string"},
+          "teamId": {"type": "string"},
+          "position": {"type": "string"},
+          "role": {"type": "string"}
+        }
+      },
+      "ClashTeam": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "tournamentId": {"type": "integer"},
+          "name": {"type": "string"},
+          "iconId": {"type": "integer"},
+          "tier": {"type": "integer"},
+          "captain": {"type": "string"},
+          "abbreviation": {"type": "string"},
+          "players": {"type": "array", "items": {"$ref": "#/components/schemas/ClashPlayer"}}
+        }
+      },
+      "ClashTournament": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "themeId": {"type": "integer"},
+          "nameKey": {"type": "string"},
+          "nameKeySecondary": {"type": "string"},
+          "schedule": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {"type": "integer"},
+                "registrationTime": {"type": "integer", "format": "int64"},
+                "startTime": {"type": "integer", "format": "int64"},
+                "cancelled": {"type": "boolean"}
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "object",
+            "properties": {
+              "message": {"type": "string"},
+              "status_code": {"type": "integer"}
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "API key is missing or invalid",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "Forbidden": {
+        "description": "Insufficient permissions for this endpoint",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "RateLimited": {
+        "description": "Rate limit exceeded. Check Retry-After header.",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      }
+    }
+  }
+}

--- a/apis/openapi/developer.riotgames.com/riot-games/meta.json
+++ b/apis/openapi/developer.riotgames.com/riot-games/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "bb031dcf40c9cc3831b453db75a2cc5b",
+    "format": "openapi",
+    "vendor": "developer.riotgames.com",
+    "api_name": "riot-games",
+    "friendly_id": "developer.riotgames.com/riot-games"
+  }
+}

--- a/apis/openapi/developers.kakao.com/kakao-maps/2.0.0/openapi.json
+++ b/apis/openapi/developers.kakao.com/kakao-maps/2.0.0/openapi.json
@@ -1,0 +1,983 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Kakao Maps Local API",
+    "description": "Kakao Maps Local REST API provides geocoding, reverse geocoding, keyword and category place search, coordinate transformation, and region code lookup for Korean locations. Authentication requires a KakaoAK REST API key in the Authorization header.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "Kakao Developers",
+      "url": "https://developers.kakao.com"
+    },
+    "x-jentic-source-url": "https://apis.map.kakao.com"
+  },
+  "servers": [
+    {
+      "url": "https://dapi.kakao.com",
+      "description": "Kakao Maps REST API server"
+    }
+  ],
+  "security": [
+    {
+      "kakaoAK": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Address to coordinates conversion"
+    },
+    {
+      "name": "Reverse Geocoding",
+      "description": "Coordinates to address/region conversion"
+    },
+    {
+      "name": "Search",
+      "description": "Place search by keyword or category"
+    },
+    {
+      "name": "Coordinates",
+      "description": "Coordinate transformation"
+    }
+  ],
+  "paths": {
+    "/v2/local/search/address.json": {
+      "get": {
+        "operationId": "searchAddress",
+        "summary": "Convert address to coordinates",
+        "description": "Searches for an address and returns the corresponding geographic coordinates. Supports both land-lot and road name addresses in Korea.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Address search query string.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "analyze_type",
+            "in": "query",
+            "required": false,
+            "description": "Search analysis type.",
+            "schema": {
+              "type": "string",
+              "enum": ["similar", "exact"],
+              "default": "similar"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Result page number.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 45,
+              "default": 1
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 30,
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful address search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AddressSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid or missing API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/local/geo/coord2regioncode.json": {
+      "get": {
+        "operationId": "coordToRegionCode",
+        "summary": "Convert coordinates to region code",
+        "description": "Returns the administrative and legal region codes for the given coordinates.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "x",
+            "in": "query",
+            "required": true,
+            "description": "Longitude coordinate.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": true,
+            "description": "Latitude coordinate.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "input_coord",
+            "in": "query",
+            "required": false,
+            "description": "Input coordinate system.",
+            "schema": {
+              "type": "string",
+              "enum": ["WGS84", "WCONGNAMUL", "CONGNAMUL", "WTM", "TM"],
+              "default": "WGS84"
+            }
+          },
+          {
+            "name": "output_coord",
+            "in": "query",
+            "required": false,
+            "description": "Output coordinate system.",
+            "schema": {
+              "type": "string",
+              "enum": ["WGS84", "WCONGNAMUL", "CONGNAMUL", "WTM", "TM"],
+              "default": "WGS84"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful region code lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegionCodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/local/geo/coord2address.json": {
+      "get": {
+        "operationId": "coordToAddress",
+        "summary": "Convert coordinates to address",
+        "description": "Returns the address (land-lot and road name) corresponding to the given coordinates.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "x",
+            "in": "query",
+            "required": true,
+            "description": "Longitude coordinate.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": true,
+            "description": "Latitude coordinate.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "input_coord",
+            "in": "query",
+            "required": false,
+            "description": "Input coordinate system.",
+            "schema": {
+              "type": "string",
+              "enum": ["WGS84", "WCONGNAMUL", "CONGNAMUL", "WTM", "TM"],
+              "default": "WGS84"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordToAddressResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/local/geo/transcoord.json": {
+      "get": {
+        "operationId": "transformCoordinates",
+        "summary": "Transform coordinates between systems",
+        "description": "Converts coordinates from one coordinate system to another (e.g., WGS84 to TM).",
+        "tags": ["Coordinates"],
+        "parameters": [
+          {
+            "name": "x",
+            "in": "query",
+            "required": true,
+            "description": "Longitude coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": true,
+            "description": "Latitude coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "input_coord",
+            "in": "query",
+            "required": false,
+            "description": "Source coordinate system.",
+            "schema": {
+              "type": "string",
+              "enum": ["WGS84", "WCONGNAMUL", "CONGNAMUL", "WTM", "TM", "KTM", "UTM", "BESSEL", "WKTM", "WUTM"],
+              "default": "WGS84"
+            }
+          },
+          {
+            "name": "output_coord",
+            "in": "query",
+            "required": true,
+            "description": "Target coordinate system.",
+            "schema": {
+              "type": "string",
+              "enum": ["WGS84", "WCONGNAMUL", "CONGNAMUL", "WTM", "TM", "KTM", "UTM", "BESSEL", "WKTM", "WUTM"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful coordinate transformation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TransCoordResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/local/search/keyword.json": {
+      "get": {
+        "operationId": "searchByKeyword",
+        "summary": "Search places by keyword",
+        "description": "Searches for places matching the given keyword. Optionally filter by category, location, and radius.",
+        "tags": ["Search"],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Search keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "category_group_code",
+            "in": "query",
+            "required": false,
+            "description": "Category group code filter (e.g., MT1=Supermarket, CS2=Convenience store, FD6=Restaurant, CE7=Cafe, HP8=Hospital, PM9=Pharmacy).",
+            "schema": {
+              "type": "string",
+              "enum": ["MT1", "CS2", "PS3", "SC4", "AC5", "PK6", "OL7", "SW8", "BK9", "CT1", "AG2", "PO3", "AT4", "AD5", "FD6", "CE7", "HP8", "PM9"]
+            }
+          },
+          {
+            "name": "x",
+            "in": "query",
+            "required": false,
+            "description": "Center longitude for distance-based search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": false,
+            "description": "Center latitude for distance-based search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in meters (0-20000).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 20000
+            }
+          },
+          {
+            "name": "rect",
+            "in": "query",
+            "required": false,
+            "description": "Rectangle bounds for search area (leftX,leftY,rightX,rightY).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Result page number.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 45,
+              "default": 1
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 15,
+              "default": 15
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Sort order for results.",
+            "schema": {
+              "type": "string",
+              "enum": ["accuracy", "distance"],
+              "default": "accuracy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful keyword search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeywordSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/local/search/category.json": {
+      "get": {
+        "operationId": "searchByCategory",
+        "summary": "Search places by category",
+        "description": "Searches for places within a specific category group. Requires either x/y/radius or rect to define the search area.",
+        "tags": ["Search"],
+        "parameters": [
+          {
+            "name": "category_group_code",
+            "in": "query",
+            "required": true,
+            "description": "Category group code (e.g., MT1=Supermarket, FD6=Restaurant, CE7=Cafe, HP8=Hospital).",
+            "schema": {
+              "type": "string",
+              "enum": ["MT1", "CS2", "PS3", "SC4", "AC5", "PK6", "OL7", "SW8", "BK9", "CT1", "AG2", "PO3", "AT4", "AD5", "FD6", "CE7", "HP8", "PM9"]
+            }
+          },
+          {
+            "name": "x",
+            "in": "query",
+            "required": false,
+            "description": "Center longitude for radius search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "y",
+            "in": "query",
+            "required": false,
+            "description": "Center latitude for radius search.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in meters (0-20000).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 20000
+            }
+          },
+          {
+            "name": "rect",
+            "in": "query",
+            "required": false,
+            "description": "Rectangle bounds for search area.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 45,
+              "default": 1
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 15,
+              "default": 15
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["accuracy", "distance"],
+              "default": "accuracy"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful category search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/KeywordSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "kakaoAK": {
+        "type": "apiKey",
+        "name": "Authorization",
+        "in": "header",
+        "description": "REST API key in the format: KakaoAK {REST_API_KEY}"
+      }
+    },
+    "schemas": {
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total_count": {
+            "type": "integer",
+            "description": "Total number of results."
+          },
+          "pageable_count": {
+            "type": "integer",
+            "description": "Number of results available for pagination."
+          },
+          "is_end": {
+            "type": "boolean",
+            "description": "Whether this is the last page."
+          }
+        }
+      },
+      "AddressSearchResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "$ref": "#/components/schemas/PaginationMeta"
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AddressDocument"
+            }
+          }
+        }
+      },
+      "AddressDocument": {
+        "type": "object",
+        "properties": {
+          "address_name": {
+            "type": "string",
+            "description": "Full address string."
+          },
+          "address_type": {
+            "type": "string",
+            "description": "Type of address.",
+            "enum": ["REGION", "ROAD", "REGION_ADDR", "ROAD_ADDR"]
+          },
+          "x": {
+            "type": "string",
+            "description": "Longitude."
+          },
+          "y": {
+            "type": "string",
+            "description": "Latitude."
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          },
+          "road_address": {
+            "$ref": "#/components/schemas/RoadAddress"
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "description": "Land-lot based address details.",
+        "properties": {
+          "address_name": {
+            "type": "string"
+          },
+          "region_1depth_name": {
+            "type": "string",
+            "description": "Province/City level."
+          },
+          "region_2depth_name": {
+            "type": "string",
+            "description": "District level."
+          },
+          "region_3depth_name": {
+            "type": "string",
+            "description": "Sub-district level."
+          },
+          "mountain_yn": {
+            "type": "string",
+            "description": "Whether address is a mountain area (Y/N)."
+          },
+          "main_address_no": {
+            "type": "string",
+            "description": "Main address number."
+          },
+          "sub_address_no": {
+            "type": "string",
+            "description": "Sub address number."
+          }
+        }
+      },
+      "RoadAddress": {
+        "type": "object",
+        "description": "Road name address details.",
+        "nullable": true,
+        "properties": {
+          "address_name": {
+            "type": "string"
+          },
+          "region_1depth_name": {
+            "type": "string"
+          },
+          "region_2depth_name": {
+            "type": "string"
+          },
+          "region_3depth_name": {
+            "type": "string"
+          },
+          "road_name": {
+            "type": "string"
+          },
+          "underground_yn": {
+            "type": "string"
+          },
+          "main_building_no": {
+            "type": "string"
+          },
+          "sub_building_no": {
+            "type": "string"
+          },
+          "building_name": {
+            "type": "string"
+          },
+          "zone_no": {
+            "type": "string",
+            "description": "Postal zone number."
+          }
+        }
+      },
+      "RegionCodeResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total_count": {
+                "type": "integer"
+              }
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegionDocument"
+            }
+          }
+        }
+      },
+      "RegionDocument": {
+        "type": "object",
+        "properties": {
+          "region_type": {
+            "type": "string",
+            "description": "H for administrative, B for legal region.",
+            "enum": ["H", "B"]
+          },
+          "address_name": {
+            "type": "string"
+          },
+          "region_1depth_name": {
+            "type": "string"
+          },
+          "region_2depth_name": {
+            "type": "string"
+          },
+          "region_3depth_name": {
+            "type": "string"
+          },
+          "region_4depth_name": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string",
+            "description": "Region code."
+          },
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "CoordToAddressResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total_count": {
+                "type": "integer",
+                "description": "0 or 1."
+              }
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "address": {
+                  "$ref": "#/components/schemas/Address"
+                },
+                "road_address": {
+                  "$ref": "#/components/schemas/RoadAddress"
+                }
+              }
+            }
+          }
+        }
+      },
+      "TransCoordResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total_count": {
+                "type": "integer"
+              }
+            }
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "x": {
+                  "type": "string",
+                  "description": "Transformed longitude."
+                },
+                "y": {
+                  "type": "string",
+                  "description": "Transformed latitude."
+                }
+              }
+            }
+          }
+        }
+      },
+      "KeywordSearchResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PaginationMeta"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "same_name": {
+                    "type": "object",
+                    "properties": {
+                      "region": {
+                        "type": "array",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "keyword": {
+                        "type": "string"
+                      },
+                      "selected_region": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ]
+          },
+          "documents": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlaceDocument"
+            }
+          }
+        }
+      },
+      "PlaceDocument": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Place ID."
+          },
+          "place_name": {
+            "type": "string",
+            "description": "Place name."
+          },
+          "category_name": {
+            "type": "string",
+            "description": "Full category path."
+          },
+          "category_group_code": {
+            "type": "string",
+            "description": "Category group code."
+          },
+          "category_group_name": {
+            "type": "string",
+            "description": "Category group name."
+          },
+          "phone": {
+            "type": "string",
+            "description": "Phone number."
+          },
+          "address_name": {
+            "type": "string",
+            "description": "Land-lot address."
+          },
+          "road_address_name": {
+            "type": "string",
+            "description": "Road name address."
+          },
+          "x": {
+            "type": "string",
+            "description": "Longitude."
+          },
+          "y": {
+            "type": "string",
+            "description": "Latitude."
+          },
+          "place_url": {
+            "type": "string",
+            "description": "Kakao Maps place URL."
+          },
+          "distance": {
+            "type": "string",
+            "description": "Distance in meters from center point (only when x/y specified)."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errorType": {
+            "type": "string",
+            "description": "Error type identifier."
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/developers.kakao.com/kakao-maps/meta.json
+++ b/apis/openapi/developers.kakao.com/kakao-maps/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "7d7fbc40d70f8b882527c8c03451f011",
+    "format": "openapi",
+    "vendor": "developers.kakao.com",
+    "api_name": "kakao-maps",
+    "friendly_id": "developers.kakao.com/kakao-maps"
+  }
+}

--- a/apis/openapi/developers.wargaming.net/wargaming-net/1.0.0/openapi.json
+++ b/apis/openapi/developers.wargaming.net/wargaming-net/1.0.0/openapi.json
@@ -1,0 +1,575 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Wargaming.net API",
+    "description": "The Wargaming.net Public API provides access to game data and player statistics for Wargaming titles including World of Tanks, World of Warships, and World of Warplanes. Retrieve player profiles, vehicle statistics, clan data, encyclopedia information, and more.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Wargaming.net Developer Room",
+      "url": "https://developers.wargaming.net"
+    },
+    "x-jentic-source-url": "https://developers.wargaming.net/"
+  },
+  "servers": [
+    {
+      "url": "https://api.worldoftanks.{region}",
+      "description": "World of Tanks API",
+      "variables": {
+        "region": {
+          "default": "eu",
+          "enum": ["eu", "com", "asia"],
+          "description": "Server region (eu = Europe, com = North America, asia = Asia)"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "applicationId": []
+    }
+  ],
+  "tags": [
+    {"name": "Account", "description": "Player account data"},
+    {"name": "Clans", "description": "Clan information and membership"},
+    {"name": "Encyclopedia", "description": "Game encyclopedia data (vehicles, modules, etc.)"},
+    {"name": "Tanks", "description": "Player vehicle statistics"},
+    {"name": "Ratings", "description": "Player ratings and rankings"},
+    {"name": "Clan Wars", "description": "Clan Wars global map data"}
+  ],
+  "paths": {
+    "/wot/account/list/": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Search players",
+        "description": "Search for player accounts by name. Returns a list of matching accounts with basic information.",
+        "operationId": "searchAccounts",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Application ID"},
+          {"name": "search", "in": "query", "required": true, "schema": {"type": "string", "minLength": 3}, "description": "Player name search string (minimum 3 characters)"},
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["startswith", "exact"], "default": "startswith"}, "description": "Search type"},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 100, "maximum": 100}, "description": "Number of results"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated response fields to return"},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}, "description": "Response language"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccountListResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wot/account/info/": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Get player info",
+        "description": "Retrieve detailed player information including statistics, last battle time, and account details.",
+        "operationId": "getAccountInfo",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Player account ID(s), comma-separated for multiple (max 100)"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated response fields"},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "access_token", "in": "query", "schema": {"type": "string"}, "description": "Access token for private data"},
+          {"name": "extra", "in": "query", "schema": {"type": "string"}, "description": "Extra fields to include (e.g., statistics.random)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Player information",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccountInfoResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wot/account/tanks/": {
+      "get": {
+        "tags": ["Account"],
+        "summary": "Get player vehicles",
+        "description": "Retrieve a list of vehicles owned by a player with basic stats.",
+        "operationId": "getAccountTanks",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "access_token", "in": "query", "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Player vehicle list",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/WargamingResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wot/tanks/stats/": {
+      "get": {
+        "tags": ["Tanks"],
+        "summary": "Get vehicle statistics",
+        "description": "Retrieve per-vehicle statistics for a player.",
+        "operationId": "getTankStats",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "tank_id", "in": "query", "schema": {"type": "string"}, "description": "Filter by vehicle ID(s)"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "access_token", "in": "query", "schema": {"type": "string"}},
+          {"name": "in_garage", "in": "query", "schema": {"type": "string", "enum": ["0", "1"]}, "description": "Filter by garage status"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Vehicle statistics",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/WargamingResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wot/tanks/achievements/": {
+      "get": {
+        "tags": ["Tanks"],
+        "summary": "Get vehicle achievements",
+        "description": "Retrieve achievements earned on specific vehicles for a player.",
+        "operationId": "getTankAchievements",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "tank_id", "in": "query", "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Vehicle achievements",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/encyclopedia/vehicles/": {
+      "get": {
+        "tags": ["Encyclopedia"],
+        "summary": "Get vehicles",
+        "description": "Retrieve the full vehicle encyclopedia with details on every tank in the game.",
+        "operationId": "getEncyclopediaVehicles",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "tank_id", "in": "query", "schema": {"type": "string"}, "description": "Filter by tank ID(s)"},
+          {"name": "nation", "in": "query", "schema": {"type": "string"}, "description": "Filter by nation(s)"},
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["heavyTank", "mediumTank", "lightTank", "AT-SPG", "SPG"]}, "description": "Filter by vehicle type"},
+          {"name": "tier", "in": "query", "schema": {"type": "string"}, "description": "Filter by tier(s)"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+          {"name": "page_no", "in": "query", "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Vehicle encyclopedia data",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/VehiclesResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wot/encyclopedia/info/": {
+      "get": {
+        "tags": ["Encyclopedia"],
+        "summary": "Get encyclopedia info",
+        "description": "Retrieve general encyclopedia metadata including game version, available nations, vehicle types, and languages.",
+        "operationId": "getEncyclopediaInfo",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Encyclopedia metadata",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/encyclopedia/achievements/": {
+      "get": {
+        "tags": ["Encyclopedia"],
+        "summary": "Get achievements",
+        "description": "Retrieve the full list of available achievements and their descriptions.",
+        "operationId": "getEncyclopediaAchievements",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Achievement data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/encyclopedia/maps/": {
+      "get": {
+        "tags": ["Encyclopedia"],
+        "summary": "Get maps",
+        "description": "Retrieve information about all available maps.",
+        "operationId": "getEncyclopediaMaps",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Map data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/clans/list/": {
+      "get": {
+        "tags": ["Clans"],
+        "summary": "Search clans",
+        "description": "Search for clans by name or tag.",
+        "operationId": "searchClans",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "search", "in": "query", "required": true, "schema": {"type": "string", "minLength": 2}, "description": "Clan name or tag search string"},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 100, "maximum": 100}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "page_no", "in": "query", "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clan search results",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/clans/info/": {
+      "get": {
+        "tags": ["Clans"],
+        "summary": "Get clan info",
+        "description": "Retrieve detailed information about one or more clans.",
+        "operationId": "getClanInfo",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "clan_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Clan ID(s), comma-separated"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "extra", "in": "query", "schema": {"type": "string"}, "description": "Extra fields (e.g., members)"},
+          {"name": "members_key", "in": "query", "schema": {"type": "string", "enum": ["account_id", "account_name"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clan information",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/clans/membersinfo/": {
+      "get": {
+        "tags": ["Clans"],
+        "summary": "Get clan member info",
+        "description": "Retrieve detailed information about clan members.",
+        "operationId": "getClanMembersInfo",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Account ID(s)"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clan member details",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/ratings/types/": {
+      "get": {
+        "tags": ["Ratings"],
+        "summary": "Get rating types",
+        "description": "Retrieve available player rating types.",
+        "operationId": "getRatingTypes",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Rating types",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/ratings/accounts/": {
+      "get": {
+        "tags": ["Ratings"],
+        "summary": "Get player ratings",
+        "description": "Retrieve player ratings for specific accounts.",
+        "operationId": "getPlayerRatings",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "account_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Account ID(s)"},
+          {"name": "type", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Rating type"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Player ratings",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/globalmap/clans/": {
+      "get": {
+        "tags": ["Clan Wars"],
+        "summary": "Get Clan Wars clans",
+        "description": "Retrieve clan information from the Global Map.",
+        "operationId": "getGlobalmapClans",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "clan_id", "in": "query", "schema": {"type": "string"}, "description": "Clan ID(s)"},
+          {"name": "search", "in": "query", "schema": {"type": "string"}},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+          {"name": "page_no", "in": "query", "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Clan Wars data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    },
+    "/wot/globalmap/provinces/": {
+      "get": {
+        "tags": ["Clan Wars"],
+        "summary": "Get Global Map provinces",
+        "description": "Retrieve province information from the Global Map for a specific front.",
+        "operationId": "getGlobalmapProvinces",
+        "parameters": [
+          {"name": "application_id", "in": "query", "required": true, "schema": {"type": "string"}},
+          {"name": "front_id", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Front ID"},
+          {"name": "province_id", "in": "query", "schema": {"type": "string"}, "description": "Province ID(s)"},
+          {"name": "fields", "in": "query", "schema": {"type": "string"}},
+          {"name": "language", "in": "query", "schema": {"type": "string", "default": "en"}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer"}},
+          {"name": "page_no", "in": "query", "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Province data",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/WargamingResponse"}}}
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "applicationId": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "application_id",
+        "description": "Wargaming application ID. Register at developers.wargaming.net to obtain one."
+      },
+      "accessToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "access_token",
+        "description": "Player access token for private data access. Obtained via OAuth authentication."
+      }
+    },
+    "schemas": {
+      "WargamingResponse": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string", "enum": ["ok", "error"], "description": "Response status"},
+          "meta": {
+            "type": "object",
+            "properties": {
+              "count": {"type": "integer", "description": "Number of results"}
+            }
+          },
+          "data": {
+            "description": "Response data (structure varies by endpoint)"
+          },
+          "error": {"$ref": "#/components/schemas/WargamingError"}
+        }
+      },
+      "WargamingError": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "code": {"type": "integer", "description": "Error code"},
+          "message": {"type": "string", "description": "Error message"},
+          "field": {"type": "string", "nullable": true, "description": "Field that caused the error"},
+          "value": {"type": "string", "nullable": true, "description": "Invalid value"}
+        }
+      },
+      "AccountListResponse": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string", "enum": ["ok", "error"]},
+          "meta": {
+            "type": "object",
+            "properties": {
+              "count": {"type": "integer"}
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/AccountListItem"}
+          },
+          "error": {"$ref": "#/components/schemas/WargamingError"}
+        }
+      },
+      "AccountListItem": {
+        "type": "object",
+        "properties": {
+          "account_id": {"type": "integer", "description": "Player account ID"},
+          "nickname": {"type": "string", "description": "Player nickname"}
+        }
+      },
+      "AccountInfoResponse": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string", "enum": ["ok", "error"]},
+          "meta": {
+            "type": "object",
+            "properties": {
+              "count": {"type": "integer"}
+            }
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#/components/schemas/AccountInfo"}
+          },
+          "error": {"$ref": "#/components/schemas/WargamingError"}
+        }
+      },
+      "AccountInfo": {
+        "type": "object",
+        "properties": {
+          "account_id": {"type": "integer"},
+          "nickname": {"type": "string"},
+          "created_at": {"type": "integer", "description": "Account creation timestamp"},
+          "updated_at": {"type": "integer", "description": "Last data update timestamp"},
+          "last_battle_time": {"type": "integer", "description": "Last battle timestamp"},
+          "global_rating": {"type": "integer", "description": "Player global rating"},
+          "clan_id": {"type": "integer", "nullable": true},
+          "statistics": {"$ref": "#/components/schemas/PlayerStatistics"}
+        }
+      },
+      "PlayerStatistics": {
+        "type": "object",
+        "properties": {
+          "all": {"$ref": "#/components/schemas/BattleStatistics"},
+          "trees_cut": {"type": "integer"}
+        }
+      },
+      "BattleStatistics": {
+        "type": "object",
+        "properties": {
+          "battles": {"type": "integer"},
+          "wins": {"type": "integer"},
+          "losses": {"type": "integer"},
+          "draws": {"type": "integer"},
+          "frags": {"type": "integer", "description": "Kills"},
+          "spotted": {"type": "integer"},
+          "damage_dealt": {"type": "integer"},
+          "damage_received": {"type": "integer"},
+          "capture_points": {"type": "integer"},
+          "dropped_capture_points": {"type": "integer"},
+          "xp": {"type": "integer", "description": "Total experience"},
+          "survived_battles": {"type": "integer"},
+          "max_damage": {"type": "integer"},
+          "max_frags": {"type": "integer"},
+          "max_xp": {"type": "integer"},
+          "hits": {"type": "integer"},
+          "shots": {"type": "integer"},
+          "piercings": {"type": "integer"},
+          "tanking_factor": {"type": "number", "format": "float"}
+        }
+      },
+      "Vehicle": {
+        "type": "object",
+        "properties": {
+          "tank_id": {"type": "integer"},
+          "name": {"type": "string"},
+          "short_name": {"type": "string"},
+          "nation": {"type": "string"},
+          "type": {"type": "string"},
+          "tier": {"type": "integer"},
+          "is_premium": {"type": "boolean"},
+          "description": {"type": "string"},
+          "price_gold": {"type": "integer", "nullable": true},
+          "price_credit": {"type": "integer", "nullable": true},
+          "images": {
+            "type": "object",
+            "properties": {
+              "small_icon": {"type": "string", "format": "uri"},
+              "contour_icon": {"type": "string", "format": "uri"},
+              "big_icon": {"type": "string", "format": "uri"}
+            }
+          }
+        }
+      },
+      "VehiclesResponse": {
+        "type": "object",
+        "properties": {
+          "status": {"type": "string", "enum": ["ok", "error"]},
+          "meta": {
+            "type": "object",
+            "properties": {
+              "count": {"type": "integer"},
+              "total": {"type": "integer"},
+              "page_total": {"type": "integer"},
+              "page": {"type": "integer"},
+              "limit": {"type": "integer"}
+            }
+          },
+          "data": {
+            "type": "object",
+            "additionalProperties": {"$ref": "#/components/schemas/Vehicle"}
+          },
+          "error": {"$ref": "#/components/schemas/WargamingError"}
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/developers.wargaming.net/wargaming-net/meta.json
+++ b/apis/openapi/developers.wargaming.net/wargaming-net/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "a4dc5793c6f1f92983b855710b8684f5",
+    "format": "openapi",
+    "vendor": "developers.wargaming.net",
+    "api_name": "wargaming-net",
+    "friendly_id": "developers.wargaming.net/wargaming-net"
+  }
+}

--- a/apis/openapi/geocod.io/geocod-io/1.12.0/openapi.json
+++ b/apis/openapi/geocod.io/geocod-io/1.12.0/openapi.json
@@ -1,0 +1,1189 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Geocodio API",
+    "description": "Geocodio provides forward and reverse geocoding for US and Canadian addresses, plus data appending for congressional districts, census data, timezones, and more. Supports single lookups, batch processing, spreadsheet uploads, and distance calculations.",
+    "version": "1.12.0",
+    "contact": {
+      "name": "Geocodio Support",
+      "url": "https://www.geocod.io/contact/"
+    },
+    "x-jentic-source-url": "https://www.geocod.io/"
+  },
+  "servers": [
+    {
+      "url": "https://api.geocod.io/v1.12",
+      "description": "Geocodio Production API v1.12"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Forward geocoding (address to coordinates)"
+    },
+    {
+      "name": "Reverse Geocoding",
+      "description": "Reverse geocoding (coordinates to address)"
+    },
+    {
+      "name": "Lists",
+      "description": "Spreadsheet/CSV batch processing"
+    },
+    {
+      "name": "Distance",
+      "description": "Distance and driving time calculations"
+    }
+  ],
+  "paths": {
+    "/geocode": {
+      "get": {
+        "operationId": "geocodeSingle",
+        "summary": "Single Address Geocoding",
+        "description": "Geocode a single address or address components to latitude/longitude coordinates.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Full address string to geocode. Use this OR individual address component parameters.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1109 N Highland St, Arlington, VA"
+          },
+          {
+            "name": "street",
+            "in": "query",
+            "description": "Street address component.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "description": "City component.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "State component.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postal_code",
+            "in": "query",
+            "description": "ZIP/postal code component.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "description": "Country (USA, CA, or MX).",
+            "schema": {
+              "type": "string",
+              "enum": ["USA", "CA", "MX"]
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of data fields to append (e.g. cd,stateleg,timezone,census).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Response format. Use 'simple' for simplified output.",
+            "schema": {
+              "type": "string",
+              "enum": ["simple"]
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "description": "Your Geocodio API key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - insufficient permissions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity - invalid data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "geocodeBatch",
+        "summary": "Batch Address Geocoding",
+        "description": "Geocode up to 10,000 addresses in a single request.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "description": "Your Geocodio API key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of data fields to append.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results per address.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of address strings."
+                  },
+                  {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    },
+                    "description": "Object mapping custom IDs to address strings."
+                  }
+                ]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch geocoding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchGeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reverse": {
+      "get": {
+        "operationId": "reverseGeocodeSingle",
+        "summary": "Single Reverse Geocoding",
+        "description": "Look up one or more addresses by coordinate pair (latitude, longitude).",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Coordinate pair as 'latitude,longitude'.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "38.9002898,-76.9990361"
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of data fields to append.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Response format. Use 'simple' for simplified output.",
+            "schema": {
+              "type": "string",
+              "enum": ["simple"]
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "description": "Your Geocodio API key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "reverseGeocodeBatch",
+        "summary": "Batch Reverse Geocoding",
+        "description": "Reverse geocode up to 10,000 coordinate pairs in a single request.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "description": "Your Geocodio API key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of data fields to append.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results per coordinate.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Array of coordinate strings ('lat,lng')."
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch reverse geocoding",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchGeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lists": {
+      "get": {
+        "operationId": "getAllLists",
+        "summary": "Get All Lists",
+        "description": "Retrieve all uploaded spreadsheet lists with pagination.",
+        "tags": ["Lists"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for pagination.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of uploaded lists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedListResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createList",
+        "summary": "Create List",
+        "description": "Upload a spreadsheet (CSV) for batch geocoding or reverse geocoding.",
+        "tags": ["Lists"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated list of data fields to append.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["file", "direction", "format"],
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "CSV file to upload."
+                  },
+                  "filename": {
+                    "type": "string",
+                    "description": "Filename (required if file is inline string)."
+                  },
+                  "direction": {
+                    "type": "string",
+                    "enum": ["forward", "reverse"],
+                    "description": "Geocoding direction."
+                  },
+                  "format": {
+                    "type": "string",
+                    "description": "Column template using {{A}}, {{B}} notation."
+                  },
+                  "callback": {
+                    "type": "string",
+                    "description": "Webhook URL to notify when processing completes."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "List created successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListCreateResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Invalid file or parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lists/{listId}": {
+      "get": {
+        "operationId": "getListStatus",
+        "summary": "Get List Status",
+        "description": "Check the processing status of an uploaded list.",
+        "tags": ["Lists"],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "List identifier.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List status details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListStatusResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "List not found"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteList",
+        "summary": "Delete List",
+        "description": "Delete an uploaded list.",
+        "tags": ["Lists"],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "List identifier.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List deleted successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/lists/{listId}/download": {
+      "get": {
+        "operationId": "downloadList",
+        "summary": "Download List",
+        "description": "Download the geocoded results as a CSV file.",
+        "tags": ["Lists"],
+        "parameters": [
+          {
+            "name": "listId",
+            "in": "path",
+            "required": true,
+            "description": "List identifier.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "CSV file download",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/distance": {
+      "get": {
+        "operationId": "calculateDistance",
+        "summary": "Calculate Distance",
+        "description": "Calculate distance and driving time between origins and destinations.",
+        "tags": ["Distance"],
+        "parameters": [
+          {
+            "name": "origins[]",
+            "in": "query",
+            "required": true,
+            "description": "Origin addresses or coordinate pairs.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "destinations[]",
+            "in": "query",
+            "required": true,
+            "description": "Destination addresses or coordinate pairs.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "distance_units",
+            "in": "query",
+            "description": "Unit for distance measurement.",
+            "schema": {
+              "type": "string",
+              "enum": ["miles", "km"],
+              "default": "miles"
+            }
+          },
+          {
+            "name": "distance_mode",
+            "in": "query",
+            "description": "Mode of distance calculation.",
+            "schema": {
+              "type": "string",
+              "enum": ["driving", "straightline"],
+              "default": "driving"
+            }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Distance calculation results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DistanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "calculateDistanceBatch",
+        "summary": "Distance Matrix",
+        "description": "Calculate a distance matrix between multiple origins and destinations.",
+        "tags": ["Distance"],
+        "parameters": [
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["origins", "destinations"],
+                "properties": {
+                  "origins": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of origin addresses or coordinates."
+                  },
+                  "destinations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of destination addresses or coordinates."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Distance matrix results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DistanceResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "description": "Geocodio API key passed as a query parameter."
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Geocodio API key passed as a Bearer token in the Authorization header."
+      }
+    },
+    "schemas": {
+      "GeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "input": {
+            "type": "object",
+            "properties": {
+              "address_components": {
+                "$ref": "#/components/schemas/AddressComponents"
+              },
+              "formatted_address": {
+                "type": "string"
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GeocodeResult"
+            }
+          }
+        }
+      },
+      "BatchGeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "description": "The original query address or coordinate."
+                },
+                "response": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "GeocodeResult": {
+        "type": "object",
+        "properties": {
+          "address_components": {
+            "$ref": "#/components/schemas/AddressComponents"
+          },
+          "formatted_address": {
+            "type": "string",
+            "description": "Full formatted address string."
+          },
+          "location": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "format": "double",
+                "description": "Latitude."
+              },
+              "lng": {
+                "type": "number",
+                "format": "double",
+                "description": "Longitude."
+              }
+            }
+          },
+          "accuracy": {
+            "type": "number",
+            "description": "Accuracy score from 0 to 1."
+          },
+          "accuracy_type": {
+            "type": "string",
+            "description": "Type of accuracy.",
+            "enum": ["rooftop", "range_interpolation", "nearest_rooftop_match", "street_center", "place", "state", "county"]
+          },
+          "source": {
+            "type": "string",
+            "description": "Data source attribution."
+          },
+          "stable_address_key": {
+            "type": "string",
+            "description": "Permanent address identifier."
+          },
+          "fields": {
+            "type": "object",
+            "description": "Additional appended field data (varies based on fields parameter).",
+            "additionalProperties": true
+          }
+        }
+      },
+      "AddressComponents": {
+        "type": "object",
+        "properties": {
+          "number": {
+            "type": "string",
+            "description": "Street number."
+          },
+          "predirectional": {
+            "type": "string",
+            "description": "Street pre-directional (e.g. N, S, E, W)."
+          },
+          "street": {
+            "type": "string",
+            "description": "Street name."
+          },
+          "suffix": {
+            "type": "string",
+            "description": "Street suffix (e.g. St, Ave, Blvd)."
+          },
+          "postdirectional": {
+            "type": "string",
+            "description": "Street post-directional."
+          },
+          "formatted_street": {
+            "type": "string",
+            "description": "Full formatted street name."
+          },
+          "city": {
+            "type": "string",
+            "description": "City name."
+          },
+          "county": {
+            "type": "string",
+            "description": "County name."
+          },
+          "state": {
+            "type": "string",
+            "description": "State abbreviation."
+          },
+          "zip": {
+            "type": "string",
+            "description": "ZIP code."
+          },
+          "country": {
+            "type": "string",
+            "description": "Country code."
+          },
+          "secondaryunit": {
+            "type": "string",
+            "description": "Secondary unit type (e.g. Apt, Suite)."
+          },
+          "secondarynumber": {
+            "type": "string",
+            "description": "Secondary unit number."
+          }
+        }
+      },
+      "PaginatedListResponse": {
+        "type": "object",
+        "properties": {
+          "current_page": {
+            "type": "integer"
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ListStatusResponse"
+            }
+          },
+          "first_page_url": {
+            "type": "string"
+          },
+          "last_page_url": {
+            "type": "string"
+          },
+          "next_page_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "prev_page_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "total": {
+            "type": "integer"
+          }
+        }
+      },
+      "ListCreateResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "List identifier."
+          },
+          "file": {
+            "type": "object",
+            "properties": {
+              "headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "estimated_rows_count": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "ListStatusResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "List identifier."
+          },
+          "fields": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "file": {
+            "type": "object",
+            "properties": {
+              "headers": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "estimated_rows_count": {
+                "type": "integer"
+              },
+              "filename": {
+                "type": "string"
+              }
+            }
+          },
+          "status": {
+            "type": "object",
+            "properties": {
+              "state": {
+                "type": "string",
+                "description": "Processing state.",
+                "enum": ["pending", "processing", "completed", "failed"]
+              },
+              "progress": {
+                "type": "number",
+                "description": "Progress percentage (0-100)."
+              },
+              "message": {
+                "type": "string"
+              },
+              "time_left": {
+                "type": "string",
+                "nullable": true,
+                "description": "Estimated time remaining."
+              }
+            }
+          },
+          "download_url": {
+            "type": "string",
+            "nullable": true,
+            "description": "URL to download results when completed."
+          },
+          "expires_at": {
+            "type": "string",
+            "nullable": true,
+            "description": "Expiration date for the results."
+          }
+        }
+      },
+      "DistanceResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "origin": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GeocodeResult"
+                      }
+                    }
+                  }
+                },
+                "destination": {
+                  "type": "object",
+                  "properties": {
+                    "query": {
+                      "type": "string"
+                    },
+                    "results": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GeocodeResult"
+                      }
+                    }
+                  }
+                },
+                "distance": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "Distance value."
+                    },
+                    "units": {
+                      "type": "string",
+                      "description": "Distance units (miles or km)."
+                    }
+                  }
+                },
+                "duration": {
+                  "type": "object",
+                  "properties": {
+                    "value": {
+                      "type": "number",
+                      "description": "Duration in seconds."
+                    },
+                    "text": {
+                      "type": "string",
+                      "description": "Human-readable duration."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/geocod.io/geocod-io/meta.json
+++ b/apis/openapi/geocod.io/geocod-io/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "cd694c498445a485a7eca86ec8ed255e",
+    "format": "openapi",
+    "vendor": "geocod.io",
+    "api_name": "geocod-io",
+    "friendly_id": "geocod.io/geocod-io"
+  }
+}

--- a/apis/openapi/guildwars2.com/guild-wars-2/2.0.0/openapi.json
+++ b/apis/openapi/guildwars2.com/guild-wars-2/2.0.0/openapi.json
@@ -1,0 +1,1091 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Guild Wars 2 API",
+    "description": "The official Guild Wars 2 API provides programmatic access to game data including account information, characters, items, commerce, PvP, WvW, achievements, and world data.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "ArenaNet",
+      "url": "https://www.arena.net"
+    },
+    "x-jentic-source-url": "https://wiki.guildwars2.com/wiki/API:2"
+  },
+  "externalDocs": {
+    "description": "Guild Wars 2 API Wiki Documentation",
+    "url": "https://wiki.guildwars2.com/wiki/API:2"
+  },
+  "servers": [
+    {
+      "url": "https://api.guildwars2.com/v2",
+      "description": "Production API server"
+    }
+  ],
+  "tags": [
+    { "name": "Account", "description": "Authenticated account data endpoints" },
+    { "name": "Characters", "description": "Character information (authenticated)" },
+    { "name": "Guild", "description": "Guild information" },
+    { "name": "Items", "description": "Game item data" },
+    { "name": "Commerce", "description": "Trading post and gem exchange" },
+    { "name": "PvP", "description": "Player vs Player data" },
+    { "name": "WvW", "description": "World vs World data" },
+    { "name": "Achievements", "description": "Achievement definitions" },
+    { "name": "Worlds", "description": "World/server information" },
+    { "name": "Maps", "description": "Map data" },
+    { "name": "Currencies", "description": "In-game currency definitions" }
+  ],
+  "security": [],
+  "paths": {
+    "/account": {
+      "get": {
+        "operationId": "getAccount",
+        "summary": "Get account information",
+        "description": "Returns information about the authenticated account including name, world, guilds, access, and creation date.",
+        "tags": ["Account"],
+        "security": [{ "BearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Account information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Account" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/account/bank": {
+      "get": {
+        "operationId": "getAccountBank",
+        "summary": "Get account bank contents",
+        "description": "Returns the items stored in the account vault. Each element can be null if the slot is empty.",
+        "tags": ["Account"],
+        "security": [{ "BearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Array of bank slot items (null for empty slots)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "nullable": true,
+                    "$ref": "#/components/schemas/BankSlot"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/account/inventory": {
+      "get": {
+        "operationId": "getAccountInventory",
+        "summary": "Get shared account inventory",
+        "description": "Returns the shared inventory slots in the account. Each element can be null if the slot is empty.",
+        "tags": ["Account"],
+        "security": [{ "BearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Array of shared inventory items",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "nullable": true,
+                    "$ref": "#/components/schemas/InventorySlot"
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/characters": {
+      "get": {
+        "operationId": "getCharacters",
+        "summary": "List all character names",
+        "description": "Returns an array of character names on the authenticated account.",
+        "tags": ["Characters"],
+        "security": [{ "BearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "List of character names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "type": "string" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/characters/{name}": {
+      "get": {
+        "operationId": "getCharacter",
+        "summary": "Get character details",
+        "description": "Returns detailed information about a specific character.",
+        "tags": ["Characters"],
+        "security": [{ "BearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "Character name",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Character details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Character" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/guild/{id}": {
+      "get": {
+        "operationId": "getGuild",
+        "summary": "Get guild information",
+        "description": "Returns core information about a guild. Some fields require authentication and guild leader/member access.",
+        "tags": ["Guild"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The guild UUID",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Guild information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Guild" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/items": {
+      "get": {
+        "operationId": "listItems",
+        "summary": "List all item IDs",
+        "description": "Returns an array of all item IDs available in the game. Use the ids parameter to fetch specific items.",
+        "tags": ["Items"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/page_size" },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of item IDs or item objects when ids parameter is provided",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Item" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/items/{id}": {
+      "get": {
+        "operationId": "getItem",
+        "summary": "Get a specific item",
+        "description": "Returns detailed information about a specific item.",
+        "tags": ["Items"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The item ID",
+            "schema": { "type": "integer" }
+          },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Item details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Item" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/commerce/listings": {
+      "get": {
+        "operationId": "listCommerceListings",
+        "summary": "List trading post listing IDs",
+        "description": "Returns item IDs with current buy and sell listings on the trading post.",
+        "tags": ["Commerce"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/page_size" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listing IDs or listing objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/CommerceListing" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commerce/listings/{id}": {
+      "get": {
+        "operationId": "getCommerceListing",
+        "summary": "Get trading post listings for an item",
+        "description": "Returns current buy and sell orders for a specific item on the trading post.",
+        "tags": ["Commerce"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The item ID",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Listing details with buy and sell orders",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CommerceListing" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/commerce/exchange/coins": {
+      "get": {
+        "operationId": "getExchangeCoins",
+        "summary": "Get gems-to-coins exchange rate",
+        "description": "Returns the current coins-to-gems exchange rate for a given quantity of coins.",
+        "tags": ["Commerce"],
+        "parameters": [
+          {
+            "name": "quantity",
+            "in": "query",
+            "required": true,
+            "description": "The number of coins to exchange",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exchange rate information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ExchangeRate" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/commerce/exchange/gems": {
+      "get": {
+        "operationId": "getExchangeGems",
+        "summary": "Get coins-to-gems exchange rate",
+        "description": "Returns the current gems-to-coins exchange rate for a given quantity of gems.",
+        "tags": ["Commerce"],
+        "parameters": [
+          {
+            "name": "quantity",
+            "in": "query",
+            "required": true,
+            "description": "The number of gems to exchange",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Exchange rate information",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ExchangeRate" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/pvp/stats": {
+      "get": {
+        "operationId": "getPvpStats",
+        "summary": "Get PvP statistics",
+        "description": "Returns PvP statistics for the authenticated account including wins, losses, and rank.",
+        "tags": ["PvP"],
+        "security": [{ "BearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "PvP statistics",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PvpStats" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/wvw/matches": {
+      "get": {
+        "operationId": "listWvwMatches",
+        "summary": "List WvW match IDs",
+        "description": "Returns all current World vs World match IDs, or match details when ids parameter is provided.",
+        "tags": ["WvW"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Match IDs or match objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/WvwMatch" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/wvw/matches/{id}": {
+      "get": {
+        "operationId": "getWvwMatch",
+        "summary": "Get a WvW match",
+        "description": "Returns details of a specific World vs World match including scores, kills, deaths, and victory points.",
+        "tags": ["WvW"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The match ID (e.g., 1-1, 2-1)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "WvW match details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/WvwMatch" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/achievements": {
+      "get": {
+        "operationId": "listAchievements",
+        "summary": "List achievement IDs",
+        "description": "Returns all achievement IDs, or achievement details when ids parameter is provided.",
+        "tags": ["Achievements"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/page_size" },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Achievement IDs or achievement objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Achievement" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/achievements/{id}": {
+      "get": {
+        "operationId": "getAchievement",
+        "summary": "Get a specific achievement",
+        "description": "Returns detailed information about a specific achievement including tiers and requirements.",
+        "tags": ["Achievements"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The achievement ID",
+            "schema": { "type": "integer" }
+          },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Achievement details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Achievement" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/worlds": {
+      "get": {
+        "operationId": "listWorlds",
+        "summary": "List world/server IDs",
+        "description": "Returns all world IDs, or world details when ids parameter is provided.",
+        "tags": ["Worlds"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "World IDs or world objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/World" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/worlds/{id}": {
+      "get": {
+        "operationId": "getWorld",
+        "summary": "Get a specific world",
+        "description": "Returns information about a specific game world/server.",
+        "tags": ["Worlds"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The world ID",
+            "schema": { "type": "integer" }
+          },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "World details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/World" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/maps": {
+      "get": {
+        "operationId": "listMaps",
+        "summary": "List map IDs",
+        "description": "Returns all map IDs, or map details when ids parameter is provided.",
+        "tags": ["Maps"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map IDs or map objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/GameMap" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/maps/{id}": {
+      "get": {
+        "operationId": "getMap",
+        "summary": "Get a specific map",
+        "description": "Returns detailed information about a specific game map.",
+        "tags": ["Maps"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The map ID",
+            "schema": { "type": "integer" }
+          },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/GameMap" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/currencies": {
+      "get": {
+        "operationId": "listCurrencies",
+        "summary": "List currency IDs",
+        "description": "Returns all currency IDs, or currency details when ids parameter is provided.",
+        "tags": ["Currencies"],
+        "parameters": [
+          { "$ref": "#/components/parameters/ids" },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Currency IDs or currency objects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "oneOf": [
+                    {
+                      "type": "array",
+                      "items": { "type": "integer" }
+                    },
+                    {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Currency" }
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/currencies/{id}": {
+      "get": {
+        "operationId": "getCurrency",
+        "summary": "Get a specific currency",
+        "description": "Returns information about a specific in-game currency.",
+        "tags": ["Currencies"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The currency ID",
+            "schema": { "type": "integer" }
+          },
+          { "$ref": "#/components/parameters/lang" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Currency details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Currency" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Guild Wars 2 API key. Generate one at https://account.arena.net/applications"
+      }
+    },
+    "parameters": {
+      "ids": {
+        "name": "ids",
+        "in": "query",
+        "description": "Comma-separated list of IDs, or 'all' to return all entries",
+        "schema": { "type": "string" }
+      },
+      "page": {
+        "name": "page",
+        "in": "query",
+        "description": "Page number for paginated results (0-indexed)",
+        "schema": { "type": "integer", "default": 0 }
+      },
+      "page_size": {
+        "name": "page_size",
+        "in": "query",
+        "description": "Number of results per page (max 200)",
+        "schema": { "type": "integer", "default": 50, "maximum": 200 }
+      },
+      "lang": {
+        "name": "lang",
+        "in": "query",
+        "description": "Language code for localized strings",
+        "schema": {
+          "type": "string",
+          "enum": ["en", "es", "de", "fr", "zh"],
+          "default": "en"
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication required. Provide a valid API key.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "The API key does not have the required permissions.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource was not found.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "Error message"
+          }
+        }
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "description": "Unique account identifier" },
+          "age": { "type": "integer", "description": "Age of the account in seconds" },
+          "name": { "type": "string", "description": "Account display name" },
+          "world": { "type": "integer", "description": "Home world ID" },
+          "guilds": { "type": "array", "items": { "type": "string", "format": "uuid" }, "description": "List of guild IDs" },
+          "guild_leader": { "type": "array", "items": { "type": "string", "format": "uuid" }, "description": "Guilds the account is leader of" },
+          "created": { "type": "string", "format": "date-time", "description": "Account creation date" },
+          "access": { "type": "array", "items": { "type": "string" }, "description": "Product access (e.g., GuildWars2, HeartOfThorns, PathOfFire, EndOfDragons)" },
+          "commander": { "type": "boolean", "description": "Whether the account has commander tag" },
+          "fractal_level": { "type": "integer", "description": "Account fractal level" },
+          "daily_ap": { "type": "integer", "description": "Daily achievement points" },
+          "monthly_ap": { "type": "integer", "description": "Monthly achievement points" },
+          "wvw_rank": { "type": "integer", "description": "WvW rank" }
+        }
+      },
+      "BankSlot": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Item ID" },
+          "count": { "type": "integer", "description": "Stack count" },
+          "charges": { "type": "integer", "description": "Remaining charges (consumables)" },
+          "skin": { "type": "integer", "description": "Skin ID applied to the item" },
+          "dyes": { "type": "array", "items": { "type": "integer" }, "description": "Dye IDs" },
+          "upgrades": { "type": "array", "items": { "type": "integer" }, "description": "Upgrade item IDs" },
+          "upgrade_slot_indices": { "type": "array", "items": { "type": "integer" } },
+          "infusions": { "type": "array", "items": { "type": "integer" }, "description": "Infusion item IDs" },
+          "binding": { "type": "string", "enum": ["Character", "Account"], "description": "Binding type" },
+          "bound_to": { "type": "string", "description": "Character name if character-bound" }
+        }
+      },
+      "InventorySlot": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Item ID" },
+          "count": { "type": "integer", "description": "Stack count" },
+          "charges": { "type": "integer", "description": "Remaining charges" },
+          "binding": { "type": "string", "enum": ["Character", "Account"] },
+          "bound_to": { "type": "string", "description": "Character name if character-bound" }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "Character name" },
+          "race": { "type": "string", "description": "Character race", "enum": ["Asura", "Charr", "Human", "Norn", "Sylvari"] },
+          "gender": { "type": "string", "enum": ["Male", "Female"] },
+          "profession": { "type": "string", "description": "Character profession/class" },
+          "level": { "type": "integer", "description": "Character level (1-80)" },
+          "guild": { "type": "string", "format": "uuid", "description": "Currently representing guild ID" },
+          "age": { "type": "integer", "description": "Character age in seconds" },
+          "created": { "type": "string", "format": "date-time" },
+          "deaths": { "type": "integer", "description": "Total deaths" },
+          "title": { "type": "integer", "description": "Currently selected title ID" }
+        }
+      },
+      "Guild": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid", "description": "Guild UUID" },
+          "name": { "type": "string", "description": "Guild name" },
+          "tag": { "type": "string", "description": "Guild tag (2-4 characters)" },
+          "level": { "type": "integer", "description": "Guild level" },
+          "motd": { "type": "string", "description": "Message of the day (authenticated, member only)" },
+          "influence": { "type": "integer", "description": "Guild influence" },
+          "aetherium": { "type": "integer" },
+          "favor": { "type": "integer" },
+          "member_count": { "type": "integer" },
+          "member_capacity": { "type": "integer" },
+          "emblem": {
+            "type": "object",
+            "properties": {
+              "background": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer" },
+                  "colors": { "type": "array", "items": { "type": "integer" } }
+                }
+              },
+              "foreground": {
+                "type": "object",
+                "properties": {
+                  "id": { "type": "integer" },
+                  "colors": { "type": "array", "items": { "type": "integer" } }
+                }
+              },
+              "flags": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Item ID" },
+          "chat_link": { "type": "string", "description": "In-game chat link" },
+          "name": { "type": "string", "description": "Item name" },
+          "description": { "type": "string", "description": "Item description" },
+          "type": { "type": "string", "description": "Item type", "enum": ["Armor", "Back", "Bag", "Consumable", "Container", "CraftingMaterial", "Gathering", "Gizmo", "Key", "MiniPet", "Tool", "Trait", "Trinket", "Trophy", "UpgradeComponent", "Weapon"] },
+          "level": { "type": "integer", "description": "Required level" },
+          "rarity": { "type": "string", "enum": ["Junk", "Basic", "Fine", "Masterwork", "Rare", "Exotic", "Ascended", "Legendary"] },
+          "vendor_value": { "type": "integer", "description": "Vendor sell value in coins" },
+          "icon": { "type": "string", "format": "uri", "description": "Icon URL" },
+          "game_types": { "type": "array", "items": { "type": "string" }, "description": "Game types where the item is usable" },
+          "flags": { "type": "array", "items": { "type": "string" }, "description": "Item flags" },
+          "restrictions": { "type": "array", "items": { "type": "string" }, "description": "Race or profession restrictions" }
+        }
+      },
+      "CommerceListing": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Item ID" },
+          "buys": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ListingEntry" },
+            "description": "Current buy orders"
+          },
+          "sells": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/ListingEntry" },
+            "description": "Current sell orders"
+          }
+        }
+      },
+      "ListingEntry": {
+        "type": "object",
+        "properties": {
+          "listings": { "type": "integer", "description": "Number of individual listings at this price" },
+          "unit_price": { "type": "integer", "description": "Price per unit in coins" },
+          "quantity": { "type": "integer", "description": "Total quantity available" }
+        }
+      },
+      "ExchangeRate": {
+        "type": "object",
+        "properties": {
+          "coins_per_gem": { "type": "integer", "description": "Current exchange rate in coins per gem" },
+          "quantity": { "type": "integer", "description": "Number of gems/coins received" }
+        }
+      },
+      "PvpStats": {
+        "type": "object",
+        "properties": {
+          "pvp_rank": { "type": "integer", "description": "PvP rank" },
+          "pvp_rank_points": { "type": "integer", "description": "Total PvP rank points" },
+          "pvp_rank_rollovers": { "type": "integer", "description": "Number of rank rollovers" },
+          "aggregate": { "$ref": "#/components/schemas/PvpWinLoss" },
+          "professions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/components/schemas/PvpWinLoss" },
+            "description": "Win/loss stats broken down by profession"
+          },
+          "ladders": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/components/schemas/PvpWinLoss" },
+            "description": "Win/loss stats broken down by ladder type"
+          }
+        }
+      },
+      "PvpWinLoss": {
+        "type": "object",
+        "properties": {
+          "wins": { "type": "integer" },
+          "losses": { "type": "integer" },
+          "desertions": { "type": "integer" },
+          "byes": { "type": "integer" },
+          "forfeits": { "type": "integer" }
+        }
+      },
+      "WvwMatch": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Match ID (e.g., 2-1)" },
+          "start_time": { "type": "string", "format": "date-time" },
+          "end_time": { "type": "string", "format": "date-time" },
+          "scores": { "$ref": "#/components/schemas/TeamValues" },
+          "worlds": { "$ref": "#/components/schemas/TeamValues" },
+          "all_worlds": {
+            "type": "object",
+            "properties": {
+              "red": { "type": "array", "items": { "type": "integer" } },
+              "blue": { "type": "array", "items": { "type": "integer" } },
+              "green": { "type": "array", "items": { "type": "integer" } }
+            }
+          },
+          "deaths": { "$ref": "#/components/schemas/TeamValues" },
+          "kills": { "$ref": "#/components/schemas/TeamValues" },
+          "victory_points": { "$ref": "#/components/schemas/TeamValues" },
+          "skirmishes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "scores": { "$ref": "#/components/schemas/TeamValues" },
+                "map_scores": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+          },
+          "maps": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "integer" },
+                "type": { "type": "string" },
+                "scores": { "$ref": "#/components/schemas/TeamValues" },
+                "kills": { "$ref": "#/components/schemas/TeamValues" },
+                "deaths": { "$ref": "#/components/schemas/TeamValues" },
+                "objectives": { "type": "array", "items": { "type": "object" } }
+              }
+            }
+          }
+        }
+      },
+      "TeamValues": {
+        "type": "object",
+        "description": "Values for each WvW team color",
+        "properties": {
+          "red": { "type": "integer" },
+          "blue": { "type": "integer" },
+          "green": { "type": "integer" }
+        }
+      },
+      "Achievement": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Achievement ID" },
+          "name": { "type": "string", "description": "Achievement name" },
+          "description": { "type": "string", "description": "Achievement description" },
+          "requirement": { "type": "string", "description": "How to progress the achievement" },
+          "locked_text": { "type": "string", "description": "Text shown when locked" },
+          "type": { "type": "string", "enum": ["Default", "ItemSet"], "description": "Achievement type" },
+          "flags": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Achievement flags (e.g., Permanent, CategoryDisplay)"
+          },
+          "tiers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "count": { "type": "integer", "description": "Threshold for this tier" },
+                "points": { "type": "integer", "description": "Achievement points awarded" }
+              }
+            }
+          },
+          "rewards": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "type": { "type": "string" },
+                "id": { "type": "integer" },
+                "count": { "type": "integer" }
+              }
+            }
+          },
+          "icon": { "type": "string", "format": "uri" }
+        }
+      },
+      "World": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "World ID" },
+          "name": { "type": "string", "description": "World name" },
+          "population": { "type": "string", "enum": ["Low", "Medium", "High", "VeryHigh", "Full"], "description": "Current population level" }
+        }
+      },
+      "GameMap": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Map ID" },
+          "name": { "type": "string", "description": "Map name" },
+          "type": { "type": "string", "description": "Map type (e.g., Public, Instance)" },
+          "min_level": { "type": "integer", "description": "Minimum recommended level" },
+          "max_level": { "type": "integer", "description": "Maximum recommended level" },
+          "default_floor": { "type": "integer", "description": "Default floor" },
+          "floors": { "type": "array", "items": { "type": "integer" }, "description": "Available floor IDs" },
+          "region_id": { "type": "integer" },
+          "region_name": { "type": "string" },
+          "continent_id": { "type": "integer" },
+          "continent_name": { "type": "string" },
+          "map_rect": {
+            "type": "array",
+            "items": { "type": "array", "items": { "type": "number" } },
+            "description": "Map coordinate boundaries [[left,bottom],[right,top]]"
+          },
+          "continent_rect": {
+            "type": "array",
+            "items": { "type": "array", "items": { "type": "number" } },
+            "description": "Continent coordinate boundaries"
+          }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "Currency ID" },
+          "name": { "type": "string", "description": "Currency name" },
+          "description": { "type": "string", "description": "Currency description" },
+          "order": { "type": "integer", "description": "Display order" },
+          "icon": { "type": "string", "format": "uri", "description": "Currency icon URL" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/guildwars2.com/guild-wars-2/meta.json
+++ b/apis/openapi/guildwars2.com/guild-wars-2/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "196b7318c1bf833f7435c2196718c304",
+    "format": "openapi",
+    "vendor": "guildwars2.com",
+    "api_name": "guild-wars-2",
+    "friendly_id": "guildwars2.com/guild-wars-2"
+  }
+}

--- a/apis/openapi/gunpolicy.org/gun-policy/1.0.0/openapi.json
+++ b/apis/openapi/gunpolicy.org/gun-policy/1.0.0/openapi.json
@@ -1,0 +1,431 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "GunPolicy.org API",
+    "description": "The GunPolicy.org API provides access to comparative data on armed violence, firearm law, and gun control compiled by the University of Sydney. It offers data on gun-related statistics, legislation, and policy across countries and regions for research and policy analysis purposes.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "GunPolicy.org",
+      "url": "https://www.gunpolicy.org"
+    },
+    "x-jentic-source-url": "https://www.gunpolicy.org/api"
+  },
+  "servers": [
+    {
+      "url": "https://www.gunpolicy.org/api",
+      "description": "GunPolicy.org API server"
+    }
+  ],
+  "tags": [
+    { "name": "regions", "description": "Geographic regions and countries" },
+    { "name": "data", "description": "Gun policy and violence data" },
+    { "name": "glossary", "description": "Data definitions and terminology" }
+  ],
+  "paths": {
+    "/region": {
+      "get": {
+        "summary": "List regions",
+        "description": "Retrieve a list of all available geographic regions and countries for which gun policy data is available.",
+        "operationId": "listRegions",
+        "tags": ["regions"],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of regions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "regions": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Region" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/region/{region_id}": {
+      "get": {
+        "summary": "Get region details",
+        "description": "Retrieve detailed information about a specific region or country.",
+        "operationId": "getRegion",
+        "tags": ["regions"],
+        "parameters": [
+          {
+            "name": "region_id",
+            "in": "path",
+            "required": true,
+            "description": "Unique numeric identifier for the region.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with region details.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Region" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/data/{measure}": {
+      "get": {
+        "summary": "Get data by measure",
+        "description": "Retrieve statistical data for a specific measure across countries or regions. Measures include rates of gun homicide, gun suicide, gun ownership, and other firearm-related statistics.",
+        "operationId": "getDataByMeasure",
+        "tags": ["data"],
+        "parameters": [
+          {
+            "name": "measure",
+            "in": "path",
+            "required": true,
+            "description": "The data measure identifier.",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "rate_of_gun_homicide",
+                "rate_of_gun_suicide",
+                "rate_of_all_gun_deaths",
+                "rate_of_gun_deaths_unintentional",
+                "rate_of_gun_deaths_undetermined",
+                "number_of_gun_homicides",
+                "number_of_gun_suicides",
+                "number_of_all_gun_deaths",
+                "number_of_gun_deaths_unintentional",
+                "number_of_gun_deaths_undetermined",
+                "rate_of_civilian_firearm_possession",
+                "number_of_civilian_firearms",
+                "rate_of_registered_firearms",
+                "number_of_registered_firearms",
+                "rate_of_unregistered_firearms",
+                "number_of_unregistered_firearms",
+                "rate_of_total_homicide",
+                "number_of_total_homicides",
+                "gun_homicide_as_percent_of_homicide",
+                "mass_shooting_incidents",
+                "mass_shooting_deaths"
+              ]
+            }
+          },
+          {
+            "name": "region_id",
+            "in": "query",
+            "description": "Filter by specific region or country ID.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "year",
+            "in": "query",
+            "description": "Filter by specific year.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "year_from",
+            "in": "query",
+            "description": "Start of year range.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "year_to",
+            "in": "query",
+            "description": "End of year range.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with data points.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "measure": { "type": "string" },
+                    "data": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/DataPoint" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/compare/{region_ids}/{measure}": {
+      "get": {
+        "summary": "Compare regions by measure",
+        "description": "Compare firearm-related data across multiple regions for a specific measure.",
+        "operationId": "compareRegions",
+        "tags": ["data"],
+        "parameters": [
+          {
+            "name": "region_ids",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of region IDs to compare.",
+            "schema": { "type": "string" },
+            "example": "10,35,192"
+          },
+          {
+            "name": "measure",
+            "in": "path",
+            "required": true,
+            "description": "The data measure to compare.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "year_from",
+            "in": "query",
+            "description": "Start of year range.",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "year_to",
+            "in": "query",
+            "description": "End of year range.",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful comparison response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "measure": { "type": "string" },
+                    "regions": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "region": { "$ref": "#/components/schemas/Region" },
+                          "data": {
+                            "type": "array",
+                            "items": { "$ref": "#/components/schemas/DataPoint" }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/glossary": {
+      "get": {
+        "summary": "List glossary terms",
+        "description": "Retrieve definitions and explanations of data measures and terms used in the GunPolicy.org database.",
+        "operationId": "listGlossary",
+        "tags": ["glossary"],
+        "responses": {
+          "200": {
+            "description": "Successful response with glossary terms.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "terms": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/GlossaryTerm" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/measures": {
+      "get": {
+        "summary": "List available measures",
+        "description": "Retrieve a list of all available data measures that can be queried.",
+        "operationId": "listMeasures",
+        "tags": ["data"],
+        "responses": {
+          "200": {
+            "description": "Successful response with available measures.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "measures": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/Measure" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "Region": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique numeric identifier for the region."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the region or country."
+          },
+          "iso_code": {
+            "type": "string",
+            "description": "ISO 3166-1 country code, if applicable."
+          },
+          "region_type": {
+            "type": "string",
+            "description": "Type of region (e.g., country, territory, region).",
+            "enum": ["country", "territory", "region", "sub-region"]
+          },
+          "population": {
+            "type": "integer",
+            "description": "Population of the region.",
+            "nullable": true
+          },
+          "continent": {
+            "type": "string",
+            "description": "Continent the region belongs to.",
+            "nullable": true
+          }
+        }
+      },
+      "DataPoint": {
+        "type": "object",
+        "properties": {
+          "region_id": {
+            "type": "integer",
+            "description": "Region identifier."
+          },
+          "region_name": {
+            "type": "string",
+            "description": "Name of the region."
+          },
+          "year": {
+            "type": "integer",
+            "description": "Year of the data point."
+          },
+          "value": {
+            "type": "number",
+            "description": "The data value.",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "description": "Source of the data.",
+            "nullable": true
+          },
+          "note": {
+            "type": "string",
+            "description": "Additional notes about the data point.",
+            "nullable": true
+          }
+        }
+      },
+      "Measure": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique identifier for the measure."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name of the measure."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of what the measure represents."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit of measurement (e.g., 'per 100,000 population', 'count')."
+          },
+          "category": {
+            "type": "string",
+            "description": "Category the measure belongs to."
+          }
+        }
+      },
+      "GlossaryTerm": {
+        "type": "object",
+        "properties": {
+          "term": {
+            "type": "string",
+            "description": "The glossary term."
+          },
+          "definition": {
+            "type": "string",
+            "description": "Definition of the term."
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid parameters.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/gunpolicy.org/gun-policy/meta.json
+++ b/apis/openapi/gunpolicy.org/gun-policy/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "a414e2cc6689937e65628106fbb59161",
+    "format": "openapi",
+    "vendor": "gunpolicy.org",
+    "api_name": "gun-policy",
+    "friendly_id": "gunpolicy.org/gun-policy"
+  }
+}

--- a/apis/openapi/haloapi.com/halo/1.0.0/openapi.json
+++ b/apis/openapi/haloapi.com/halo/1.0.0/openapi.json
@@ -1,0 +1,1327 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Halo API",
+    "description": "The Halo API provides access to Halo 5: Guardians game data including player stats, match history, metadata, and player profiles. Note: This API has been deprecated by 343 Industries and may no longer be available.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "343 Industries",
+      "url": "https://www.halowaypoint.com"
+    },
+    "x-jentic-source-url": "https://developer.haloapi.com"
+  },
+  "externalDocs": {
+    "description": "Halo Developer Portal (archived)",
+    "url": "https://developer.haloapi.com"
+  },
+  "servers": [
+    {
+      "url": "https://www.haloapi.com",
+      "description": "Halo API production server (deprecated)"
+    }
+  ],
+  "tags": [
+    { "name": "Stats", "description": "Match and player statistics" },
+    { "name": "Metadata", "description": "Game metadata and definitions" },
+    { "name": "Profile", "description": "Player profile information" },
+    { "name": "UGC", "description": "User-generated content (map variants, game variants)" }
+  ],
+  "security": [
+    { "ApiKeyAuth": [] }
+  ],
+  "paths": {
+    "/stats/h5/matches/{matchId}": {
+      "get": {
+        "operationId": "getMatchResult",
+        "summary": "Get match result",
+        "description": "Retrieves detailed results for a specific Halo 5 match by its match ID.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "matchId",
+            "in": "path",
+            "required": true,
+            "description": "The unique match identifier (GUID)",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Match result details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/MatchResult" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/players/{player}/matches": {
+      "get": {
+        "operationId": "getPlayerMatches",
+        "summary": "Get player match history",
+        "description": "Retrieves a list of matches the specified player has participated in.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "player",
+            "in": "path",
+            "required": true,
+            "description": "The player's gamertag",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "modes",
+            "in": "query",
+            "description": "Comma-separated game modes to filter (arena, warzone, custom)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Start index for pagination (0-based)",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of results to return (max 25)",
+            "schema": { "type": "integer", "default": 25, "maximum": 25 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player match history",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerMatchHistory" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/servicerecords/arena": {
+      "get": {
+        "operationId": "getArenaServiceRecord",
+        "summary": "Get arena service record",
+        "description": "Retrieves arena service records for one or more players.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "players",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of gamertags (max 32)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "seasonId",
+            "in": "query",
+            "description": "Season GUID to filter results",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Arena service records",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ServiceRecordCollection" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/servicerecords/warzone": {
+      "get": {
+        "operationId": "getWarzoneServiceRecord",
+        "summary": "Get warzone service record",
+        "description": "Retrieves warzone service records for one or more players.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "players",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of gamertags (max 32)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Warzone service records",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ServiceRecordCollection" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/servicerecords/custom": {
+      "get": {
+        "operationId": "getCustomServiceRecord",
+        "summary": "Get custom game service record",
+        "description": "Retrieves custom game service records for one or more players.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "players",
+            "in": "query",
+            "required": true,
+            "description": "Comma-separated list of gamertags (max 32)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Custom game service records",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ServiceRecordCollection" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/companies/{companyId}": {
+      "get": {
+        "operationId": "getCompany",
+        "summary": "Get company details",
+        "description": "Retrieves information about a Spartan Company.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "companyId",
+            "in": "path",
+            "required": true,
+            "description": "The company GUID",
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Company details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Company" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/stats/h5/player-leaderboards/csr/{seasonId}/{playlistId}": {
+      "get": {
+        "operationId": "getLeaderboard",
+        "summary": "Get player leaderboard",
+        "description": "Retrieves the leaderboard for a specific season and playlist.",
+        "tags": ["Stats"],
+        "parameters": [
+          {
+            "name": "seasonId",
+            "in": "path",
+            "required": true,
+            "description": "The season GUID",
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "playlistId",
+            "in": "path",
+            "required": true,
+            "description": "The playlist GUID",
+            "schema": { "type": "string", "format": "uuid" }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of results to return (max 250)",
+            "schema": { "type": "integer", "default": 200, "maximum": 250 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard results",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Leaderboard" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/game-base-variants": {
+      "get": {
+        "operationId": "getGameBaseVariants",
+        "summary": "List game base variants",
+        "description": "Returns a list of base game variant definitions (e.g., Slayer, CTF, Strongholds).",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of game base variants",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/GameBaseVariant" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/maps": {
+      "get": {
+        "operationId": "getMaps",
+        "summary": "List maps",
+        "description": "Returns a list of map definitions available in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of maps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Map" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/playlists": {
+      "get": {
+        "operationId": "getPlaylists",
+        "summary": "List playlists",
+        "description": "Returns a list of active playlists in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of playlists",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Playlist" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/seasons": {
+      "get": {
+        "operationId": "getSeasons",
+        "summary": "List seasons",
+        "description": "Returns a list of competitive seasons in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of seasons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Season" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/weapons": {
+      "get": {
+        "operationId": "getWeapons",
+        "summary": "List weapons",
+        "description": "Returns a list of weapon definitions in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of weapons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Weapon" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/medals": {
+      "get": {
+        "operationId": "getMedals",
+        "summary": "List medals",
+        "description": "Returns a list of medal definitions in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of medals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Medal" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/commendations": {
+      "get": {
+        "operationId": "getCommendations",
+        "summary": "List commendations",
+        "description": "Returns a list of commendation definitions in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of commendations",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Commendation" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/spartan-ranks": {
+      "get": {
+        "operationId": "getSpartanRanks",
+        "summary": "List Spartan ranks",
+        "description": "Returns a list of Spartan rank definitions with XP requirements.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of Spartan ranks",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/SpartanRank" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/team-colors": {
+      "get": {
+        "operationId": "getTeamColors",
+        "summary": "List team colors",
+        "description": "Returns a list of team color definitions used in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of team colors",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/TeamColor" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/vehicles": {
+      "get": {
+        "operationId": "getVehicles",
+        "summary": "List vehicles",
+        "description": "Returns a list of vehicle definitions in Halo 5.",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of vehicles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Vehicle" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/metadata/h5/metadata/enemies": {
+      "get": {
+        "operationId": "getEnemies",
+        "summary": "List enemies",
+        "description": "Returns a list of enemy definitions in Halo 5 (Warzone AI).",
+        "tags": ["Metadata"],
+        "responses": {
+          "200": {
+            "description": "List of enemies",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Enemy" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/profile/h5/profiles/{player}/appearance": {
+      "get": {
+        "operationId": "getPlayerAppearance",
+        "summary": "Get player appearance",
+        "description": "Returns the player's Spartan appearance image.",
+        "tags": ["Profile"],
+        "parameters": [
+          {
+            "name": "player",
+            "in": "path",
+            "required": true,
+            "description": "The player's gamertag",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Image size (95, 128, 190, 256, 512)",
+            "schema": { "type": "integer", "enum": [95, 128, 190, 256, 512] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player Spartan appearance image",
+            "content": {
+              "image/png": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/profile/h5/profiles/{player}/emblem": {
+      "get": {
+        "operationId": "getPlayerEmblem",
+        "summary": "Get player emblem",
+        "description": "Returns the player's emblem image.",
+        "tags": ["Profile"],
+        "parameters": [
+          {
+            "name": "player",
+            "in": "path",
+            "required": true,
+            "description": "The player's gamertag",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "Image size (95, 128, 190, 256, 512)",
+            "schema": { "type": "integer", "enum": [95, 128, 190, 256, 512] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player emblem image",
+            "content": {
+              "image/png": {
+                "schema": { "type": "string", "format": "binary" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/ugc/h5/players/{player}/mapvariants": {
+      "get": {
+        "operationId": "getPlayerMapVariants",
+        "summary": "List player map variants",
+        "description": "Returns a list of map variants created by the specified player.",
+        "tags": ["UGC"],
+        "parameters": [
+          {
+            "name": "player",
+            "in": "path",
+            "required": true,
+            "description": "The player's gamertag",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Start index for pagination",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of results (max 100)",
+            "schema": { "type": "integer", "default": 100, "maximum": 100 }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort order",
+            "schema": { "type": "integer", "enum": [1, 2, 3] }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort direction",
+            "schema": { "type": "integer", "enum": [1, 2] }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of map variants",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UgcResultSet" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/ugc/h5/players/{player}/gamevariants": {
+      "get": {
+        "operationId": "getPlayerGameVariants",
+        "summary": "List player game variants",
+        "description": "Returns a list of game variants created by the specified player.",
+        "tags": ["UGC"],
+        "parameters": [
+          {
+            "name": "player",
+            "in": "path",
+            "required": true,
+            "description": "The player's gamertag",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Start index for pagination",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "description": "Number of results (max 100)",
+            "schema": { "type": "integer", "default": 100, "maximum": 100 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of game variants",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UgcResultSet" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "429": { "$ref": "#/components/responses/RateLimited" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Ocp-Apim-Subscription-Key",
+        "description": "Azure API Management subscription key for the Halo API"
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Missing or invalid API subscription key.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource was not found.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Rate limit exceeded. Retry after the duration specified in the Retry-After header.",
+        "headers": {
+          "Retry-After": {
+            "description": "Number of seconds to wait before retrying",
+            "schema": { "type": "integer" }
+          }
+        },
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "statusCode": { "type": "integer", "description": "HTTP status code" },
+          "message": { "type": "string", "description": "Error message" }
+        }
+      },
+      "MatchResult": {
+        "type": "object",
+        "properties": {
+          "IsMatchOver": { "type": "boolean", "description": "Whether the match has completed" },
+          "TotalDuration": { "type": "string", "description": "ISO 8601 duration of the match" },
+          "MapVariantId": { "type": "string", "format": "uuid", "description": "Map variant GUID" },
+          "GameBaseVariantId": { "type": "string", "format": "uuid", "description": "Base game variant GUID" },
+          "PlaylistId": { "type": "string", "format": "uuid", "description": "Playlist GUID" },
+          "MapId": { "type": "string", "format": "uuid", "description": "Map GUID" },
+          "IsTeamGame": { "type": "boolean" },
+          "PlayerStats": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/PlayerStat" }
+          },
+          "TeamStats": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TeamStat" }
+          }
+        }
+      },
+      "PlayerStat": {
+        "type": "object",
+        "properties": {
+          "Player": {
+            "type": "object",
+            "properties": {
+              "Gamertag": { "type": "string" },
+              "Xuid": { "type": "string" }
+            }
+          },
+          "TeamId": { "type": "integer" },
+          "Rank": { "type": "integer" },
+          "DNF": { "type": "boolean", "description": "Did not finish" },
+          "TotalKills": { "type": "integer" },
+          "TotalDeaths": { "type": "integer" },
+          "TotalAssists": { "type": "integer" },
+          "TotalHeadshots": { "type": "integer" },
+          "TotalShotsFired": { "type": "integer" },
+          "TotalShotsLanded": { "type": "integer" },
+          "TotalMeleeKills": { "type": "integer" },
+          "TotalGrenadeDamage": { "type": "number", "format": "double" },
+          "TotalGroundPoundKills": { "type": "integer" },
+          "TotalPowerWeaponKills": { "type": "integer" },
+          "WeaponStats": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/WeaponStat" }
+          },
+          "MedalAwards": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "MedalId": { "type": "integer" },
+                "Count": { "type": "integer" }
+              }
+            }
+          }
+        }
+      },
+      "TeamStat": {
+        "type": "object",
+        "properties": {
+          "TeamId": { "type": "integer" },
+          "Score": { "type": "integer" },
+          "Rank": { "type": "integer" },
+          "RoundStats": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "RoundNumber": { "type": "integer" },
+                "Rank": { "type": "integer" },
+                "Score": { "type": "integer" }
+              }
+            }
+          }
+        }
+      },
+      "WeaponStat": {
+        "type": "object",
+        "properties": {
+          "WeaponId": {
+            "type": "object",
+            "properties": {
+              "StockId": { "type": "integer" },
+              "Attachments": { "type": "array", "items": { "type": "integer" } }
+            }
+          },
+          "TotalShotsFired": { "type": "integer" },
+          "TotalShotsLanded": { "type": "integer" },
+          "TotalHeadshots": { "type": "integer" },
+          "TotalKills": { "type": "integer" },
+          "TotalDamageDealt": { "type": "number", "format": "double" },
+          "TotalPossessionTime": { "type": "string", "description": "ISO 8601 duration" }
+        }
+      },
+      "PlayerMatchHistory": {
+        "type": "object",
+        "properties": {
+          "Start": { "type": "integer", "description": "Start index" },
+          "Count": { "type": "integer", "description": "Number of results returned" },
+          "ResultCount": { "type": "integer", "description": "Total results available" },
+          "Results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Id": {
+                  "type": "object",
+                  "properties": {
+                    "MatchId": { "type": "string", "format": "uuid" },
+                    "GameMode": { "type": "integer", "description": "1=Arena, 2=Campaign, 3=Custom, 4=Warzone" }
+                  }
+                },
+                "HopperId": { "type": "string", "format": "uuid" },
+                "MapId": { "type": "string", "format": "uuid" },
+                "MapVariant": {
+                  "type": "object",
+                  "properties": {
+                    "ResourceType": { "type": "integer" },
+                    "ResourceId": { "type": "string", "format": "uuid" },
+                    "OwnerType": { "type": "integer" },
+                    "Owner": { "type": "string" }
+                  }
+                },
+                "GameBaseVariantId": { "type": "string", "format": "uuid" },
+                "MatchDuration": { "type": "string", "description": "ISO 8601 duration" },
+                "MatchCompletedDate": {
+                  "type": "object",
+                  "properties": {
+                    "ISO8601Date": { "type": "string", "format": "date-time" }
+                  }
+                },
+                "Teams": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Id": { "type": "integer" },
+                      "Score": { "type": "integer" },
+                      "Rank": { "type": "integer" }
+                    }
+                  }
+                },
+                "Players": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "Player": {
+                        "type": "object",
+                        "properties": {
+                          "Gamertag": { "type": "string" },
+                          "Xuid": { "type": "string" }
+                        }
+                      },
+                      "TeamId": { "type": "integer" },
+                      "Rank": { "type": "integer" },
+                      "Result": { "type": "integer", "description": "0=Did Not Finish, 1=Lost, 2=Tied, 3=Won" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ServiceRecordCollection": {
+        "type": "object",
+        "properties": {
+          "Results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Id": { "type": "string", "description": "Player gamertag" },
+                "ResultCode": { "type": "integer", "description": "0=Success, 1=NotFound, 2=ServiceFailure" },
+                "Result": { "$ref": "#/components/schemas/ServiceRecord" }
+              }
+            }
+          }
+        }
+      },
+      "ServiceRecord": {
+        "type": "object",
+        "properties": {
+          "PlayerId": {
+            "type": "object",
+            "properties": {
+              "Gamertag": { "type": "string" },
+              "Xuid": { "type": "string" }
+            }
+          },
+          "SpartanRank": { "type": "integer" },
+          "Xp": { "type": "integer" },
+          "ArenaStats": {
+            "type": "object",
+            "properties": {
+              "TotalKills": { "type": "integer" },
+              "TotalDeaths": { "type": "integer" },
+              "TotalAssists": { "type": "integer" },
+              "TotalGamesCompleted": { "type": "integer" },
+              "TotalGamesWon": { "type": "integer" },
+              "TotalGamesLost": { "type": "integer" },
+              "TotalGamesTied": { "type": "integer" },
+              "TotalTimePlayed": { "type": "string", "description": "ISO 8601 duration" },
+              "HighestCsrAttained": { "$ref": "#/components/schemas/Csr" }
+            }
+          },
+          "WarzoneStats": {
+            "type": "object",
+            "properties": {
+              "TotalKills": { "type": "integer" },
+              "TotalDeaths": { "type": "integer" },
+              "TotalAssists": { "type": "integer" },
+              "TotalGamesCompleted": { "type": "integer" },
+              "TotalGamesWon": { "type": "integer" },
+              "TotalGamesLost": { "type": "integer" }
+            }
+          },
+          "CustomStats": {
+            "type": "object",
+            "properties": {
+              "TotalKills": { "type": "integer" },
+              "TotalDeaths": { "type": "integer" },
+              "TotalAssists": { "type": "integer" },
+              "TotalGamesCompleted": { "type": "integer" },
+              "TotalGamesWon": { "type": "integer" },
+              "TotalGamesLost": { "type": "integer" }
+            }
+          }
+        }
+      },
+      "Csr": {
+        "type": "object",
+        "description": "Competitive Skill Rank",
+        "properties": {
+          "Tier": { "type": "integer" },
+          "DesignationId": { "type": "integer", "description": "CSR designation (e.g., 1=Bronze, 6=Champion)" },
+          "Csr": { "type": "integer" },
+          "PercentToNextTier": { "type": "integer" },
+          "Rank": { "type": "integer", "description": "Only populated for Champion rank" }
+        }
+      },
+      "Company": {
+        "type": "object",
+        "properties": {
+          "Id": { "type": "string", "format": "uuid" },
+          "Name": { "type": "string" },
+          "Members": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Identity": { "type": "string" },
+                "Gamertag": { "type": "string" },
+                "Rank": { "type": "integer" },
+                "LastLoginTime": {
+                  "type": "object",
+                  "properties": {
+                    "ISO8601Date": { "type": "string", "format": "date-time" }
+                  }
+                }
+              }
+            }
+          },
+          "Creator": {
+            "type": "object",
+            "properties": {
+              "Identity": { "type": "string" },
+              "Gamertag": { "type": "string" }
+            }
+          },
+          "CreatedDate": {
+            "type": "object",
+            "properties": {
+              "ISO8601Date": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      },
+      "Leaderboard": {
+        "type": "object",
+        "properties": {
+          "Start": { "type": "integer" },
+          "Count": { "type": "integer" },
+          "ResultCount": { "type": "integer" },
+          "Results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Player": {
+                  "type": "object",
+                  "properties": {
+                    "Gamertag": { "type": "string" },
+                    "Xuid": { "type": "string" }
+                  }
+                },
+                "Rank": { "type": "integer" },
+                "Score": {
+                  "type": "object",
+                  "properties": {
+                    "Tier": { "type": "integer" },
+                    "DesignationId": { "type": "integer" },
+                    "Csr": { "type": "integer" },
+                    "PercentToNextTier": { "type": "integer" },
+                    "Rank": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "GameBaseVariant": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "Display name" },
+          "internalName": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "iconUrl": { "type": "string", "format": "uri", "description": "Icon image URL" },
+          "supportedGameModes": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "List of supported game modes (e.g., Arena, Warzone)"
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Map": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string", "description": "Map display name" },
+          "description": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "imageUrl": { "type": "string", "format": "uri" },
+          "supportedGameModes": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Playlist": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "isRanked": { "type": "boolean" },
+          "imageUrl": { "type": "string", "format": "uri" },
+          "gameMode": { "type": "string" },
+          "isActive": { "type": "boolean" },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Season": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "format": "uuid" },
+          "name": { "type": "string" },
+          "startDate": {
+            "type": "object",
+            "properties": {
+              "ISO8601Date": { "type": "string", "format": "date-time" }
+            }
+          },
+          "endDate": {
+            "type": "object",
+            "properties": {
+              "ISO8601Date": { "type": "string", "format": "date-time" }
+            }
+          },
+          "isActive": { "type": "boolean" },
+          "playlists": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string", "format": "uuid" },
+                "name": { "type": "string" }
+              }
+            }
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Weapon": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "integer" },
+          "type": { "type": "string", "description": "Weapon category" },
+          "largeIconImageUrl": { "type": "string", "format": "uri" },
+          "smallIconImageUrl": { "type": "string", "format": "uri" },
+          "isUsableByPlayer": { "type": "boolean" },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Medal": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "integer" },
+          "classification": { "type": "string", "description": "Medal classification (e.g., KillingSpree, MultiKill, Style)" },
+          "difficulty": { "type": "integer", "description": "Difficulty rating" },
+          "spriteLocation": {
+            "type": "object",
+            "properties": {
+              "spriteSheetUri": { "type": "string", "format": "uri" },
+              "left": { "type": "integer" },
+              "top": { "type": "integer" },
+              "width": { "type": "integer" },
+              "height": { "type": "integer" },
+              "spriteWidth": { "type": "integer" },
+              "spriteHeight": { "type": "integer" }
+            }
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Commendation": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "string", "format": "uuid" },
+          "type": { "type": "string" },
+          "levels": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "threshold": { "type": "integer" },
+                "reward": {
+                  "type": "object",
+                  "properties": {
+                    "xp": { "type": "integer" },
+                    "requisitionPacks": { "type": "array", "items": { "type": "object" } }
+                  }
+                }
+              }
+            }
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "SpartanRank": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "startXp": { "type": "integer", "description": "XP required to reach this rank" },
+          "reward": {
+            "type": "object",
+            "properties": {
+              "xp": { "type": "integer" },
+              "requisitionPacks": { "type": "array", "items": { "type": "object" } }
+            }
+          },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "TeamColor": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "integer" },
+          "color": { "type": "string", "description": "Hex color code (e.g., #FF0000)" },
+          "iconUrl": { "type": "string", "format": "uri" },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Vehicle": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "integer" },
+          "largeIconImageUrl": { "type": "string", "format": "uri" },
+          "smallIconImageUrl": { "type": "string", "format": "uri" },
+          "isUsableByPlayer": { "type": "boolean" },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "Enemy": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "id": { "type": "integer" },
+          "faction": { "type": "string" },
+          "largeIconImageUrl": { "type": "string", "format": "uri" },
+          "smallIconImageUrl": { "type": "string", "format": "uri" },
+          "contentId": { "type": "string", "format": "uuid" }
+        }
+      },
+      "UgcResultSet": {
+        "type": "object",
+        "properties": {
+          "Start": { "type": "integer" },
+          "Count": { "type": "integer" },
+          "ResultCount": { "type": "integer" },
+          "Results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "Name": { "type": "string" },
+                "Description": { "type": "string" },
+                "Identity": {
+                  "type": "object",
+                  "properties": {
+                    "ResourceType": { "type": "integer" },
+                    "ResourceId": { "type": "string", "format": "uuid" },
+                    "OwnerType": { "type": "integer" },
+                    "Owner": { "type": "string" }
+                  }
+                },
+                "AccessControl": { "type": "integer" },
+                "CreatedTimeUtc": {
+                  "type": "object",
+                  "properties": {
+                    "ISO8601Date": { "type": "string", "format": "date-time" }
+                  }
+                },
+                "ModifiedTimeUtc": {
+                  "type": "object",
+                  "properties": {
+                    "ISO8601Date": { "type": "string", "format": "date-time" }
+                  }
+                },
+                "Stats": {
+                  "type": "object",
+                  "properties": {
+                    "BookmarkCount": { "type": "integer" },
+                    "HasCallerBookmarked": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/haloapi.com/halo/meta.json
+++ b/apis/openapi/haloapi.com/halo/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "9123346c7bd58c3523c007ff6604db4a",
+    "format": "openapi",
+    "vendor": "haloapi.com",
+    "api_name": "halo",
+    "friendly_id": "haloapi.com/halo"
+  }
+}

--- a/apis/openapi/hearthstoneapi.com/hearthstone/1.0.0/openapi.json
+++ b/apis/openapi/hearthstoneapi.com/hearthstone/1.0.0/openapi.json
@@ -1,0 +1,1021 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Hearthstone API",
+    "description": "API for retrieving Hearthstone card data including cards, card backs, and game metadata. Provides access to cards by name, class, set, race, quality, type, faction, and search.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Hearthstone API",
+      "url": "http://hearthstoneapi.com/"
+    },
+    "x-jentic-source-url": "http://hearthstoneapi.com/"
+  },
+  "servers": [
+    {
+      "url": "https://omgvamp-hearthstone-v1.p.rapidapi.com",
+      "description": "RapidAPI production server"
+    }
+  ],
+  "security": [
+    {
+      "RapidAPIKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Cards",
+      "description": "Endpoints for retrieving card data"
+    },
+    {
+      "name": "Card Backs",
+      "description": "Endpoints for retrieving card back data"
+    },
+    {
+      "name": "Info",
+      "description": "Endpoints for retrieving game metadata"
+    }
+  ],
+  "paths": {
+    "/cards": {
+      "get": {
+        "operationId": "getAllCards",
+        "summary": "Get all cards",
+        "description": "Returns a list of all Hearthstone cards, optionally filtered by query parameters.",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/durability"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/Card"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/{name}": {
+      "get": {
+        "operationId": "getCardByName",
+        "summary": "Get card by name",
+        "description": "Returns card data for the specified card name.",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The exact name of the card.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/classes/{class}": {
+      "get": {
+        "operationId": "getCardsByClass",
+        "summary": "Get cards by class",
+        "description": "Returns all cards belonging to a specific class (e.g., Mage, Warrior, Paladin).",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "class",
+            "in": "path",
+            "required": true,
+            "description": "The card class (e.g., Mage, Warrior, Paladin, Druid, Hunter, Priest, Rogue, Shaman, Warlock, Neutral, Death Knight, Demon Hunter).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/durability"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/sets/{set}": {
+      "get": {
+        "operationId": "getCardsBySet",
+        "summary": "Get cards by set",
+        "description": "Returns all cards belonging to a specific card set.",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "set",
+            "in": "path",
+            "required": true,
+            "description": "The card set name (e.g., Classic, Basic, Naxxramas, Goblins vs Gnomes).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/durability"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/races/{race}": {
+      "get": {
+        "operationId": "getCardsByRace",
+        "summary": "Get cards by race",
+        "description": "Returns all cards belonging to a specific race (e.g., Murloc, Demon, Beast, Dragon, Mech, Pirate, Totem, Elemental).",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "race",
+            "in": "path",
+            "required": true,
+            "description": "The card race (e.g., Murloc, Demon, Beast, Dragon, Mech, Pirate, Totem, Elemental).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/qualities/{quality}": {
+      "get": {
+        "operationId": "getCardsByQuality",
+        "summary": "Get cards by quality",
+        "description": "Returns all cards of a specific quality/rarity (e.g., Free, Common, Rare, Epic, Legendary).",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "quality",
+            "in": "path",
+            "required": true,
+            "description": "The card quality/rarity (e.g., Free, Common, Rare, Epic, Legendary).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/durability"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/types/{type}": {
+      "get": {
+        "operationId": "getCardsByType",
+        "summary": "Get cards by type",
+        "description": "Returns all cards of a specific type (e.g., Minion, Spell, Weapon, Hero, Hero Power).",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "type",
+            "in": "path",
+            "required": true,
+            "description": "The card type (e.g., Minion, Spell, Weapon, Hero, Hero Power).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/durability"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/factions/{faction}": {
+      "get": {
+        "operationId": "getCardsByFaction",
+        "summary": "Get cards by faction",
+        "description": "Returns all cards belonging to a specific faction (e.g., Horde, Alliance, Neutral).",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "faction",
+            "in": "path",
+            "required": true,
+            "description": "The card faction (e.g., Horde, Alliance, Neutral).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          },
+          {
+            "$ref": "#/components/parameters/attack"
+          },
+          {
+            "$ref": "#/components/parameters/health"
+          },
+          {
+            "$ref": "#/components/parameters/cost"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cards/search/{name}": {
+      "get": {
+        "operationId": "searchCards",
+        "summary": "Search cards by partial name",
+        "description": "Search for cards by partial name match.",
+        "tags": ["Cards"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The partial card name to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "$ref": "#/components/parameters/locale"
+          },
+          {
+            "$ref": "#/components/parameters/collectible"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with matching cards",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Card"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/info": {
+      "get": {
+        "operationId": "getInfo",
+        "summary": "Get game metadata",
+        "description": "Returns information about Hearthstone game data including patch, classes, sets, types, factions, qualities, races, and locales.",
+        "tags": ["Info"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response with game metadata",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Info"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/cardbacks": {
+      "get": {
+        "operationId": "getCardBacks",
+        "summary": "Get all card backs",
+        "description": "Returns a list of all Hearthstone card backs.",
+        "tags": ["Card Backs"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/locale"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with card back data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CardBack"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "RapidAPIKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-RapidAPI-Key",
+        "description": "RapidAPI key for authentication."
+      }
+    },
+    "parameters": {
+      "locale": {
+        "name": "locale",
+        "in": "query",
+        "required": false,
+        "description": "Locale for the response (e.g., enUS, enGB, deDE, esES, esMX, frFR, itIT, koKR, plPL, ptBR, ruRU, zhCN, zhTW, jaJP, thTH).",
+        "schema": {
+          "type": "string",
+          "default": "enUS"
+        }
+      },
+      "collectible": {
+        "name": "collectible",
+        "in": "query",
+        "required": false,
+        "description": "Set to 1 to only return collectible cards.",
+        "schema": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      },
+      "attack": {
+        "name": "attack",
+        "in": "query",
+        "required": false,
+        "description": "Filter by attack value.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "durability": {
+        "name": "durability",
+        "in": "query",
+        "required": false,
+        "description": "Filter by durability value (weapons only).",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "health": {
+        "name": "health",
+        "in": "query",
+        "required": false,
+        "description": "Filter by health value.",
+        "schema": {
+          "type": "integer"
+        }
+      },
+      "cost": {
+        "name": "cost",
+        "in": "query",
+        "required": false,
+        "description": "Filter by mana cost.",
+        "schema": {
+          "type": "integer"
+        }
+      }
+    },
+    "schemas": {
+      "Card": {
+        "type": "object",
+        "properties": {
+          "cardId": {
+            "type": "string",
+            "description": "Unique card identifier."
+          },
+          "dbfId": {
+            "type": "integer",
+            "description": "Database field ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Card name."
+          },
+          "cardSet": {
+            "type": "string",
+            "description": "The set this card belongs to."
+          },
+          "type": {
+            "type": "string",
+            "description": "Card type (e.g., Minion, Spell, Weapon)."
+          },
+          "faction": {
+            "type": "string",
+            "description": "Card faction (e.g., Horde, Alliance, Neutral)."
+          },
+          "rarity": {
+            "type": "string",
+            "description": "Card rarity (e.g., Free, Common, Rare, Epic, Legendary)."
+          },
+          "cost": {
+            "type": "integer",
+            "description": "Mana cost of the card."
+          },
+          "attack": {
+            "type": "integer",
+            "description": "Attack value."
+          },
+          "health": {
+            "type": "integer",
+            "description": "Health value."
+          },
+          "durability": {
+            "type": "integer",
+            "description": "Durability value (weapons only)."
+          },
+          "text": {
+            "type": "string",
+            "description": "Card text/description."
+          },
+          "flavor": {
+            "type": "string",
+            "description": "Flavor text."
+          },
+          "artist": {
+            "type": "string",
+            "description": "Card artist name."
+          },
+          "collectible": {
+            "type": "boolean",
+            "description": "Whether the card is collectible."
+          },
+          "elite": {
+            "type": "boolean",
+            "description": "Whether the card is elite/legendary."
+          },
+          "race": {
+            "type": "string",
+            "description": "Card race (e.g., Murloc, Demon, Beast)."
+          },
+          "playerClass": {
+            "type": "string",
+            "description": "The class this card belongs to."
+          },
+          "img": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the card image."
+          },
+          "imgGold": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the golden card image."
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the card data."
+          },
+          "mechanics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Card mechanics (e.g., Taunt, Battlecry)."
+          }
+        }
+      },
+      "CardBack": {
+        "type": "object",
+        "properties": {
+          "cardBackId": {
+            "type": "integer",
+            "description": "Unique card back identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Card back name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Card back description."
+          },
+          "source": {
+            "type": "string",
+            "description": "How to obtain this card back."
+          },
+          "sourceDescription": {
+            "type": "string",
+            "description": "Detailed description of how to obtain."
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the card back is currently enabled."
+          },
+          "img": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the card back image."
+          },
+          "imgAnimated": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the animated card back image."
+          },
+          "sortCategory": {
+            "type": "integer",
+            "description": "Sort category."
+          },
+          "sortOrder": {
+            "type": "integer",
+            "description": "Sort order."
+          },
+          "locale": {
+            "type": "string",
+            "description": "Locale of the data."
+          }
+        }
+      },
+      "Info": {
+        "type": "object",
+        "properties": {
+          "patch": {
+            "type": "string",
+            "description": "Current game patch version."
+          },
+          "classes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all classes."
+          },
+          "sets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all card sets."
+          },
+          "types": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all card types."
+          },
+          "factions": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all factions."
+          },
+          "qualities": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all card qualities/rarities."
+          },
+          "races": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all card races."
+          },
+          "locales": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "List of all supported locales."
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "integer",
+            "description": "Error code."
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message."
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden - invalid or missing API key.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Not found - no results for the given query.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Too many requests - rate limit exceeded.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/hearthstoneapi.com/hearthstone/meta.json
+++ b/apis/openapi/hearthstoneapi.com/hearthstone/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "d3917e5d8ff7db215fd466c98186b119",
+    "format": "openapi",
+    "vendor": "hearthstoneapi.com",
+    "api_name": "hearthstone",
+    "friendly_id": "hearthstoneapi.com/hearthstone"
+  }
+}

--- a/apis/openapi/here.com/here-maps/1.0.0/openapi.json
+++ b/apis/openapi/here.com/here-maps/1.0.0/openapi.json
@@ -1,0 +1,601 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "HERE Geocoding & Search API",
+    "description": "HERE Geocoding & Search API provides endpoints for geocoding addresses, reverse geocoding coordinates, discovering places, and searching for locations. Part of the HERE Maps platform for digital mapping and location services.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "HERE Technologies",
+      "url": "https://developer.here.com"
+    },
+    "x-jentic-source-url": "https://developer.here.com"
+  },
+  "servers": [
+    {
+      "url": "https://geocode.search.hereapi.com/v1",
+      "description": "Geocoding & Search API"
+    },
+    {
+      "url": "https://revgeocode.search.hereapi.com/v1",
+      "description": "Reverse Geocoding API"
+    },
+    {
+      "url": "https://autosuggest.search.hereapi.com/v1",
+      "description": "Autosuggest API"
+    },
+    {
+      "url": "https://browse.search.hereapi.com/v1",
+      "description": "Browse API"
+    },
+    {
+      "url": "https://lookup.search.hereapi.com/v1",
+      "description": "Lookup API"
+    },
+    {
+      "url": "https://discover.search.hereapi.com/v1",
+      "description": "Discover API"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocode",
+      "description": "Forward geocoding - convert addresses to coordinates"
+    },
+    {
+      "name": "Reverse Geocode",
+      "description": "Reverse geocoding - convert coordinates to addresses"
+    },
+    {
+      "name": "Autosuggest",
+      "description": "Search suggestions as you type"
+    },
+    {
+      "name": "Discover",
+      "description": "Free-form search for places and addresses"
+    },
+    {
+      "name": "Browse",
+      "description": "Browse places by category around a location"
+    },
+    {
+      "name": "Lookup",
+      "description": "Look up a place by its HERE ID"
+    }
+  ],
+  "paths": {
+    "/geocode": {
+      "get": {
+        "tags": ["Geocode"],
+        "summary": "Geocode an address",
+        "description": "Converts a free-text address into geographic coordinates and a complete address object.",
+        "operationId": "geocode",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text query for the address to geocode",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "qq",
+            "in": "query",
+            "description": "Qualified query with structured address components (e.g., city=Berlin;country=Germany)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "description": "Search within a geographic area (circle, bbox, or countryCode)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "description": "Center of search context as lat,lng",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results",
+            "schema": { "type": "integer", "default": 20, "maximum": 100 }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language for result text and address formatting (BCP 47)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid API key"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/revgeocode": {
+      "get": {
+        "tags": ["Reverse Geocode"],
+        "summary": "Reverse geocode coordinates",
+        "description": "Converts geographic coordinates into the nearest address.",
+        "operationId": "reverseGeocode",
+        "parameters": [
+          {
+            "name": "at",
+            "in": "query",
+            "required": true,
+            "description": "Location as lat,lng",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "description": "Search within a geographic area",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results",
+            "schema": { "type": "integer", "default": 1, "maximum": 100 }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Language for result text (BCP 47)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Filter by result type (e.g., address, street, city)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/autosuggest": {
+      "get": {
+        "tags": ["Autosuggest"],
+        "summary": "Get search suggestions",
+        "description": "Provides search suggestions as the user types. Returns a mix of places, addresses, and query completions.",
+        "operationId": "autosuggest",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Partial search query text",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "required": true,
+            "description": "Center of search context as lat,lng",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "description": "Search within a geographic area",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results",
+            "schema": { "type": "integer", "default": 20, "maximum": 100 }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "termsLimit",
+            "in": "query",
+            "description": "Maximum number of query term suggestions",
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful autosuggest response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AutosuggestResponse" }
+              }
+            }
+          },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/discover": {
+      "get": {
+        "tags": ["Discover"],
+        "summary": "Search for places",
+        "description": "Free-form search for places, addresses, and geographic features.",
+        "operationId": "discover",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-text search query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "at",
+            "in": "query",
+            "description": "Center of search context as lat,lng",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "description": "Search within a geographic area",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20, "maximum": 100 }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/browse": {
+      "get": {
+        "tags": ["Browse"],
+        "summary": "Browse places by category",
+        "description": "Browse places by category around a specified location.",
+        "operationId": "browse",
+        "parameters": [
+          {
+            "name": "at",
+            "in": "query",
+            "required": true,
+            "description": "Center of search as lat,lng",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "categories",
+            "in": "query",
+            "description": "Comma-separated list of category IDs to filter by",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "in",
+            "in": "query",
+            "description": "Search within a geographic area",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "name",
+            "in": "query",
+            "description": "Filter by place name",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 20, "maximum": 100 }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful browse response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+              }
+            }
+          },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/lookup": {
+      "get": {
+        "tags": ["Lookup"],
+        "summary": "Lookup a place by ID",
+        "description": "Look up a place by its HERE ID to get full details.",
+        "operationId": "lookup",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "description": "HERE place ID",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful lookup response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Place" }
+              }
+            }
+          },
+          "404": {
+            "description": "Place not found"
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apiKey",
+        "description": "HERE API key obtained from the HERE Developer portal"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "OAuth 2.0 bearer token"
+      }
+    },
+    "schemas": {
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Place" }
+          }
+        }
+      },
+      "AutosuggestResponse": {
+        "type": "object",
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AutosuggestItem" }
+          },
+          "queryTerms": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "term": { "type": "string" },
+                "replaces": { "type": "string" },
+                "start": { "type": "integer" },
+                "end": { "type": "integer" }
+              }
+            }
+          }
+        }
+      },
+      "AutosuggestItem": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string", "description": "Display title" },
+          "id": { "type": "string", "description": "HERE place ID" },
+          "resultType": { "type": "string", "description": "Type of result" },
+          "address": { "$ref": "#/components/schemas/Address" },
+          "position": { "$ref": "#/components/schemas/Position" },
+          "distance": { "type": "integer", "description": "Distance in meters from search center" },
+          "highlights": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "start": { "type": "integer" },
+                    "end": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Place": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string", "description": "Display title for the result" },
+          "id": { "type": "string", "description": "Unique HERE place ID" },
+          "resultType": {
+            "type": "string",
+            "description": "Type of result",
+            "enum": ["houseNumber", "addressBlock", "street", "intersection", "administrativeArea", "locality", "place", "chainQuery", "categoryQuery"]
+          },
+          "houseNumberType": { "type": "string", "enum": ["PA", "interpolated"] },
+          "address": { "$ref": "#/components/schemas/Address" },
+          "position": { "$ref": "#/components/schemas/Position" },
+          "access": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Position" },
+            "description": "Access points for navigation"
+          },
+          "distance": { "type": "integer", "description": "Distance in meters" },
+          "mapView": { "$ref": "#/components/schemas/MapView" },
+          "categories": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Category" }
+          },
+          "contacts": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Contact" }
+          },
+          "openingHours": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "text": { "type": "array", "items": { "type": "string" } },
+                "isOpen": { "type": "boolean" }
+              }
+            }
+          },
+          "scoring": {
+            "type": "object",
+            "properties": {
+              "queryScore": { "type": "number" },
+              "fieldScore": {
+                "type": "object",
+                "properties": {
+                  "country": { "type": "number" },
+                  "city": { "type": "number" },
+                  "streets": { "type": "array", "items": { "type": "number" } },
+                  "houseNumber": { "type": "number" },
+                  "postalCode": { "type": "number" }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "label": { "type": "string", "description": "Full formatted address" },
+          "countryCode": { "type": "string" },
+          "countryName": { "type": "string" },
+          "stateCode": { "type": "string" },
+          "state": { "type": "string" },
+          "county": { "type": "string" },
+          "city": { "type": "string" },
+          "district": { "type": "string" },
+          "street": { "type": "string" },
+          "houseNumber": { "type": "string" },
+          "postalCode": { "type": "string" }
+        }
+      },
+      "Position": {
+        "type": "object",
+        "properties": {
+          "lat": { "type": "number", "format": "double", "description": "Latitude" },
+          "lng": { "type": "number", "format": "double", "description": "Longitude" }
+        }
+      },
+      "MapView": {
+        "type": "object",
+        "properties": {
+          "west": { "type": "number", "format": "double" },
+          "south": { "type": "number", "format": "double" },
+          "east": { "type": "number", "format": "double" },
+          "north": { "type": "number", "format": "double" }
+        }
+      },
+      "Category": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "primary": { "type": "boolean" }
+        }
+      },
+      "Contact": {
+        "type": "object",
+        "properties": {
+          "phone": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" }
+              }
+            }
+          },
+          "www": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "value": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": { "type": "integer" },
+          "title": { "type": "string" },
+          "code": { "type": "string" },
+          "cause": { "type": "string" },
+          "action": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/here.com/here-maps/meta.json
+++ b/apis/openapi/here.com/here-maps/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "e69715c6b9e1386d9367e3bbb5967e3b",
+    "format": "openapi",
+    "vendor": "here.com",
+    "api_name": "here-maps",
+    "friendly_id": "here.com/here-maps"
+  }
+}

--- a/apis/openapi/hirak.site/hirak-ip-to-country/1.0.0/openapi.json
+++ b/apis/openapi/hirak.site/hirak-ip-to-country/1.0.0/openapi.json
@@ -1,0 +1,150 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Hirak IP to Country API",
+    "description": "A simple API that translates an IP address into country information. Provides IP-to-location mapping for determining the geographic origin of IP addresses.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Hirak",
+      "url": "https://iplocation.hirak.site/"
+    },
+    "x-jentic-source-url": "https://iplocation.hirak.site/"
+  },
+  "servers": [
+    {
+      "url": "https://iplocation.hirak.site/api",
+      "description": "Production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "IP Lookup",
+      "description": "IP address to country lookup operations"
+    }
+  ],
+  "paths": {
+    "/": {
+      "get": {
+        "tags": ["IP Lookup"],
+        "summary": "Get country from caller IP",
+        "description": "Returns the country information for the requesting client's IP address.",
+        "operationId": "getCallerCountry",
+        "responses": {
+          "200": {
+            "description": "Successful response with IP location data",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IpLocationResponse" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    },
+    "/{ip}": {
+      "get": {
+        "tags": ["IP Lookup"],
+        "summary": "Get country from specific IP",
+        "description": "Returns the country information for the specified IP address.",
+        "operationId": "getCountryByIp",
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "path",
+            "required": true,
+            "description": "IPv4 or IPv6 address to look up",
+            "schema": { "type": "string" },
+            "example": "8.8.8.8"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with IP location data",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IpLocationResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid IP address format",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "IP address not found in database"
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "IpLocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "description": "The queried IP address"
+          },
+          "country": {
+            "type": "string",
+            "description": "Full country name"
+          },
+          "country_code": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code"
+          },
+          "continent": {
+            "type": "string",
+            "description": "Continent name"
+          },
+          "continent_code": {
+            "type": "string",
+            "description": "Continent code"
+          },
+          "city": {
+            "type": "string",
+            "description": "City name (if available)"
+          },
+          "region": {
+            "type": "string",
+            "description": "Region or state name (if available)"
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Approximate latitude"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Approximate longitude"
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone identifier"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/hirak.site/hirak-ip-to-country/meta.json
+++ b/apis/openapi/hirak.site/hirak-ip-to-country/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "8cf7b64e069391b0db24507f5966597c",
+    "format": "openapi",
+    "vendor": "hirak.site",
+    "api_name": "hirak-ip-to-country",
+    "friendly_id": "hirak.site/hirak-ip-to-country"
+  }
+}

--- a/apis/openapi/humorapi.com/humor/1.0.0/openapi.json
+++ b/apis/openapi/humorapi.com/humor/1.0.0/openapi.json
@@ -1,0 +1,1238 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Humor API",
+    "description": "The Humor API lets you search for jokes, memes, gifs, and more. It includes joke analysis, word funniness rating, insult and praise generation, and nonsense word generation.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Humor API",
+      "url": "https://humorapi.com"
+    },
+    "x-jentic-source-url": "https://humorapi.com"
+  },
+  "servers": [
+    {
+      "url": "https://api.humorapi.com",
+      "description": "Production server"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Jokes",
+      "description": "Endpoints for searching, retrieving, creating, analyzing, and voting on jokes"
+    },
+    {
+      "name": "Memes",
+      "description": "Endpoints for searching, retrieving, and voting on memes"
+    },
+    {
+      "name": "Other",
+      "description": "GIF search, praise, insults, and word-related endpoints"
+    }
+  ],
+  "paths": {
+    "/jokes/search": {
+      "get": {
+        "operationId": "searchJokes",
+        "summary": "Search jokes",
+        "description": "Search for jokes matching the given criteria.",
+        "tags": ["Jokes"],
+        "parameters": [
+          {
+            "name": "keywords",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of keywords to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "include-tags",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of tags the jokes must have (e.g., clean, dark, nerdy, political, christmas).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude-tags",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of tags the jokes must not have.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "min-rating",
+            "in": "query",
+            "required": false,
+            "description": "The minimum rating of jokes to return (0-10).",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "max-length",
+            "in": "query",
+            "required": false,
+            "description": "The maximum length of the joke in characters.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of results to skip for pagination.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "The number of results to return (max 10).",
+            "schema": {
+              "type": "integer",
+              "default": 3,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with joke search results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JokeSearchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes/random": {
+      "get": {
+        "operationId": "randomJoke",
+        "summary": "Get a random joke",
+        "description": "Returns a random joke matching the given criteria.",
+        "tags": ["Jokes"],
+        "parameters": [
+          {
+            "name": "include-tags",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of tags the joke must have.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "exclude-tags",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of tags the joke must not have.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "min-rating",
+            "in": "query",
+            "required": false,
+            "description": "The minimum rating of the joke (0-10).",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "max-length",
+            "in": "query",
+            "required": false,
+            "description": "The maximum length of the joke in characters.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with a random joke.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Joke"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes/create": {
+      "get": {
+        "operationId": "createJoke",
+        "summary": "Create a joke",
+        "description": "Generate a joke using AI based on given topics.",
+        "tags": ["Jokes"],
+        "parameters": [
+          {
+            "name": "topics",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of topics the joke should be about.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "max-length",
+            "in": "query",
+            "required": false,
+            "description": "The maximum length of the joke in characters.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with generated joke.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Joke"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes/analyze": {
+      "post": {
+        "operationId": "analyzeJoke",
+        "summary": "Analyze a joke",
+        "description": "Analyze a joke and return information about it, such as the type of joke.",
+        "tags": ["Jokes"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["joke"],
+                "properties": {
+                  "joke": {
+                    "type": "string",
+                    "description": "The joke text to analyze."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful joke analysis.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/JokeAnalysis"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes": {
+      "post": {
+        "operationId": "submitJoke",
+        "summary": "Submit a joke",
+        "description": "Submit a joke to the Humor API database.",
+        "tags": ["Jokes"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["joke"],
+                "properties": {
+                  "joke": {
+                    "type": "string",
+                    "description": "The joke text to submit."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Joke submitted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SubmitResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes/{id}/upvote": {
+      "post": {
+        "operationId": "upvoteJoke",
+        "summary": "Upvote a joke",
+        "description": "Upvote a joke by its ID.",
+        "tags": ["Jokes"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the joke to upvote.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Joke upvoted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/jokes/{id}/downvote": {
+      "post": {
+        "operationId": "downvoteJoke",
+        "summary": "Downvote a joke",
+        "description": "Downvote a joke by its ID.",
+        "tags": ["Jokes"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the joke to downvote.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Joke downvoted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/memes/search": {
+      "get": {
+        "operationId": "searchMemes",
+        "summary": "Search memes",
+        "description": "Search for memes matching the given criteria.",
+        "tags": ["Memes"],
+        "parameters": [
+          {
+            "name": "keywords",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of keywords to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keywords-in-image",
+            "in": "query",
+            "required": false,
+            "description": "Whether to search for keywords in the meme image content.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "media-type",
+            "in": "query",
+            "required": false,
+            "description": "The media type (e.g., image, video).",
+            "schema": {
+              "type": "string",
+              "enum": ["image", "video"]
+            }
+          },
+          {
+            "name": "min-rating",
+            "in": "query",
+            "required": false,
+            "description": "The minimum rating of memes to return (0-10).",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "max-age-days",
+            "in": "query",
+            "required": false,
+            "description": "The maximum age of memes in days.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "The number of results to skip for pagination.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "The number of results to return (max 10).",
+            "schema": {
+              "type": "integer",
+              "default": 3,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with meme search results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemeSearchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/memes/random": {
+      "get": {
+        "operationId": "randomMeme",
+        "summary": "Get a random meme",
+        "description": "Returns a random meme matching the given criteria.",
+        "tags": ["Memes"],
+        "parameters": [
+          {
+            "name": "keywords",
+            "in": "query",
+            "required": false,
+            "description": "A comma-separated list of keywords.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "keywords-in-image",
+            "in": "query",
+            "required": false,
+            "description": "Whether to search for keywords in the meme image content.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "media-type",
+            "in": "query",
+            "required": false,
+            "description": "The media type (e.g., image, video).",
+            "schema": {
+              "type": "string",
+              "enum": ["image", "video"]
+            }
+          },
+          {
+            "name": "min-rating",
+            "in": "query",
+            "required": false,
+            "description": "The minimum rating of the meme (0-10).",
+            "schema": {
+              "type": "number",
+              "minimum": 0,
+              "maximum": 10
+            }
+          },
+          {
+            "name": "max-age-days",
+            "in": "query",
+            "required": false,
+            "description": "The maximum age of the meme in days.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with a random meme.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Meme"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/memes/{id}/upvote": {
+      "post": {
+        "operationId": "upvoteMeme",
+        "summary": "Upvote a meme",
+        "description": "Upvote a meme by its ID.",
+        "tags": ["Memes"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the meme to upvote.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meme upvoted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/memes/{id}/downvote": {
+      "post": {
+        "operationId": "downvoteMeme",
+        "summary": "Downvote a meme",
+        "description": "Downvote a meme by its ID.",
+        "tags": ["Memes"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the meme to downvote.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Meme downvoted successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/VoteResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/gif/search": {
+      "get": {
+        "operationId": "searchGifs",
+        "summary": "Search GIFs",
+        "description": "Search for GIFs matching the given query.",
+        "tags": ["Other"],
+        "parameters": [
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "The search query.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "number",
+            "in": "query",
+            "required": false,
+            "description": "The number of results to return (max 10).",
+            "schema": {
+              "type": "integer",
+              "default": 3,
+              "maximum": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with GIF search results.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GifSearchResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/praise": {
+      "get": {
+        "operationId": "praise",
+        "summary": "Praise someone",
+        "description": "Generate a praise message for someone.",
+        "tags": ["Other"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "The name of the person to praise.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "reason",
+            "in": "query",
+            "required": true,
+            "description": "The reason for the praise.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with praise text.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/insult": {
+      "get": {
+        "operationId": "insult",
+        "summary": "Insult someone",
+        "description": "Generate a humorous insult for someone.",
+        "tags": ["Other"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "query",
+            "required": true,
+            "description": "The name of the person to insult.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "reason",
+            "in": "query",
+            "required": true,
+            "description": "The reason for the insult.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with insult text.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TextResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/words/rate": {
+      "get": {
+        "operationId": "rateWord",
+        "summary": "Rate a word's funniness",
+        "description": "Rate how funny a word is on a scale.",
+        "tags": ["Other"],
+        "parameters": [
+          {
+            "name": "word",
+            "in": "query",
+            "required": true,
+            "description": "The word to rate.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with word rating.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WordRating"
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    },
+    "/words/nonsense/random": {
+      "get": {
+        "operationId": "generateNonsenseWord",
+        "summary": "Generate a nonsense word",
+        "description": "Generate a random nonsense word.",
+        "tags": ["Other"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful response with a nonsense word.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NonsenseWord"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          },
+          "500": {
+            "$ref": "#/components/responses/InternalServerError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api-key",
+        "description": "API key for authentication. Pass as a query parameter."
+      }
+    },
+    "schemas": {
+      "Joke": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The joke ID."
+          },
+          "joke": {
+            "type": "string",
+            "description": "The joke text."
+          }
+        }
+      },
+      "JokeSearchResult": {
+        "type": "object",
+        "properties": {
+          "jokes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Joke"
+            },
+            "description": "List of matching jokes."
+          },
+          "total_jokes": {
+            "type": "integer",
+            "description": "Total number of jokes matching the query."
+          }
+        }
+      },
+      "JokeAnalysis": {
+        "type": "object",
+        "properties": {
+          "joke": {
+            "type": "string",
+            "description": "The analyzed joke text."
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Tags identified for the joke."
+          },
+          "word_count": {
+            "type": "integer",
+            "description": "Number of words in the joke."
+          }
+        }
+      },
+      "SubmitResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message."
+          }
+        }
+      },
+      "Meme": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The meme ID."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL to the meme."
+          },
+          "type": {
+            "type": "string",
+            "description": "The media type of the meme (image or video)."
+          }
+        }
+      },
+      "MemeSearchResult": {
+        "type": "object",
+        "properties": {
+          "memes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Meme"
+            },
+            "description": "List of matching memes."
+          },
+          "total_memes": {
+            "type": "integer",
+            "description": "Total number of memes matching the query."
+          }
+        }
+      },
+      "VoteResult": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Confirmation message."
+          }
+        }
+      },
+      "GifSearchResult": {
+        "type": "object",
+        "properties": {
+          "images": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string",
+                  "format": "uri",
+                  "description": "URL of the GIF."
+                },
+                "width": {
+                  "type": "integer",
+                  "description": "Width of the GIF."
+                },
+                "height": {
+                  "type": "integer",
+                  "description": "Height of the GIF."
+                }
+              }
+            },
+            "description": "List of matching GIF images."
+          }
+        }
+      },
+      "TextResult": {
+        "type": "object",
+        "properties": {
+          "text": {
+            "type": "string",
+            "description": "The generated text."
+          }
+        }
+      },
+      "WordRating": {
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string",
+            "description": "The rated word."
+          },
+          "rating": {
+            "type": "number",
+            "description": "The funniness rating."
+          }
+        }
+      },
+      "NonsenseWord": {
+        "type": "object",
+        "properties": {
+          "word": {
+            "type": "string",
+            "description": "The generated nonsense word."
+          },
+          "rating": {
+            "type": "number",
+            "description": "The funniness rating of the word."
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Error message."
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code."
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid or missing parameters.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - invalid or missing API key.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "PaymentRequired": {
+        "description": "Payment required - usage limit reached for free tier.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Too many requests - rate limit exceeded.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "InternalServerError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/humorapi.com/humor/meta.json
+++ b/apis/openapi/humorapi.com/humor/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "b44c4d9bfbddb6024256839ad144037f",
+    "format": "openapi",
+    "vendor": "humorapi.com",
+    "api_name": "humor",
+    "friendly_id": "humorapi.com/humor"
+  }
+}

--- a/apis/openapi/hypixel.net/hypixel/meta.json
+++ b/apis/openapi/hypixel.net/hypixel/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "a4f7eac0f0c11dc30b59358beb645fbc",
+    "format": "openapi",
+    "vendor": "hypixel.net",
+    "api_name": "hypixel",
+    "friendly_id": "hypixel.net/hypixel"
+  }
+}

--- a/apis/openapi/hypixel.net/hypixel/v2/openapi.json
+++ b/apis/openapi/hypixel.net/hypixel/v2/openapi.json
@@ -1,0 +1,2742 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Hypixel Public API",
+    "x-logo": {
+      "url": "https://api.hypixel.net/assets/images/logo.png",
+      "altText": "Hypixel Logo",
+      "href": "#"
+    },
+    "description": "# Introduction\nThis is the official Hypixel API documentation. [Hypixel Website](https://hypixel.net/) - [GitHub Repo](https://github.com/HypixelDev/PublicAPI) - [API Help Forum](https://hypixel.net/forums/api-help.111/)\n\nAll use of the API must conform to the [API policies](https://developer.hypixel.net/policies), violation of these policies may lead to applications being revoked or users banned from the API.\n## Limits\nAPI keys are limited to a maximum amount of requests per 5 minute intervals. These limits will depend on the type of application that the key is assigned to.\n\nEndpoints which require the use of an API key will also respond with headers to assist with managing the rate limit:\n- 'RateLimit-Limit' - The limit of requests per minute for the provided API key.\n- 'RateLimit-Remaining' - The remaining amount of requests allowed for the current minute.\n- 'RateLimit-Reset' - The amount of seconds until the next minute and the reset of the API key usages.\n\n## GameTypes\n| ID | Type Name      | Database Name | Clean Name           |\n |----|----------------|---------------|----------------------|\n | 2  | QUAKECRAFT     | Quake         | Quake                |\n | 3  | WALLS          | Walls         | Walls                |\n | 4  | PAINTBALL      | Paintball     | Paintball            |\n | 5  | SURVIVAL_GAMES | HungerGames   | Blitz Survival Games |\n | 6  | TNTGAMES       | TNTGames      | TNT Games            |\n | 7  | VAMPIREZ       | VampireZ      | VampireZ             |\n | 13 | WALLS3         | Walls3        | Mega Walls           |\n | 14 | ARCADE         | Arcade        | Arcade               |\n | 17 | ARENA          | Arena         | Arena                |\n | 20 | UHC            | UHC           | UHC Champions        |\n | 21 | MCGO           | MCGO          | Cops and Crims       |\n | 23 | BATTLEGROUND   | Battleground  | Warlords             |\n | 24 | SUPER_SMASH    | SuperSmash    | Smash Heroes         |\n | 25 | GINGERBREAD    | GingerBread   | Turbo Kart Racers    |\n | 26 | HOUSING        | Housing       | Housing              |\n | 51 | SKYWARS        | SkyWars       | SkyWars              |\n | 52 | TRUE_COMBAT    | TrueCombat    | Crazy Walls          |\n | 54 | SPEED_UHC      | SpeedUHC      | Speed UHC            |\n | 55 | SKYCLASH       | SkyClash      | SkyClash             |\n | 56 | LEGACY         | Legacy        | Classic Games        |\n | 57 | PROTOTYPE      | Prototype     | Prototype            |\n | 58 | BEDWARS        | Bedwars       | Bed Wars             |\n | 59 | MURDER_MYSTERY | MurderMystery | Murder Mystery       |\n | 60 | BUILD_BATTLE   | BuildBattle   | Build Battle         |\n | 61 | DUELS          | Duels         | Duels                |\n | 63 | SKYBLOCK       | SkyBlock      | SkyBlock             |\n | 64 | PIT            | Pit           | Pit                  |\n | 65 | REPLAY         | Replay        | Replay               |\n | 67 | SMP            | SMP           | SMP                  |\n | 68 | WOOL_GAMES     | WoolGames     | Wool Wars            |\n\n### Storage\nGames store their respective stats and data in a Player's `stats` collection. The game's specific data is held within a JSON object named after it's `Database Name` (seen above.)\n### GameType Notes\n* Clean names are what is displayed to the user when referencing the name.\n* Database names or IDs are used when the API references a specific GameType.\n## Notes\n\n### Date and Time\nGenerally dates are stored as a Unix Epoch times in milliseconds.\n### Response Format\nResponses are served in JSON format.\n### UUID Parameters\nAll uuid parameters support both dashed and undashed versions.\n### SkyBlock items and inventories\nItems and inventory data are stored as a base64 encoded string containing gzipped nbt data.\nIf a method is missing important information about an item or inventory, you should try checking this!\n>Note: the base64 string may contain a unicode escape for non-alphabetical symbols, and some programming languages may have silent defects when interpreting the string. \n\n# Authentication\n\n<!-- ReDoc-Inject: <security-definitions> -->",
+    "version": "v2",
+    "termsOfService": "https://hypixel.net/tos",
+    "contact": {
+      "name": "Hypixel Support",
+      "url": "https://developer.hypixel.net"
+    },
+    "x-jentic-source-url": "https://api.hypixel.net/"
+  },
+  "servers": [
+    {
+      "url": "https://api.hypixel.net"
+    }
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "API-Key",
+        "description": "Obtained via the [Hypixel Developer Dashboard](https://developer.hypixel.net) when creating an application. You can also request higher limits for production applications in this dashboard."
+      }
+    },
+    "responses": {
+      "DataMissing": {
+        "description": "Some data is missing, this is usually a field.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Missing one or more fields [...]"
+                }
+              }
+            }
+          }
+        }
+      },
+      "InvalidKey": {
+        "description": "Access is forbidden, usually due to an invalid API key being used.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Invalid API key"
+                }
+              }
+            }
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "A request limit has been reached, usually this is due to the limit on the key being reached but can also be triggered by a global throttle.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Key throttle"
+                },
+                "throttle": {
+                  "type": "boolean",
+                  "example": true
+                },
+                "global": {
+                  "type": "boolean",
+                  "description": "When this boolean exists and is true, the throttle occurring is a global throttle applied to all users",
+                  "example": true
+                }
+              }
+            }
+          }
+        }
+      },
+      "InvalidPage": {
+        "description": "The page provided is invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Invalid page"
+                }
+              }
+            }
+          }
+        }
+      },
+      "MissingPage": {
+        "description": "The page provided does not exist.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Page not found"
+                }
+              }
+            }
+          }
+        }
+      },
+      "MalformedData": {
+        "description": "Some data provided is invalid.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Malformed UUID"
+                }
+              }
+            }
+          }
+        }
+      },
+      "NotPopulated": {
+        "description": "The data is not yet populated and should be available shortly",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "Leaderboard data has not yet been populated"
+                }
+              }
+            }
+          }
+        }
+      },
+      "NoResult": {
+        "description": "The request responded with no result.",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "properties": {
+                "success": {
+                  "type": "boolean",
+                  "example": false
+                },
+                "cause": {
+                  "type": "string",
+                  "example": "No result was found"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Booster": {
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "objectid"
+          },
+          "purchaserUuid": {
+            "type": "string",
+            "format": "uuid",
+            "example": "ad8fefaa8351454bb739a4eaa872173f"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "originalLength": {
+            "type": "integer"
+          },
+          "length": {
+            "type": "integer"
+          },
+          "gameType": {
+            "type": "integer"
+          },
+          "dateActivated": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "ActiveBooster": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Booster"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stacked": {
+                "type": "array",
+                "nullable": true,
+                "items": {
+                  "type": "string",
+                  "description": "UUID of the player in a dashed format",
+                  "format": "uuid",
+                  "example": "ad8fefaa-8351-454b-b739-a4eaa872173f"
+                }
+              }
+            }
+          }
+        ]
+      },
+      "QueuedBooster": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/Booster"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "stacked": {
+                "type": "boolean",
+                "nullable": true
+              }
+            }
+          }
+        ]
+      },
+      "SkyBlockAuction": {
+        "properties": {
+          "_id": {
+            "type": "string",
+            "format": "objectid"
+          },
+          "uuid": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "auctioneer": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "profile_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "coop": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          "start": {
+            "type": "number",
+            "format": "int64"
+          },
+          "end": {
+            "type": "number",
+            "format": "int64"
+          },
+          "item_name": {
+            "type": "string"
+          },
+          "item_lore": {
+            "type": "string"
+          },
+          "extra": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "string"
+          },
+          "starting_bid": {
+            "type": "number"
+          },
+          "item_bytes": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "number"
+              },
+              "data": {
+                "type": "string"
+              }
+            }
+          },
+          "claimed": {
+            "type": "boolean"
+          },
+          "claimed_bidders": {
+            "type": "array"
+          },
+          "highest_bid_amount": {
+            "type": "number"
+          },
+          "bids": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "auction_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "bidder": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "profile_id": {
+                  "type": "string",
+                  "format": "uuid"
+                },
+                "amount": {
+                  "type": "number"
+                },
+                "timestamp": {
+                  "type": "number",
+                  "format": "int64"
+                }
+              }
+            }
+          }
+        },
+        "example": {
+          "uuid": "409a1e0f261a49849493278d6cd9305a",
+          "auctioneer": "347ef6c1daac45ed9d1fa02818cf0fb6",
+          "profile_id": "347ef6c1daac45ed9d1fa02818cf0fb6",
+          "coop": [
+            "347ef6c1daac45ed9d1fa02818cf0fb6"
+          ],
+          "start": 1573760802637,
+          "end": 1573761102637,
+          "item_name": "Azure Bluet",
+          "item_lore": "\u00a7f\u00a7lCOMMON",
+          "extra": "Azure Bluet Red Rose",
+          "category": "blocks",
+          "tier": "COMMON",
+          "starting_bid": 1,
+          "item_bytes": {
+            "type": 0,
+            "data": "H4sIAAAAAAAAAB2NQQqCQBhGv1ErHaKu0KoLtGtnarRIhTpA/OGfDIwZ4wxUF/IeHiyyto/3eBKIIJQEIDx4qsJaYJK07m6FhG+p9hEdVMV7TXU3Wh+JWaW6h6ZXhODYGg5/LeZDfxt6nZR5XhYhgoIaxmKE8dsZXu20YwuJZfa0hmJrjbo6y134f8pTll5O5TnbbgAP05Qaqhk+8AVIrd2eoAAAAA=="
+          },
+          "claimed": true,
+          "claimed_bidders": [],
+          "highest_bid_amount": 7607533,
+          "bids": [
+            {
+              "auction_id": "409a1e0f261a49849493278d6cd9305a",
+              "bidder": "99748e629dee463892f68abf3a780094",
+              "profile_id": "99748e629dee463892f68abf3a780094",
+              "amount": 7607533,
+              "timestamp": 1573760824844
+            }
+          ]
+        }
+      },
+      "SkyBlockProfile": {
+        "properties": {
+          "profile_id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "members": {
+            "description": "A map of member UUIDs to member profiles objects",
+            "type": "object",
+            "properties": {
+              "player_id": {
+                "type": "string",
+                "format": "uuid"
+              },
+              "profile": {
+                "type": "object",
+                "properties": {
+                  "deletion_notice": {
+                    "description": "If this field exists, the member profile is marked as deleted",
+                    "nullable": true,
+                    "type": "object",
+                    "properties": {
+                      "timestamp": {
+                        "type": "integer",
+                        "format": "int64"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "cute_name": {
+            "description": "The cute name of the profile, only provided on the profiles endpoint",
+            "nullable": true,
+            "type": "string"
+          },
+          "selected": {
+            "description": "Whether or not this is the currently selected profile, only provided on the profiles endpoint",
+            "nullable": true,
+            "type": "boolean"
+          },
+          "community_upgrades": {
+            "nullable": true,
+            "type": "object"
+          },
+          "banking": {
+            "description": "Information about the bank account for this profile, only present if the API banking setting is enabled",
+            "nullable": true,
+            "type": "object",
+            "properties": {
+              "balance": {
+                "type": "number",
+                "format": "double"
+              },
+              "transactions": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "timestamp": {
+                      "type": "integer",
+                      "format": "int64"
+                    },
+                    "action": {
+                      "type": "string",
+                      "enum": [
+                        "DEPOSIT",
+                        "WITHDRAW"
+                      ]
+                    },
+                    "initiator_name": {
+                      "type": "string"
+                    },
+                    "amount": {
+                      "type": "number",
+                      "format": "double"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "game_mode": {
+            "description": "The SkyBlock game mode of the profile, not present if normal mode",
+            "nullable": true,
+            "type": "string",
+            "enum": [
+              "ironman",
+              "island",
+              "bingo"
+            ]
+          }
+        }
+      },
+      "SkyBlockItem": {
+        "properties": {
+          "id": {
+            "description": "The unique identifier for this item",
+            "type": "string"
+          },
+          "material": {
+            "description": "The Bukkit material enum value for the item",
+            "type": "string"
+          },
+          "name": {
+            "description": "The name of the item",
+            "type": "string"
+          },
+          "tier": {
+            "description": "The rarity tier of the item",
+            "type": "string",
+            "enum": [
+              "COMMON",
+              "UNCOMMON",
+              "RARE",
+              "EPIC",
+              "LEGENDARY",
+              "MYTHIC",
+              "SUPREME",
+              "SPECIAL",
+              "VERY_SPECIAL"
+            ]
+          },
+          "color": {
+            "description": "The color metadata to be applied to an item, usually leather armor pieces",
+            "pattern": "^(?:(?:^|,\\s*)([01]?\\d\\d?|2[0-4]\\d|25[0-5])){3}$",
+            "type": "string"
+          },
+          "skin": {
+            "description": "The skin value for a skull based item",
+            "type": "string"
+          }
+        },
+        "example": {
+          "material": "LEATHER_CHESTPLATE",
+          "color": "255,215,0",
+          "name": "Farm Armor Chestplate",
+          "category": "CHESTPLATE",
+          "tier": "RARE",
+          "stats": {
+            "DEFENSE": 75,
+            "HEALTH": 20
+          },
+          "npc_sell_price": 5200,
+          "id": "FARM_ARMOR_CHESTPLATE"
+        }
+      },
+      "SkyBlockMuseum": {
+        "properties": {
+          "value": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "appraisal": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "object"
+          },
+          "special": {
+            "type": "array",
+            "properties": {
+              "donated_time": {
+                "type": "integer",
+                "format": "int64"
+              },
+              "items": {
+                "type": "object"
+              }
+            }
+          }
+        }
+      },
+      "Game": {
+        "description": "Information about a specific game. When a field is not present you should fallback to the provided default if there is one, required fields will always exist.",
+        "required": [
+          "id",
+          "name",
+          "databaseName"
+        ],
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "The backend ID of the game.",
+            "example": 1
+          },
+          "name": {
+            "type": "string",
+            "description": "The display name of the game.",
+            "example": "Bed Wars"
+          },
+          "databaseName": {
+            "type": "string",
+            "description": "The key used for database storage, such as for stats.",
+            "example": "Bedwars"
+          },
+          "modeNames": {
+            "type": "object",
+            "description": "A map of mode key to display name",
+            "example": {
+              "solo_normal": "Solo",
+              "team_normal": "Doubles"
+            }
+          },
+          "retired": {
+            "type": "boolean",
+            "description": "True if the game is retired and no longer playable.",
+            "default": false
+          },
+          "legacy": {
+            "type": "boolean",
+            "description": "True if the game is legacy and part of the Classic Lobby.",
+            "default": false
+          }
+        },
+        "example": {
+          "id": 58,
+          "name": "Bed Wars",
+          "databaseName": "Bedwars",
+          "modeNames": {
+            "BEDWARS_TWO_FOUR": "4v4",
+            "BEDWARS_EIGHT_ONE": "Solo"
+          }
+        }
+      },
+      "SkyBlockFireSale": {
+        "properties": {
+          "item_id": {
+            "description": "The SkyBlock item ID for this sale",
+            "type": "string"
+          },
+          "start": {
+            "description": "The start time in unix milliseconds for the sale",
+            "type": "number"
+          },
+          "end": {
+            "description": "The end time in unix milliseconds for the sale",
+            "type": "number"
+          },
+          "amount": {
+            "description": "The amount of items available for this sale",
+            "type": "integer"
+          },
+          "price": {
+            "description": "The price in Gems for this sale",
+            "type": "integer"
+          }
+        }
+      },
+      "SkyBlockGarden": {
+        "description": "Information about a player's SkyBlock garden, the only guaranteed field is the `uuid` field.",
+        "required": [
+          "uuid"
+        ],
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The UUID of the profile for this garden."
+          },
+          "commission_data": {
+            "type": "object",
+            "properties": {
+              "visits": {
+                "type": "object",
+                "description": "A map of visitor identifier to visit count",
+                "example": {
+                  "jerry": 1,
+                  "jacob": 2,
+                  "andrew": 3
+                }
+              },
+              "completed": {
+                "type": "object",
+                "description": "A map of visitor identifier to completed count",
+                "example": {
+                  "jerry": 1,
+                  "jacob": 1,
+                  "andrew": 2
+                }
+              },
+              "total_completed": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "unique_npcs_served": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "composter_data": {
+            "type": "object",
+            "example": {
+              "organic_matter": 1772.8,
+              "fuel_units": 17000,
+              "compost_units": 0,
+              "compost_items": 2,
+              "conversion_ticks": 300,
+              "last_save": 1721039418436,
+              "upgrades": {
+                "speed": 25,
+                "multi_drop": 25,
+                "fuel_cap": 22,
+                "organic_matter_cap": 25,
+                "cost_reduction": 25
+              }
+            }
+          },
+          "active_commissions": {
+            "type": "object",
+            "example": {
+              "liam": {
+                "requirement": [
+                  {
+                    "original_item": "NETHER_STALK",
+                    "original_amount": 93995,
+                    "item": "MUTANT_NETHER_STALK",
+                    "amount": 4
+                  }
+                ],
+                "status": "NOT_STARTED",
+                "position": 1
+              },
+              "lumberjack": {
+                "requirement": [
+                  {
+                    "original_item": "POTATO_ITEM",
+                    "original_amount": 81380,
+                    "item": "ENCHANTED_BAKED_POTATO",
+                    "amount": 3
+                  }
+                ],
+                "status": "NOT_STARTED",
+                "position": 2
+              },
+              "oringo": {
+                "requirement": [
+                  {
+                    "original_item": "WHEAT",
+                    "original_amount": 26798,
+                    "item": "ENCHANTED_HAY_BLOCK",
+                    "amount": 21
+                  }
+                ],
+                "status": "NOT_STARTED",
+                "position": 3
+              },
+              "rhys": {
+                "requirement": [
+                  {
+                    "original_item": "JACK_O_LANTERN",
+                    "original_amount": 512,
+                    "item": "JACK_O_LANTERN",
+                    "amount": 512
+                  }
+                ],
+                "status": "NOT_STARTED",
+                "position": 4
+              },
+              "fear_mongerer": {
+                "requirement": [
+                  {
+                    "original_item": "PUMPKIN",
+                    "original_amount": 27709,
+                    "item": "POLISHED_PUMPKIN",
+                    "amount": 1
+                  }
+                ],
+                "status": "NOT_STARTED",
+                "position": 5,
+                "extra_rewards": [
+                  {
+                    "candy": "PURPLE_CANDY"
+                  }
+                ]
+              }
+            }
+          },
+          "resources_collected": {
+            "type": "object",
+            "description": "A map of resource ID to amount collected",
+            "example": {
+              "WHEAT": 100,
+              "POTATO_ITEM": 100,
+              "INK_SACK:3": 100
+            }
+          },
+          "crop_upgrade_levels": {
+            "type": "object",
+            "example": {
+              "WHEAT": 1,
+              "POTATO_ITEM": 2,
+              "INK_SACK:3": 3
+            }
+          },
+          "unlocked_plots_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "example": [
+              "beginner_1",
+              "intermediate_3"
+            ]
+          },
+          "garden_experience": {
+            "type": "integer",
+            "format": "double"
+          },
+          "unlocked_barn_skins": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "selected_barn_skin": {
+            "type": "string"
+          }
+        }
+      },
+      "HousingHouse": {
+        "description": "Information about a player's house.",
+        "required": [
+          "uuid",
+          "owner",
+          "name",
+          "createdAt",
+          "players",
+          "cookies"
+        ],
+        "properties": {
+          "uuid": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The UUID of this house."
+          },
+          "owner": {
+            "type": "string",
+            "format": "uuid",
+            "description": "The UUID of the owner of this house."
+          },
+          "name": {
+            "type": "string",
+            "nullable": true,
+            "description": "The name of this house, may contain Minecraft color symbols."
+          },
+          "createdAt": {
+            "type": "number",
+            "format": "int64",
+            "description": "The time this house was created."
+          },
+          "players": {
+            "type": "number",
+            "format": "int32",
+            "description": "The number of players in this house."
+          },
+          "cookies": {
+            "type": "object",
+            "properties": {
+              "current": {
+                "type": "number",
+                "format": "int32",
+                "description": "The current amount of cookies that this house has for the current week."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/v2/player": {
+      "get": {
+        "summary": "Data of a specific player, including game stats",
+        "tags": [
+          "Player Data"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get player's data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": true
+                    },
+                    "player": {
+                      "type": "object",
+                      "properties": {
+                        "uuid": {
+                          "type": "string",
+                          "example": "3fa85f6457174562b3fc2c963f66afa6"
+                        },
+                        "displayname": {
+                          "type": "string",
+                          "nullable": true
+                        },
+                        "rank": {
+                          "type": "string",
+                          "nullable": true,
+                          "enum": [
+                            "ADMIN",
+                            "MODERATOR",
+                            "HELPER",
+                            "NORMAL"
+                          ]
+                        },
+                        "packageRank": {
+                          "type": "string",
+                          "nullable": true,
+                          "enum": [
+                            "MVP_PLUS",
+                            "MVP",
+                            "VIP_PLUS",
+                            "VIP",
+                            "NONE"
+                          ]
+                        },
+                        "newPackageRank": {
+                          "type": "string",
+                          "nullable": true,
+                          "enum": [
+                            "MVP_PLUS",
+                            "MVP",
+                            "VIP_PLUS",
+                            "VIP",
+                            "NONE"
+                          ]
+                        },
+                        "monthlyPackageRank": {
+                          "type": "string",
+                          "nullable": true,
+                          "enum": [
+                            "SUPERSTAR",
+                            "NONE"
+                          ]
+                        },
+                        "firstLogin": {
+                          "type": "number",
+                          "nullable": true
+                        },
+                        "lastLogin": {
+                          "type": "number",
+                          "nullable": true
+                        },
+                        "lastLogout": {
+                          "type": "number",
+                          "nullable": true
+                        },
+                        "stats": {
+                          "type": "object",
+                          "nullable": true
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/recentgames": {
+      "get": {
+        "summary": "The recently played games of a specific player",
+        "tags": [
+          "Player Data"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get player's recent game",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid"
+                    },
+                    "games": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "date": {
+                            "type": "number",
+                            "format": "int64"
+                          },
+                          "gameType": {
+                            "type": "string"
+                          },
+                          "mode": {
+                            "type": "string"
+                          },
+                          "map": {
+                            "type": "string"
+                          },
+                          "ended": {
+                            "type": "number",
+                            "format": "int64"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/status": {
+      "get": {
+        "summary": "The current online status of a specific player",
+        "tags": [
+          "Player Data"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get player status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "uuid": {
+                      "type": "string",
+                      "format": "uuid",
+                      "example": "ad8fefaa8351454bb739a4eaa872173f"
+                    },
+                    "session": {
+                      "type": "object",
+                      "properties": {
+                        "online": {
+                          "type": "boolean"
+                        },
+                        "gameType": {
+                          "type": "string"
+                        },
+                        "mode": {
+                          "type": "string"
+                        },
+                        "map": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/guild": {
+      "get": {
+        "summary": "Retrieve a Guild by a player, id, or name",
+        "tags": [
+          "Player Data"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "id",
+            "schema": {
+              "type": "string",
+              "format": "objectid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "player",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "in": "query",
+            "name": "name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get guild information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "guild": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/resources/games": {
+      "get": {
+        "summary": "Game Information",
+        "description": "Returns information about Hypixel Games. This endpoint is in early development and we are working to add more information when possible <a href=\"https://github.com/HypixelDev/PublicAPI/discussions/197#discussioncomment-1047648\">HypixelDev/PublicAPI#197</a>",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "games": {
+                      "type": "object",
+                      "description": "A map where the key is the backend name of the game",
+                      "additionalProperties": {
+                        "$ref": "#/components/schemas/Game"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/achievements": {
+      "get": {
+        "summary": "Achievements",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "achievements": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/challenges": {
+      "get": {
+        "summary": "Challenges",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "challenges": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/quests": {
+      "get": {
+        "summary": "Quests",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "quests": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/guilds/achievements": {
+      "get": {
+        "summary": "Guild Achievements",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "one_time": {
+                      "type": "object"
+                    },
+                    "tiered": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/vanity/pets": {
+      "get": {
+        "summary": "Vanity Pets",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "types": {
+                      "type": "object"
+                    },
+                    "rarities": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/vanity/companions": {
+      "get": {
+        "summary": "Vanity Companions",
+        "tags": [
+          "Resources"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "types": {
+                      "type": "object"
+                    },
+                    "rarities": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/skyblock/collections": {
+      "get": {
+        "summary": "Collections",
+        "description": "Information regarding Collections in the SkyBlock game.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "0.11.22"
+                    },
+                    "collections": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/skyblock/skills": {
+      "get": {
+        "summary": "Skills",
+        "description": "Information regarding skills in the SkyBlock game.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "0.11.22"
+                    },
+                    "skills": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/skyblock/items": {
+      "get": {
+        "summary": "Items",
+        "description": "Information regarding items in the SkyBlock game.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkyBlockItem"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/skyblock/election": {
+      "get": {
+        "summary": "Election and Mayor",
+        "description": "Information regarding the current mayor and ongoing election in SkyBlock.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number"
+                    },
+                    "mayor": {
+                      "type": "object",
+                      "description": "Data regarding the current mayor"
+                    },
+                    "current": {
+                      "type": "object",
+                      "description": "Data regarding the current election, will not be provided if there is no open election ongoing"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/resources/skyblock/bingo": {
+      "get": {
+        "summary": "Current Bingo Event",
+        "description": "Information regarding the current bingo event and its goals.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": [
+                    "success",
+                    "lastUpdated",
+                    "id",
+                    "name",
+                    "start",
+                    "end",
+                    "modifier",
+                    "goals"
+                  ],
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number",
+                      "format": "int64",
+                      "description": "The unix milliseconds timestamp of the last time this data was updated"
+                    },
+                    "id": {
+                      "type": "number",
+                      "format": "int32",
+                      "description": "The current bingo event ID, increments by 1 for each bingo hosted",
+                      "example": 27
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "The display name for the current bingo event",
+                      "example": "March 2024"
+                    },
+                    "start": {
+                      "type": "number",
+                      "format": "int64",
+                      "description": "The start time of the current bingo event in unix milliseconds",
+                      "example": 1709269200000
+                    },
+                    "end": {
+                      "type": "number",
+                      "format": "int64",
+                      "description": "The end time of the current bingo event in unix milliseconds",
+                      "example": 1709874000000
+                    },
+                    "modifier": {
+                      "type": "string",
+                      "enum": [
+                        "NORMAL",
+                        "EXTREME",
+                        "SECRET"
+                      ],
+                      "description": "The modifier for the current bingo event",
+                      "example": "NORMAL"
+                    },
+                    "goals": {
+                      "type": "array",
+                      "description": "The goals for the current bingo event, as well as their progress",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "id",
+                          "name"
+                        ],
+                        "properties": {
+                          "id": {
+                            "description": "The backend ID for this goal",
+                            "type": "string"
+                          },
+                          "name": {
+                            "description": "The user friendly display name for this goal",
+                            "type": "string"
+                          },
+                          "lore": {
+                            "description": "Description of this goal",
+                            "type": "string"
+                          },
+                          "fullLore": {
+                            "description": "The full description of this goal",
+                            "type": "array"
+                          },
+                          "tiers": {
+                            "description": "The tiers of this goal, if a global goal",
+                            "type": "array",
+                            "items": {
+                              "type": "number",
+                              "format": "int64"
+                            }
+                          },
+                          "progress": {
+                            "description": "The global progress of this goal",
+                            "type": "number",
+                            "format": "int64"
+                          },
+                          "requiredAmount": {
+                            "description": "The required amount for this specific goal",
+                            "type": "number",
+                            "format": "int32"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/skyblock/news": {
+      "get": {
+        "summary": "News",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "items": {
+                      "items": {
+                        "example": {
+                          "item": {
+                            "material": "DIAMOND"
+                          },
+                          "link": "https://hypixel.net",
+                          "title": "SkyBlock v0.11",
+                          "text": "15th January 2021"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/auction": {
+      "get": {
+        "summary": "Request auction(s) by the auction UUID, player UUID, or profile UUID.",
+        "description": "Returns the auctions selected by the provided query. Only one query parameter can be used in a single request, and cannot be filtered by multiple.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "description": "The auction UUID that you wish to request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "player",
+            "description": "The player UUID that you wish to request",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "profile",
+            "description": "The profile UUID that you wish to request",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "auctions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkyBlockAuction"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/auctions": {
+      "get": {
+        "summary": "Active auctions",
+        "description": "Returns the currently active auctions sorted by last updated first and paginated.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "type": "number",
+              "default": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "page": {
+                      "type": "number"
+                    },
+                    "totalPages": {
+                      "type": "number",
+                      "example": 32
+                    },
+                    "totalAuctions": {
+                      "type": "number",
+                      "example": 31267
+                    },
+                    "lastUpdated": {
+                      "type": "number",
+                      "format": "int64",
+                      "example": 1571065561345
+                    },
+                    "auctions": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkyBlockAuction"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/MissingPage"
+          },
+          "422": {
+            "$ref": "#/components/responses/InvalidPage"
+          },
+          "503": {
+            "$ref": "#/components/responses/NotPopulated"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/auctions_ended": {
+      "get": {
+        "summary": "Recently ended auctions",
+        "description": "SkyBlock auctions which ended in the last 60 seconds.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number",
+                      "format": "int64",
+                      "example": 1607456463916
+                    },
+                    "auctions": {
+                      "type": "array",
+                      "items": {
+                        "example": {
+                          "auction_id": "015fe0c67e6041e69797bbe0c2725a21",
+                          "seller": "fc76242bf64a4698ae0ebc136d900929",
+                          "seller_profile": "85b96cd3e73e4580b8379162ec059141",
+                          "buyer": "c1eff55de0d24ec6b44848799e9323ba",
+                          "buyer_profile": "a3e1c076533a40a58085e7f43a598bf3",
+                          "timestamp": 1607456400329,
+                          "price": 190000,
+                          "bin": true,
+                          "item_bytes": "H4sIAAAAAAAAAEWR3W7TQBCFx2mBxKgtSH2ArUACZKL6L9jtndUYBdHQyGlV7qq1PXZX9U+03kB6yYNw7ffwo/AgiHEC4m7mmz1nz87qACPQhA4A2gAGItUGGjy5qNeV0nTYUzzX4PlNFUvkDzwuUNuD0Uyk+LHgeUOi3zo8S0WzKvjjCPYva4lDoofwsmu9KS95juesaxPDN+GY0FJJrHJ1v4PWxKTDAfGQy4rQB8M2WVKLqqHGy2RdsrKuGoWSPYiiaNjbS/yGBQ3RMo3+TF0Vj+/I5NXWj+2u7Acr0hCbmGbfbdWgd60/5xtmOBM4JPq5p9sofY43W4tfP3+wfyn/++Bfn+91nYJBxS0VlLQoMFGCIvYu6FnvXcenindtMQ++htMT8u11dPH1vWiYUFiyhFcsRiYxq2WO6Qm86NozUkRBFLLl7VU0HcL+F14iHNAg4rRuyYINgg5H4UZJHiglRbxW2AxhVEuRi+qa53CwnF0t7hY30cUsWIbD/jdBj4JP0zC6ozBkul4Teu34Tua7vj124tQduz73xtxOvbGVoZtMbN/xnIyMlSixUbxcwZFln/qn9DX2ue2wxRxgAE93q6b3wR9BYJa/RAIAAA=="
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/skyblock/bazaar": {
+      "get": {
+        "summary": "Bazaar",
+        "description": "Returns the list of products along with their sell summary, buy summary and quick status.\n ### Product Description\n The returned product info has 3 main fields:\n - `buy_summary`\n - `sell_summary`\n - `quick_status`\n\n`buy_summary` and `sell_summary` are the current top 30 orders for each transaction type (in-game example: [Stock of Stonks](https://i.imgur.com/SjRONxq.png)).\n\n`quick_status` is a computed summary of the live state of the product (used for advanced mode view in the bazaar):\n- `sellVolume` and `buyVolume` are the sum of item amounts in all orders.\n - `sellPrice` and `buyPrice` are the weighted average of the top 2% of orders by volume.\n - `movingWeek` is the historic transacted volume from last 7d + live state.\n - `sellOrders` and `buyOrders` are the count of active orders. ",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "lastUpdated": {
+                      "type": "number",
+                      "format": "int64",
+                      "example": 1590854517479
+                    },
+                    "products": {
+                      "type": "object",
+                      "example": {
+                        "INK_SACK:3": {
+                          "product_id": "INK_SACK:3",
+                          "sell_summary": [
+                            {
+                              "amount": 20569,
+                              "pricePerUnit": 4.2,
+                              "orders": 1
+                            },
+                            {
+                              "amount": 140326,
+                              "pricePerUnit": 3.8,
+                              "orders": 2
+                            }
+                          ],
+                          "buy_summary": [
+                            {
+                              "amount": 640,
+                              "pricePerUnit": 4.8,
+                              "orders": 1
+                            },
+                            {
+                              "amount": 640,
+                              "pricePerUnit": 4.9,
+                              "orders": 1
+                            },
+                            {
+                              "amount": 25957,
+                              "pricePerUnit": 5,
+                              "orders": 3
+                            }
+                          ],
+                          "quick_status": {
+                            "productId": "INK_SACK:3",
+                            "sellPrice": 4.2,
+                            "sellVolume": 409855,
+                            "sellMovingWeek": 8301075,
+                            "sellOrders": 11,
+                            "buyPrice": 4.99260315136572,
+                            "buyVolume": 1254854,
+                            "buyMovingWeek": 5830656,
+                            "buyOrders": 85
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "503": {
+            "$ref": "#/components/responses/NotPopulated"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/profile": {
+      "get": {
+        "summary": "Profile by UUID",
+        "description": "SkyBlock profile data, such as stats, objectives etc. The data returned can differ depending on the players in-game API settings.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "profile": {
+                      "$ref": "#/components/schemas/SkyBlockProfile"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/profiles": {
+      "get": {
+        "summary": "Profiles by player",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "profiles": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkyBlockProfile"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/museum": {
+      "get": {
+        "summary": "Museum data by profile ID",
+        "description": "SkyBlock museum data for all members of the provided profile. The data returned can differ depending on the players in-game API settings.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "profile": {
+                      "$ref": "#/components/schemas/SkyBlockMuseum"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/garden": {
+      "get": {
+        "summary": "Garden data by profile ID",
+        "description": "SkyBlock garden data for the provided profile.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "profile",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "garden": {
+                      "$ref": "#/components/schemas/SkyBlockGarden"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "404": {
+            "$ref": "#/components/responses/NoResult"
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/bingo": {
+      "get": {
+        "summary": "Bingo data by player",
+        "description": "Bingo data for participated events of the provided player.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "uuid",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "events": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "required": [
+                          "key",
+                          "points",
+                          "completed_goals"
+                        ],
+                        "properties": {
+                          "key": {
+                            "description": "The id for this event",
+                            "type": "number",
+                            "format": "int32",
+                            "example": 2
+                          },
+                          "points": {
+                            "description": "The amount of points earned",
+                            "type": "number",
+                            "format": "int32",
+                            "example": 117
+                          },
+                          "completed_goals": {
+                            "description": "The completed goal IDs",
+                            "type": "array",
+                            "items": {
+                              "type": "string",
+                              "example": [
+                                "stat_walk_speed",
+                                "KILL_TRAPPER_MOB"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/DataMissing"
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "404": {
+            "description": "No data could be found for the provided player uuid.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "example": false
+                    },
+                    "cause": {
+                      "type": "string",
+                      "example": "No bingo data could be found"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "$ref": "#/components/responses/MalformedData"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/skyblock/firesales": {
+      "get": {
+        "summary": "Active/Upcoming Fire Sales",
+        "description": "Retrieve the currently active or upcoming Fire Sales for SkyBlock.",
+        "tags": [
+          "SkyBlock"
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "sales": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/SkyBlockFireSale"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/housing/active": {
+      "get": {
+        "summary": "The currently active public houses.",
+        "description": "This data may be cached for a short period of time.",
+        "tags": [
+          "Housing"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HousingHouse"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/housing/house": {
+      "get": {
+        "summary": "Information about a specific house.",
+        "description": "This data may be cached for a short period of time.",
+        "tags": [
+          "Housing"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "house",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "The UUID of the house to get information about."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HousingHouse"
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "404": {
+            "$ref": "#/components/responses/NoResult"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/housing/houses": {
+      "get": {
+        "summary": "The public houses for a specific player.",
+        "description": "This data may be cached for a short period of time.",
+        "tags": [
+          "Housing"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "player",
+            "schema": {
+              "type": "string"
+            },
+            "description": "The UUID of the player to get houses for."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/HousingHouse"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/boosters": {
+      "get": {
+        "summary": "Active Network Boosters",
+        "tags": [
+          "Other"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Get boosters list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "boosters": {
+                      "type": "array",
+                      "items": {
+                        "oneOf": [
+                          {
+                            "$ref": "#/components/schemas/ActiveBooster"
+                          },
+                          {
+                            "$ref": "#/components/schemas/QueuedBooster"
+                          }
+                        ]
+                      }
+                    },
+                    "boosterState": {
+                      "type": "object",
+                      "properties": {
+                        "decrementing": {
+                          "type": "boolean"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/counts": {
+      "get": {
+        "summary": "Current Player Counts",
+        "tags": [
+          "Other"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "playerCount": {
+                      "type": "integer"
+                    },
+                    "games": {
+                      "type": "object",
+                      "example": {
+                        "GAME_TYPE": {
+                          "players": 2,
+                          "modes": {
+                            "mode_1": 1,
+                            "mode_2": 1
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          }
+        }
+      }
+    },
+    "/v2/leaderboards": {
+      "get": {
+        "summary": "Current Leaderboards",
+        "tags": [
+          "Other"
+        ],
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "leaderboards": {
+                      "type": "object"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/NotPopulated"
+          }
+        }
+      }
+    },
+    "/v2/punishmentstats": {
+      "get": {
+        "tags": [
+          "Other"
+        ],
+        "summary": "Punishment Statistics",
+        "security": [
+          {
+            "ApiKey": []
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "A successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "watchdog_lastMinute": {
+                      "type": "integer"
+                    },
+                    "staff_rollingDaily": {
+                      "type": "integer"
+                    },
+                    "watchdog_total": {
+                      "type": "integer"
+                    },
+                    "watchdog_rollingDaily": {
+                      "type": "integer"
+                    },
+                    "staff_total": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "$ref": "#/components/responses/InvalidKey"
+          },
+          "429": {
+            "$ref": "#/components/responses/RateLimited"
+          },
+          "503": {
+            "$ref": "#/components/responses/NotPopulated"
+          }
+        }
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Housing"
+    },
+    {
+      "name": "Other"
+    },
+    {
+      "name": "Player Data"
+    },
+    {
+      "name": "Resources"
+    },
+    {
+      "name": "SkyBlock"
+    }
+  ]
+}

--- a/apis/openapi/igdb.com/igdb/4.0.0/openapi.json
+++ b/apis/openapi/igdb.com/igdb/4.0.0/openapi.json
@@ -1,0 +1,1237 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IGDB API",
+    "description": "The Internet Game Database (IGDB) API provides access to a comprehensive video game database including games, platforms, characters, companies, and more. The API uses Apicalypse query language sent as POST request bodies to filter, sort, and select fields.",
+    "version": "4.0.0",
+    "contact": {
+      "name": "IGDB",
+      "url": "https://api-docs.igdb.com"
+    },
+    "x-jentic-source-url": "https://api-docs.igdb.com"
+  },
+  "servers": [
+    {
+      "url": "https://api.igdb.com/v4",
+      "description": "IGDB API v4 Production"
+    }
+  ],
+  "security": [
+    {
+      "clientId": [],
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    { "name": "Games", "description": "Game information and metadata" },
+    { "name": "Platforms", "description": "Gaming platforms" },
+    { "name": "Characters", "description": "Game characters" },
+    { "name": "Companies", "description": "Game companies and publishers" },
+    { "name": "Genres", "description": "Game genres" },
+    { "name": "Themes", "description": "Game themes" },
+    { "name": "Franchises", "description": "Game franchises and series" },
+    { "name": "Covers", "description": "Game cover artwork" },
+    { "name": "Screenshots", "description": "Game screenshots" },
+    { "name": "Videos", "description": "Game videos" },
+    { "name": "Collections", "description": "Game collections" },
+    { "name": "Search", "description": "Multi-search across resources" },
+    { "name": "Release Dates", "description": "Game release dates" },
+    { "name": "Involved Companies", "description": "Companies involved in game development" },
+    { "name": "Age Ratings", "description": "Age rating information" }
+  ],
+  "paths": {
+    "/games": {
+      "post": {
+        "operationId": "queryGames",
+        "summary": "Query games",
+        "description": "Query the games database using Apicalypse query language in the request body. Supports fields, where, sort, limit, offset, search, and exclude.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Game" }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/games/count": {
+      "post": {
+        "operationId": "countGames",
+        "summary": "Count games",
+        "description": "Returns the count of games matching the query.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CountResult" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/platforms": {
+      "post": {
+        "operationId": "queryPlatforms",
+        "summary": "Query platforms",
+        "description": "Query gaming platforms using Apicalypse query language.",
+        "tags": ["Platforms"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Platform" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/platform_families": {
+      "post": {
+        "operationId": "queryPlatformFamilies",
+        "summary": "Query platform families",
+        "description": "Query platform families (e.g., PlayStation, Xbox, Nintendo).",
+        "tags": ["Platforms"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/PlatformFamily" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/platform_logos": {
+      "post": {
+        "operationId": "queryPlatformLogos",
+        "summary": "Query platform logos",
+        "description": "Query platform logo images.",
+        "tags": ["Platforms"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Image" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/characters": {
+      "post": {
+        "operationId": "queryCharacters",
+        "summary": "Query characters",
+        "description": "Query video game characters using Apicalypse query language.",
+        "tags": ["Characters"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Character" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/character_mug_shots": {
+      "post": {
+        "operationId": "queryCharacterMugShots",
+        "summary": "Query character mug shots",
+        "description": "Query character portrait images.",
+        "tags": ["Characters"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Image" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/companies": {
+      "post": {
+        "operationId": "queryCompanies",
+        "summary": "Query companies",
+        "description": "Query game companies and publishers using Apicalypse query language.",
+        "tags": ["Companies"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Company" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "429": { "$ref": "#/components/responses/TooManyRequests" }
+        }
+      }
+    },
+    "/company_logos": {
+      "post": {
+        "operationId": "queryCompanyLogos",
+        "summary": "Query company logos",
+        "description": "Query company logo images.",
+        "tags": ["Companies"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Image" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/genres": {
+      "post": {
+        "operationId": "queryGenres",
+        "summary": "Query genres",
+        "description": "Query game genres.",
+        "tags": ["Genres"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Genre" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/themes": {
+      "post": {
+        "operationId": "queryThemes",
+        "summary": "Query themes",
+        "description": "Query game themes.",
+        "tags": ["Themes"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Theme" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/game_modes": {
+      "post": {
+        "operationId": "queryGameModes",
+        "summary": "Query game modes",
+        "description": "Query game modes (single player, multiplayer, etc.).",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/GameMode" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/player_perspectives": {
+      "post": {
+        "operationId": "queryPlayerPerspectives",
+        "summary": "Query player perspectives",
+        "description": "Query player perspectives (first person, third person, etc.).",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/PlayerPerspective" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/franchises": {
+      "post": {
+        "operationId": "queryFranchises",
+        "summary": "Query franchises",
+        "description": "Query game franchises.",
+        "tags": ["Franchises"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Franchise" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/collections": {
+      "post": {
+        "operationId": "queryCollections",
+        "summary": "Query collections",
+        "description": "Query game collections (series of games).",
+        "tags": ["Collections"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Collection" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/covers": {
+      "post": {
+        "operationId": "queryCovers",
+        "summary": "Query covers",
+        "description": "Query game cover artwork.",
+        "tags": ["Covers"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Cover" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/screenshots": {
+      "post": {
+        "operationId": "queryScreenshots",
+        "summary": "Query screenshots",
+        "description": "Query game screenshots.",
+        "tags": ["Screenshots"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Screenshot" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/artworks": {
+      "post": {
+        "operationId": "queryArtworks",
+        "summary": "Query artworks",
+        "description": "Query game artwork images.",
+        "tags": ["Covers"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Image" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/game_videos": {
+      "post": {
+        "operationId": "queryGameVideos",
+        "summary": "Query game videos",
+        "description": "Query game video references (YouTube IDs).",
+        "tags": ["Videos"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/GameVideo" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/involved_companies": {
+      "post": {
+        "operationId": "queryInvolvedCompanies",
+        "summary": "Query involved companies",
+        "description": "Query companies involved in game development or publishing.",
+        "tags": ["Involved Companies"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/InvolvedCompany" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/release_dates": {
+      "post": {
+        "operationId": "queryReleaseDates",
+        "summary": "Query release dates",
+        "description": "Query game release dates by platform and region.",
+        "tags": ["Release Dates"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ReleaseDate" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/age_ratings": {
+      "post": {
+        "operationId": "queryAgeRatings",
+        "summary": "Query age ratings",
+        "description": "Query game age ratings (ESRB, PEGI, etc.).",
+        "tags": ["Age Ratings"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/AgeRating" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/age_rating_content_descriptions": {
+      "post": {
+        "operationId": "queryAgeRatingContentDescriptions",
+        "summary": "Query age rating content descriptions",
+        "description": "Query content descriptions associated with age ratings.",
+        "tags": ["Age Ratings"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/AgeRatingContentDescription" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/game_engines": {
+      "post": {
+        "operationId": "queryGameEngines",
+        "summary": "Query game engines",
+        "description": "Query game engines (Unreal, Unity, etc.).",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/GameEngine" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/game_engine_logos": {
+      "post": {
+        "operationId": "queryGameEngineLogos",
+        "summary": "Query game engine logos",
+        "description": "Query game engine logo images.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Image" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/keywords": {
+      "post": {
+        "operationId": "queryKeywords",
+        "summary": "Query keywords",
+        "description": "Query game keywords/tags.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Keyword" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/websites": {
+      "post": {
+        "operationId": "queryWebsites",
+        "summary": "Query websites",
+        "description": "Query game-related website URLs.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Website" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/alternative_names": {
+      "post": {
+        "operationId": "queryAlternativeNames",
+        "summary": "Query alternative names",
+        "description": "Query alternative names for games.",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/AlternativeName" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/external_games": {
+      "post": {
+        "operationId": "queryExternalGames",
+        "summary": "Query external games",
+        "description": "Query external game references (Steam, GOG, etc.).",
+        "tags": ["Games"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/ExternalGame" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/multiquery": {
+      "post": {
+        "operationId": "multiQuery",
+        "summary": "Multi-query",
+        "description": "Execute multiple queries in a single request using the multi-query endpoint.",
+        "tags": ["Search"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response with results from multiple queries",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": { "type": "string" },
+                      "count": { "type": "integer" },
+                      "result": {
+                        "type": "array",
+                        "items": { "type": "object" }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/search": {
+      "post": {
+        "operationId": "search",
+        "summary": "Search across resources",
+        "description": "Search across multiple IGDB resources.",
+        "tags": ["Search"],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/ApicalypseQuery"
+        },
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/SearchResult" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "clientId": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Client-ID",
+        "description": "Your Twitch application Client ID"
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "OAuth 2.0 Bearer token obtained from Twitch authentication (https://id.twitch.tv/oauth2/token)"
+      }
+    },
+    "requestBodies": {
+      "ApicalypseQuery": {
+        "description": "Apicalypse query string. Example: 'fields name,genres.name; where rating > 80; sort rating desc; limit 10;'",
+        "required": false,
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string",
+              "example": "fields name, cover.url, rating, genres.name; where rating > 80; sort rating desc; limit 10;"
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid query syntax or parameters",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - missing or invalid Client-ID or access token",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Rate limit exceeded - maximum 4 requests per second",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "status": { "type": "integer" },
+          "cause": { "type": "string" }
+        }
+      },
+      "CountResult": {
+        "type": "object",
+        "properties": {
+          "count": { "type": "integer", "description": "Number of matching records" }
+        }
+      },
+      "Game": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "summary": { "type": "string" },
+          "storyline": { "type": "string" },
+          "rating": { "type": "number", "format": "double", "description": "Average user rating (0-100)" },
+          "aggregated_rating": { "type": "number", "format": "double", "description": "Average critic rating (0-100)" },
+          "total_rating": { "type": "number", "format": "double", "description": "Combined user and critic rating" },
+          "rating_count": { "type": "integer" },
+          "aggregated_rating_count": { "type": "integer" },
+          "total_rating_count": { "type": "integer" },
+          "first_release_date": { "type": "integer", "description": "Unix timestamp" },
+          "created_at": { "type": "integer", "description": "Unix timestamp" },
+          "updated_at": { "type": "integer", "description": "Unix timestamp" },
+          "category": { "type": "integer", "description": "0=main_game, 1=dlc_addon, 2=expansion, 3=bundle, 4=standalone_expansion, 5=mod, 6=episode, 7=season, 8=remake, 9=remaster, 10=expanded_game, 11=port, 12=fork" },
+          "status": { "type": "integer", "description": "0=released, 2=alpha, 3=beta, 4=early_access, 5=offline, 6=cancelled, 7=rumored, 8=delisted" },
+          "cover": { "type": "integer", "description": "Cover ID (expandable)" },
+          "genres": { "type": "array", "items": { "type": "integer" }, "description": "Genre IDs (expandable)" },
+          "themes": { "type": "array", "items": { "type": "integer" }, "description": "Theme IDs (expandable)" },
+          "platforms": { "type": "array", "items": { "type": "integer" }, "description": "Platform IDs (expandable)" },
+          "screenshots": { "type": "array", "items": { "type": "integer" } },
+          "videos": { "type": "array", "items": { "type": "integer" } },
+          "game_modes": { "type": "array", "items": { "type": "integer" } },
+          "player_perspectives": { "type": "array", "items": { "type": "integer" } },
+          "involved_companies": { "type": "array", "items": { "type": "integer" } },
+          "franchises": { "type": "array", "items": { "type": "integer" } },
+          "collection": { "type": "integer" },
+          "game_engines": { "type": "array", "items": { "type": "integer" } },
+          "keywords": { "type": "array", "items": { "type": "integer" } },
+          "websites": { "type": "array", "items": { "type": "integer" } },
+          "similar_games": { "type": "array", "items": { "type": "integer" } },
+          "age_ratings": { "type": "array", "items": { "type": "integer" } },
+          "alternative_names": { "type": "array", "items": { "type": "integer" } },
+          "external_games": { "type": "array", "items": { "type": "integer" } },
+          "release_dates": { "type": "array", "items": { "type": "integer" } },
+          "url": { "type": "string", "format": "uri" },
+          "hypes": { "type": "integer" },
+          "follows": { "type": "integer" }
+        }
+      },
+      "Platform": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "abbreviation": { "type": "string" },
+          "alternative_name": { "type": "string" },
+          "category": { "type": "integer", "description": "1=console, 2=arcade, 3=platform, 4=operating_system, 5=portable_console, 6=computer" },
+          "generation": { "type": "integer" },
+          "platform_family": { "type": "integer" },
+          "platform_logo": { "type": "integer" },
+          "summary": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "PlatformFamily": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "description": { "type": "string" },
+          "gender": { "type": "integer", "description": "0=male, 1=female, 2=other" },
+          "species": { "type": "integer", "description": "1=human, 2=alien, 3=animal, 4=android, 5=unknown" },
+          "mug_shot": { "type": "integer" },
+          "games": { "type": "array", "items": { "type": "integer" } },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Company": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "description": { "type": "string" },
+          "country": { "type": "integer", "description": "ISO 3166-1 country code" },
+          "logo": { "type": "integer" },
+          "developed": { "type": "array", "items": { "type": "integer" } },
+          "published": { "type": "array", "items": { "type": "integer" } },
+          "parent": { "type": "integer" },
+          "start_date": { "type": "integer" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Genre": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Theme": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "GameMode": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "PlayerPerspective": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Franchise": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "games": { "type": "array", "items": { "type": "integer" } },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Collection": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "games": { "type": "array", "items": { "type": "integer" } },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Cover": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "image_id": { "type": "string" },
+          "url": { "type": "string" },
+          "width": { "type": "integer" },
+          "height": { "type": "integer" },
+          "animated": { "type": "boolean" }
+        }
+      },
+      "Screenshot": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "image_id": { "type": "string" },
+          "url": { "type": "string" },
+          "width": { "type": "integer" },
+          "height": { "type": "integer" }
+        }
+      },
+      "Image": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "image_id": { "type": "string" },
+          "url": { "type": "string" },
+          "width": { "type": "integer" },
+          "height": { "type": "integer" },
+          "animated": { "type": "boolean" }
+        }
+      },
+      "GameVideo": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "name": { "type": "string" },
+          "video_id": { "type": "string", "description": "YouTube video ID" }
+        }
+      },
+      "InvolvedCompany": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "company": { "type": "integer" },
+          "game": { "type": "integer" },
+          "developer": { "type": "boolean" },
+          "publisher": { "type": "boolean" },
+          "porting": { "type": "boolean" },
+          "supporting": { "type": "boolean" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "ReleaseDate": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "platform": { "type": "integer" },
+          "date": { "type": "integer", "description": "Unix timestamp" },
+          "human": { "type": "string", "description": "Human readable date string" },
+          "category": { "type": "integer", "description": "0=YYYYMMMMDD, 1=YYYYMMMM, 2=YYYY, 3=YYYYQ1-Q4, 4=TBD" },
+          "region": { "type": "integer", "description": "1=europe, 2=north_america, 3=australia, 4=new_zealand, 5=japan, 6=china, 7=asia, 8=worldwide, 9=korea, 10=brazil" },
+          "y": { "type": "integer" },
+          "m": { "type": "integer" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "AgeRating": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "category": { "type": "integer", "description": "1=ESRB, 2=PEGI" },
+          "rating": { "type": "integer" },
+          "content_descriptions": { "type": "array", "items": { "type": "integer" } },
+          "synopsis": { "type": "string" }
+        }
+      },
+      "AgeRatingContentDescription": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "category": { "type": "integer" },
+          "description": { "type": "string" }
+        }
+      },
+      "GameEngine": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "description": { "type": "string" },
+          "logo": { "type": "integer" },
+          "companies": { "type": "array", "items": { "type": "integer" } },
+          "platforms": { "type": "array", "items": { "type": "integer" } },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Keyword": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "Website": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "category": { "type": "integer", "description": "1=official, 2=wikia, 3=wikipedia, 4=facebook, 5=twitter, 6=twitch, 8=instagram, 9=youtube, 10=iphone, 11=ipad, 12=android, 13=steam, 14=reddit, 15=itch, 16=epicgames, 17=gog, 18=discord" },
+          "url": { "type": "string", "format": "uri" },
+          "trusted": { "type": "boolean" }
+        }
+      },
+      "AlternativeName": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "name": { "type": "string" },
+          "comment": { "type": "string" }
+        }
+      },
+      "ExternalGame": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "game": { "type": "integer" },
+          "category": { "type": "integer", "description": "1=steam, 5=gog, 10=youtube, 11=microsoft, 13=apple, 14=twitch, 15=android, 20=amazon_asin, 22=amazon_luna, 23=amazon_adg, 26=epic_game_store, 28=oculus, 29=utomik, 30=itch_io, 31=xbox_marketplace, 32=kartridge, 36=playstation_store_us, 37=focus_entertainment, 54=xbox_game_pass_ultimate_cloud, 55=gamejolt" },
+          "uid": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "created_at": { "type": "integer" },
+          "updated_at": { "type": "integer" }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "alternative_name": { "type": "string" },
+          "character": { "type": "integer" },
+          "collection": { "type": "integer" },
+          "company": { "type": "integer" },
+          "game": { "type": "integer" },
+          "platform": { "type": "integer" },
+          "theme": { "type": "integer" },
+          "description": { "type": "string" },
+          "published_at": { "type": "integer" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/igdb.com/igdb/meta.json
+++ b/apis/openapi/igdb.com/igdb/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "f404ae52f5232e3001cdcc49bab8e412",
+    "format": "openapi",
+    "vendor": "igdb.com",
+    "api_name": "igdb",
+    "friendly_id": "igdb.com/igdb"
+  }
+}

--- a/apis/openapi/ipapi.com/ipapi/1.0.0/openapi.json
+++ b/apis/openapi/ipapi.com/ipapi/1.0.0/openapi.json
@@ -1,0 +1,554 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "ipapi - IP Geolocation API",
+    "description": "ipapi provides a REST API for IP address geolocation and reverse IP lookup. Get location data, timezone, currency, and connection details for any IPv4 or IPv6 address.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "ipapi Support",
+      "url": "https://ipapi.com/contact"
+    },
+    "x-jentic-source-url": "https://ipapi.com/"
+  },
+  "servers": [
+    {
+      "url": "https://api.ipapi.com",
+      "description": "ipapi Production API (HTTPS - paid plans)"
+    },
+    {
+      "url": "http://api.ipapi.com",
+      "description": "ipapi Production API (HTTP - free plan)"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "IP Lookup",
+      "description": "Single IP address geolocation lookups"
+    },
+    {
+      "name": "Bulk Lookup",
+      "description": "Bulk IP address lookups"
+    }
+  ],
+  "paths": {
+    "/check": {
+      "get": {
+        "operationId": "lookupRequesterIp",
+        "summary": "Requester IP Lookup",
+        "description": "Look up geolocation data for the IP address of the client making the API request.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{ip}": {
+      "get": {
+        "operationId": "lookupSingleIp",
+        "summary": "Standard IP Lookup",
+        "description": "Look up geolocation data for a single IPv4 or IPv6 address.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "path",
+            "required": true,
+            "description": "IPv4 or IPv6 address to look up.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "134.201.250.155"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{ips}": {
+      "get": {
+        "operationId": "lookupBulkIps",
+        "summary": "Bulk IP Lookup",
+        "description": "Look up geolocation data for multiple IP addresses at once (comma-separated). Available on Professional plan and higher.",
+        "tags": ["Bulk Lookup"],
+        "parameters": [
+          {
+            "name": "ips",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of IPv4 or IPv6 addresses (up to 50).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "134.201.250.155,72.229.28.185"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful bulk geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeolocationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "access_key",
+        "description": "API access key obtained from your ipapi dashboard."
+      }
+    },
+    "parameters": {
+      "AccessKey": {
+        "name": "access_key",
+        "in": "query",
+        "required": true,
+        "description": "Your ipapi API access key.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Fields": {
+        "name": "fields",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated list of response fields to return.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Hostname": {
+        "name": "hostname",
+        "in": "query",
+        "required": false,
+        "description": "Set to 1 to include the hostname for the IP address.",
+        "schema": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      },
+      "Security": {
+        "name": "security",
+        "in": "query",
+        "required": false,
+        "description": "Set to 1 to include security module data in the response.",
+        "schema": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      },
+      "Language": {
+        "name": "language",
+        "in": "query",
+        "required": false,
+        "description": "2-letter language code to localize output.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Callback": {
+        "name": "callback",
+        "in": "query",
+        "required": false,
+        "description": "JSONP callback function name.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Output": {
+        "name": "output",
+        "in": "query",
+        "required": false,
+        "description": "Set to 'xml' to receive XML output instead of JSON.",
+        "schema": {
+          "type": "string",
+          "enum": ["json", "xml"]
+        }
+      }
+    },
+    "schemas": {
+      "GeolocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "description": "The requested IP address."
+          },
+          "hostname": {
+            "type": "string",
+            "description": "Hostname for the IP address (if enabled)."
+          },
+          "type": {
+            "type": "string",
+            "description": "IP address type.",
+            "enum": ["ipv4", "ipv6"]
+          },
+          "continent_code": {
+            "type": "string",
+            "description": "2-letter continent code."
+          },
+          "continent_name": {
+            "type": "string",
+            "description": "Full continent name."
+          },
+          "country_code": {
+            "type": "string",
+            "description": "2-letter country code (ISO 3166-1 alpha-2)."
+          },
+          "country_name": {
+            "type": "string",
+            "description": "Full country name."
+          },
+          "region_code": {
+            "type": "string",
+            "description": "Region/state code."
+          },
+          "region_name": {
+            "type": "string",
+            "description": "Full region/state name."
+          },
+          "city": {
+            "type": "string",
+            "description": "City name."
+          },
+          "zip": {
+            "type": "string",
+            "description": "ZIP or postal code."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude."
+          },
+          "location": {
+            "$ref": "#/components/schemas/Location"
+          },
+          "time_zone": {
+            "$ref": "#/components/schemas/TimeZone"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/Connection"
+          },
+          "security": {
+            "$ref": "#/components/schemas/Security"
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "geoname_id": {
+            "type": "integer",
+            "description": "GeoNames ID."
+          },
+          "capital": {
+            "type": "string",
+            "description": "Capital city of the country."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "code": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "native": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "country_flag": {
+            "type": "string",
+            "description": "URL of the country flag SVG."
+          },
+          "country_flag_emoji": {
+            "type": "string",
+            "description": "Country flag emoji."
+          },
+          "country_flag_emoji_unicode": {
+            "type": "string",
+            "description": "Country flag emoji unicode."
+          },
+          "calling_code": {
+            "type": "string",
+            "description": "International calling code."
+          },
+          "is_eu": {
+            "type": "boolean",
+            "description": "Whether the country is in the EU."
+          }
+        }
+      },
+      "TimeZone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Timezone identifier."
+          },
+          "current_time": {
+            "type": "string",
+            "description": "Current time in the timezone."
+          },
+          "gmt_offset": {
+            "type": "integer",
+            "description": "GMT offset in seconds."
+          },
+          "code": {
+            "type": "string",
+            "description": "Timezone abbreviation."
+          },
+          "is_daylight_saving": {
+            "type": "boolean",
+            "description": "Whether DST is active."
+          }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "3-letter currency code."
+          },
+          "name": {
+            "type": "string",
+            "description": "Currency name."
+          },
+          "plural": {
+            "type": "string",
+            "description": "Plural currency name."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Currency symbol."
+          },
+          "symbol_native": {
+            "type": "string",
+            "description": "Native currency symbol."
+          }
+        }
+      },
+      "Connection": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "type": "integer",
+            "description": "Autonomous System Number."
+          },
+          "isp": {
+            "type": "string",
+            "description": "ISP name."
+          }
+        }
+      },
+      "Security": {
+        "type": "object",
+        "description": "Security assessment data (paid plans).",
+        "properties": {
+          "is_proxy": {
+            "type": "boolean"
+          },
+          "proxy_type": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_crawler": {
+            "type": "boolean"
+          },
+          "crawler_name": {
+            "type": "string",
+            "nullable": true
+          },
+          "crawler_type": {
+            "type": "string",
+            "nullable": true
+          },
+          "is_tor": {
+            "type": "boolean"
+          },
+          "threat_level": {
+            "type": "string",
+            "enum": ["low", "medium", "high"]
+          },
+          "threat_types": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "integer",
+                "description": "Error code."
+              },
+              "type": {
+                "type": "string",
+                "description": "Error type identifier."
+              },
+              "info": {
+                "type": "string",
+                "description": "Human-readable error description."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/ipapi.com/ipapi/meta.json
+++ b/apis/openapi/ipapi.com/ipapi/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "4d2704c98996b817defc9244d7edbec8",
+    "format": "openapi",
+    "vendor": "ipapi.com",
+    "api_name": "ipapi",
+    "friendly_id": "ipapi.com/ipapi"
+  }
+}

--- a/apis/openapi/ipgeolocation.io/ipgeolocation/3.0.0/openapi.json
+++ b/apis/openapi/ipgeolocation.io/ipgeolocation/3.0.0/openapi.json
@@ -1,0 +1,1020 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "ipgeolocation.io API",
+    "description": "ipgeolocation.io provides a comprehensive suite of IP-based geolocation APIs including IP geolocation, IP security/threat detection, ASN lookup, timezone, astronomy, and user-agent parsing. All endpoints are served over HTTPS with API key authentication.",
+    "version": "3.0.0",
+    "contact": {
+      "name": "ipgeolocation.io",
+      "url": "https://ipgeolocation.io"
+    },
+    "x-jentic-source-url": "https://ipgeolocation.io/"
+  },
+  "servers": [
+    {
+      "url": "https://api.ipgeolocation.io",
+      "description": "Production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "IP Geolocation",
+      "description": "IP address geolocation lookup"
+    },
+    {
+      "name": "IP Security",
+      "description": "IP threat and security detection"
+    },
+    {
+      "name": "ASN",
+      "description": "Autonomous System Number lookup"
+    },
+    {
+      "name": "Timezone",
+      "description": "Timezone and time conversion"
+    },
+    {
+      "name": "Astronomy",
+      "description": "Sun and moon rise/set times"
+    },
+    {
+      "name": "User Agent",
+      "description": "User-agent string parsing"
+    }
+  ],
+  "paths": {
+    "/v3/ipgeo": {
+      "get": {
+        "tags": ["IP Geolocation"],
+        "summary": "Single IP geolocation lookup",
+        "description": "Look up geolocation data for a single IPv4/IPv6 address or domain name. Omit the ip parameter to detect the caller's IP.",
+        "operationId": "getIpGeolocation",
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "description": "IPv4, IPv6, or domain name to look up. Omit to detect caller IP.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Response language (en, de, ru, ja, fr, cn, es, cs, it, ko, fa, pt)",
+            "schema": { "type": "string", "default": "en" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "description": "Comma-separated fields to include in response",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludes",
+            "in": "query",
+            "description": "Comma-separated fields/objects to exclude from response",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Optional modules: geo_accuracy, dma_code, user_agent, security, abuse, hostname, liveHostname, hostnameFallbackLive",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/IpGeolocationResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - malformed request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid API key or unauthorized feature access"
+          },
+          "429": {
+            "description": "Rate limit exceeded (free plan: 1000 requests/day)"
+          }
+        }
+      }
+    },
+    "/v3/ipgeo-bulk": {
+      "post": {
+        "tags": ["IP Geolocation"],
+        "summary": "Bulk IP geolocation lookup",
+        "description": "Look up geolocation data for up to 50,000 IP addresses or domain names in a single request.",
+        "operationId": "bulkIpGeolocation",
+        "parameters": [
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludes",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BulkIpRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful bulk lookup response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/IpGeolocationResponse" }
+                }
+              }
+            }
+          },
+          "400": { "description": "Bad request" },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/security": {
+      "get": {
+        "tags": ["IP Security"],
+        "summary": "IP security lookup",
+        "description": "Detect threats, proxies, VPNs, Tor exit nodes, and other suspicious IP addresses. Each lookup costs 2 credits.",
+        "operationId": "getIpSecurity",
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "query",
+            "description": "IPv4 or IPv6 address. Omit to detect caller IP.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludes",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "output",
+            "in": "query",
+            "description": "Response format: json or xml",
+            "schema": { "type": "string", "enum": ["json", "xml"], "default": "json" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful security lookup",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SecurityResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/security-bulk": {
+      "post": {
+        "tags": ["IP Security"],
+        "summary": "Bulk IP security lookup",
+        "description": "Check security data for up to 50,000 IPs in a single request. Each valid IP costs 2 credits.",
+        "operationId": "bulkIpSecurity",
+        "parameters": [
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludes",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "output",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["json", "xml"] }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/BulkIpRequest" }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful bulk security response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/SecurityResponse" }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v3/asn": {
+      "get": {
+        "tags": ["ASN"],
+        "summary": "ASN lookup",
+        "description": "Get detailed information about an Autonomous System Number by ASN or IP address.",
+        "operationId": "getAsn",
+        "parameters": [
+          {
+            "name": "asn",
+            "in": "query",
+            "description": "AS number to query (e.g., AS24940)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "description": "IP address to query for ASN information",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Comma-separated optional data: peers, downstreams, upstreams, routes, whois_response",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludes",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful ASN lookup",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AsnResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/timezone": {
+      "get": {
+        "tags": ["Timezone"],
+        "summary": "Timezone lookup",
+        "description": "Get timezone and date/time information using timezone name, IP address, coordinates, address, or airport/locode codes.",
+        "operationId": "getTimezone",
+        "parameters": [
+          {
+            "name": "tz",
+            "in": "query",
+            "description": "IANA timezone name (e.g., America/New_York)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "description": "IPv4 or IPv6 address",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "description": "Address string (e.g., London, UK)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "description": "Latitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "long",
+            "in": "query",
+            "description": "Longitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "iata_code",
+            "in": "query",
+            "description": "3-letter IATA airport code",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "icao_code",
+            "in": "query",
+            "description": "4-letter ICAO airport code",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lo_code",
+            "in": "query",
+            "description": "5-character UN/LOCODE",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Response language",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful timezone lookup",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TimezoneResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/timezone/convert": {
+      "get": {
+        "tags": ["Timezone"],
+        "summary": "Convert time between timezones",
+        "description": "Convert a timestamp from one timezone/location to another.",
+        "operationId": "convertTimezone",
+        "parameters": [
+          {
+            "name": "tz_from",
+            "in": "query",
+            "description": "Source IANA timezone name",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "tz_to",
+            "in": "query",
+            "description": "Target IANA timezone name",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "location_from",
+            "in": "query",
+            "description": "Source address string",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "location_to",
+            "in": "query",
+            "description": "Target address string",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lat_from",
+            "in": "query",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "long_from",
+            "in": "query",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "lat_to",
+            "in": "query",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "long_to",
+            "in": "query",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "time",
+            "in": "query",
+            "description": "Timestamp to convert (yyyy-MM-dd HH:mm or yyyy-MM-dd HH:mm:ss)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful time conversion",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TimeConversionResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/astronomy": {
+      "get": {
+        "tags": ["Astronomy"],
+        "summary": "Astronomy data lookup",
+        "description": "Get sun rise/set, moon rise/set, twilight phases, golden hour, and other astronomical data for a location and date.",
+        "operationId": "getAstronomy",
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "description": "Address string (e.g., New York, USA)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "description": "Latitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "long",
+            "in": "query",
+            "description": "Longitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "description": "IP address for location detection",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "description": "Date in YYYY-MM-DD format",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "elevation",
+            "in": "query",
+            "description": "Height above sea level in meters (0-10000)",
+            "schema": { "type": "number", "minimum": 0, "maximum": 10000 }
+          },
+          {
+            "name": "time_zone",
+            "in": "query",
+            "description": "IANA timezone for event time conversion",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful astronomy lookup",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AstronomyResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/astronomy/timeSeries": {
+      "get": {
+        "tags": ["Astronomy"],
+        "summary": "Astronomy time series",
+        "description": "Get astronomy data over a date range (max 90-day span).",
+        "operationId": "getAstronomyTimeSeries",
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "description": "Latitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "long",
+            "in": "query",
+            "description": "Longitude",
+            "schema": { "type": "number", "format": "double" }
+          },
+          {
+            "name": "dateStart",
+            "in": "query",
+            "required": true,
+            "description": "Start date in YYYY-MM-DD format",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "dateEnd",
+            "in": "query",
+            "required": true,
+            "description": "End date in YYYY-MM-DD format (max 90 days from start)",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "elevation",
+            "in": "query",
+            "schema": { "type": "number" }
+          },
+          {
+            "name": "time_zone",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful astronomy time series",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/AstronomyResponse" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/user-agent": {
+      "get": {
+        "tags": ["User Agent"],
+        "summary": "Parse user-agent string",
+        "description": "Parse the User-Agent header and return browser, device, and operating system details.",
+        "operationId": "getUserAgent",
+        "responses": {
+          "200": {
+            "description": "Successful user-agent parse",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserAgentResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      },
+      "post": {
+        "tags": ["User Agent"],
+        "summary": "Parse custom user-agent string",
+        "description": "Submit a custom user-agent string for parsing. Paid plans only.",
+        "operationId": "postUserAgent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "uaString": { "type": "string", "description": "User-agent string to parse" }
+                },
+                "required": ["uaString"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful user-agent parse",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/UserAgentResponse" }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/user-agent-bulk": {
+      "post": {
+        "tags": ["User Agent"],
+        "summary": "Bulk user-agent parsing",
+        "description": "Parse up to 50,000 user-agent strings in a single request. Paid plans only.",
+        "operationId": "bulkUserAgent",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "uaStrings": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Array of user-agent strings to parse",
+                    "maxItems": 50000
+                  }
+                },
+                "required": ["uaStrings"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful bulk user-agent parse",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/UserAgentResponse" }
+                }
+              }
+            }
+          },
+          "401": { "description": "Unauthorized" }
+        }
+      }
+    },
+    "/v3/getip": {
+      "get": {
+        "tags": ["IP Geolocation"],
+        "summary": "Get caller's IP address",
+        "description": "Returns the IP address of the calling client. No authentication required.",
+        "operationId": "getCallerIp",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Successful response with caller's IP",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "ip": { "type": "string", "description": "Caller's IP address" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apiKey",
+        "description": "API key for authentication. Free plan allows 1000 requests/day."
+      }
+    },
+    "schemas": {
+      "BulkIpRequest": {
+        "type": "object",
+        "required": ["ips"],
+        "properties": {
+          "ips": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Array of IP addresses or domain names (max 50,000)",
+            "maxItems": 50000
+          }
+        }
+      },
+      "IpGeolocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip": { "type": "string", "description": "Queried IP address" },
+          "location": { "$ref": "#/components/schemas/Location" },
+          "country_metadata": { "$ref": "#/components/schemas/CountryMetadata" },
+          "currency": { "$ref": "#/components/schemas/Currency" },
+          "asn": { "$ref": "#/components/schemas/AsnInfo" },
+          "time_zone": { "$ref": "#/components/schemas/TimeZoneInfo" },
+          "network": { "$ref": "#/components/schemas/NetworkInfo" },
+          "company": { "$ref": "#/components/schemas/CompanyInfo" },
+          "security": { "$ref": "#/components/schemas/SecurityInfo" }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "continent_code": { "type": "string" },
+          "country_code2": { "type": "string" },
+          "country_code3": { "type": "string" },
+          "country_name": { "type": "string" },
+          "state_prov": { "type": "string" },
+          "state_code": { "type": "string" },
+          "district": { "type": "string" },
+          "city": { "type": "string" },
+          "zipcode": { "type": "string" },
+          "latitude": { "type": "number", "format": "double" },
+          "longitude": { "type": "number", "format": "double" }
+        }
+      },
+      "CountryMetadata": {
+        "type": "object",
+        "properties": {
+          "calling_code": { "type": "string" },
+          "tld": { "type": "string" },
+          "languages": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "country_flag": { "type": "string", "format": "uri" },
+          "is_eu": { "type": "boolean" }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string" },
+          "name": { "type": "string" },
+          "symbol": { "type": "string" }
+        }
+      },
+      "AsnInfo": {
+        "type": "object",
+        "properties": {
+          "as_number": { "type": "string" },
+          "organization": { "type": "string" },
+          "country": { "type": "string" },
+          "type": { "type": "string" },
+          "domain": { "type": "string" },
+          "date_allocated": { "type": "string" },
+          "rir": { "type": "string" }
+        }
+      },
+      "TimeZoneInfo": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "offset": { "type": "number" },
+          "offset_with_dst": { "type": "number" },
+          "current_time": { "type": "string" },
+          "current_time_unix": { "type": "number" },
+          "is_dst": { "type": "boolean" },
+          "dst_savings": { "type": "integer" }
+        }
+      },
+      "NetworkInfo": {
+        "type": "object",
+        "properties": {
+          "connection_type": { "type": "string" },
+          "route": { "type": "string" },
+          "is_anycast": { "type": "boolean" }
+        }
+      },
+      "CompanyInfo": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "domain": { "type": "string" }
+        }
+      },
+      "SecurityInfo": {
+        "type": "object",
+        "properties": {
+          "threat_score": { "type": "number", "description": "Risk rating 0-100" },
+          "is_tor": { "type": "boolean" },
+          "is_proxy": { "type": "boolean" },
+          "is_vpn": { "type": "boolean" },
+          "is_residential_proxy": { "type": "boolean" },
+          "is_relay": { "type": "boolean" },
+          "is_anonymous": { "type": "boolean" },
+          "is_known_attacker": { "type": "boolean" },
+          "is_bot": { "type": "boolean" },
+          "is_spam": { "type": "boolean" },
+          "is_cloud_provider": { "type": "boolean" },
+          "cloud_provider_name": { "type": "string" },
+          "proxy_confidence_score": { "type": "number" },
+          "vpn_confidence_score": { "type": "number" },
+          "proxy_last_seen": { "type": "string" },
+          "vpn_last_seen": { "type": "string" },
+          "proxy_provider_names": { "type": "array", "items": { "type": "string" } },
+          "vpn_provider_names": { "type": "array", "items": { "type": "string" } }
+        }
+      },
+      "SecurityResponse": {
+        "type": "object",
+        "properties": {
+          "ip": { "type": "string" },
+          "security": { "$ref": "#/components/schemas/SecurityInfo" }
+        }
+      },
+      "AsnResponse": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "type": "object",
+            "properties": {
+              "as_number": { "type": "string" },
+              "organization": { "type": "string" },
+              "country": { "type": "string" },
+              "asn_name": { "type": "string" },
+              "type": { "type": "string", "enum": ["ISP", "HOSTING", "BUSINESS", "EDUCATION", "GOVERNMENT"] },
+              "domain": { "type": "string" },
+              "date_allocated": { "type": "string" },
+              "rir": { "type": "string" },
+              "allocation_status": { "type": "string" },
+              "num_of_ipv4_routes": { "type": "string" },
+              "num_of_ipv6_routes": { "type": "string" }
+            }
+          },
+          "peers": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AsnPeer" }
+          },
+          "upstreams": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AsnPeer" }
+          },
+          "downstreams": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AsnPeer" }
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "prefix": { "type": "string" },
+                "version": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "AsnPeer": {
+        "type": "object",
+        "properties": {
+          "as_number": { "type": "string" },
+          "description": { "type": "string" },
+          "country": { "type": "string" }
+        }
+      },
+      "TimezoneResponse": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "offset": { "type": "number" },
+              "offset_with_dst": { "type": "number" },
+              "current_time": { "type": "string" },
+              "current_time_unix": { "type": "number" },
+              "date": { "type": "string" },
+              "date_time": { "type": "string" },
+              "time_24": { "type": "string" },
+              "time_12": { "type": "string" },
+              "is_dst": { "type": "boolean" },
+              "dst_exists": { "type": "boolean" },
+              "dst_start": {
+                "type": "object",
+                "properties": {
+                  "utc_time": { "type": "string" },
+                  "duration": { "type": "string" },
+                  "gap": { "type": "boolean" },
+                  "dateTimeAfter": { "type": "string" },
+                  "dateTimeBefore": { "type": "string" },
+                  "overlap": { "type": "boolean" }
+                }
+              },
+              "dst_end": {
+                "type": "object",
+                "properties": {
+                  "utc_time": { "type": "string" },
+                  "duration": { "type": "string" },
+                  "gap": { "type": "boolean" },
+                  "dateTimeAfter": { "type": "string" },
+                  "dateTimeBefore": { "type": "string" },
+                  "overlap": { "type": "boolean" }
+                }
+              }
+            }
+          },
+          "location": { "$ref": "#/components/schemas/Location" }
+        }
+      },
+      "TimeConversionResponse": {
+        "type": "object",
+        "properties": {
+          "original_time": { "type": "string" },
+          "converted_time": { "type": "string" },
+          "diff_hour": { "type": "number" },
+          "diff_min": { "type": "number" }
+        }
+      },
+      "AstronomyResponse": {
+        "type": "object",
+        "properties": {
+          "location": { "$ref": "#/components/schemas/Location" },
+          "date": { "type": "string" },
+          "sunrise": { "type": "string" },
+          "sunset": { "type": "string" },
+          "solar_noon": { "type": "string" },
+          "day_length": { "type": "string" },
+          "moonrise": { "type": "string" },
+          "moonset": { "type": "string" },
+          "moon_phase": { "type": "string" },
+          "moon_illumination_percentage": { "type": "string" },
+          "civil_twilight_begin": { "type": "string" },
+          "civil_twilight_end": { "type": "string" },
+          "nautical_twilight_begin": { "type": "string" },
+          "nautical_twilight_end": { "type": "string" },
+          "astronomical_twilight_begin": { "type": "string" },
+          "astronomical_twilight_end": { "type": "string" },
+          "golden_hour_begin": { "type": "string" },
+          "golden_hour_end": { "type": "string" },
+          "blue_hour_begin": { "type": "string" },
+          "blue_hour_end": { "type": "string" },
+          "sun_altitude": { "type": "number" },
+          "sun_azimuth": { "type": "number" },
+          "sun_distance": { "type": "number" },
+          "moon_altitude": { "type": "number" },
+          "moon_azimuth": { "type": "number" },
+          "moon_distance": { "type": "number" }
+        }
+      },
+      "UserAgentResponse": {
+        "type": "object",
+        "properties": {
+          "user_agent_string": { "type": "string", "description": "Original user-agent string" },
+          "name": { "type": "string", "description": "Agent/browser name" },
+          "type": { "type": "string", "description": "Agent classification type" },
+          "version": { "type": "string", "description": "Agent version" },
+          "version_major": { "type": "string", "description": "Major version number" },
+          "device": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string" },
+              "brand": { "type": "string" },
+              "cpu": { "type": "string" }
+            }
+          },
+          "engine": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string" },
+              "version": { "type": "string" },
+              "version_major": { "type": "string" }
+            }
+          },
+          "os": {
+            "type": "object",
+            "properties": {
+              "name": { "type": "string" },
+              "type": { "type": "string" },
+              "version": { "type": "string" },
+              "version_major": { "type": "string" },
+              "build": { "type": "string" }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": { "type": "string", "description": "Error description" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/ipgeolocation.io/ipgeolocation/meta.json
+++ b/apis/openapi/ipgeolocation.io/ipgeolocation/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "fe77c1bc778c2778450f1df37a6bceba",
+    "format": "openapi",
+    "vendor": "ipgeolocation.io",
+    "api_name": "ipgeolocation",
+    "friendly_id": "ipgeolocation.io/ipgeolocation"
+  }
+}

--- a/apis/openapi/ipinfodb.com/ipinfodb/3.0.0/openapi.json
+++ b/apis/openapi/ipinfodb.com/ipinfodb/3.0.0/openapi.json
@@ -1,0 +1,279 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IPInfoDB API",
+    "description": "IPInfoDB provides a free IP geolocation API that returns the location of an IP address including country, region, city, zip code, latitude, longitude and timezone. The API offers two levels of precision: IP-to-Country and IP-to-City lookups.",
+    "version": "3.0.0",
+    "contact": {
+      "name": "IPInfoDB",
+      "url": "https://www.ipinfodb.com"
+    },
+    "x-jentic-source-url": "https://www.ipinfodb.com/api"
+  },
+  "servers": [
+    {
+      "url": "https://api.ipinfodb.com/v3",
+      "description": "IPInfoDB API v3 server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geolocation",
+      "description": "IP geolocation lookup endpoints"
+    }
+  ],
+  "paths": {
+    "/ip-city/": {
+      "get": {
+        "operationId": "getIpCity",
+        "summary": "IP to City geolocation lookup",
+        "description": "Returns detailed geolocation data for an IP address including country, region, city, zip code, latitude, longitude and timezone.",
+        "tags": ["Geolocation"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "Your API key for authentication.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "required": false,
+            "description": "IP address to look up. If omitted, the caller's IP is used.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Response format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "raw"],
+              "default": "raw"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpCityResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Missing or invalid parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/ip-country/": {
+      "get": {
+        "operationId": "getIpCountry",
+        "summary": "IP to Country geolocation lookup",
+        "description": "Returns country-level geolocation data for an IP address.",
+        "tags": ["Geolocation"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "Your API key for authentication.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "required": false,
+            "description": "IP address to look up. If omitted, the caller's IP is used.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Response format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "raw"],
+              "default": "raw"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful country lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IpCountryResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "key",
+        "in": "query",
+        "description": "API key obtained by registering at ipinfodb.com."
+      }
+    },
+    "schemas": {
+      "IpCityResponse": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "string",
+            "description": "Status of the request (OK or ERROR)."
+          },
+          "statusMessage": {
+            "type": "string",
+            "description": "Additional status information."
+          },
+          "ipAddress": {
+            "type": "string",
+            "description": "The queried IP address."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code."
+          },
+          "countryName": {
+            "type": "string",
+            "description": "Full country name."
+          },
+          "regionName": {
+            "type": "string",
+            "description": "Region or state name."
+          },
+          "cityName": {
+            "type": "string",
+            "description": "City name."
+          },
+          "zipCode": {
+            "type": "string",
+            "description": "Postal or zip code."
+          },
+          "latitude": {
+            "type": "string",
+            "description": "Latitude coordinate."
+          },
+          "longitude": {
+            "type": "string",
+            "description": "Longitude coordinate."
+          },
+          "timeZone": {
+            "type": "string",
+            "description": "Timezone offset (e.g., +09:00)."
+          }
+        }
+      },
+      "IpCountryResponse": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "string",
+            "description": "Status of the request (OK or ERROR)."
+          },
+          "statusMessage": {
+            "type": "string",
+            "description": "Additional status information."
+          },
+          "ipAddress": {
+            "type": "string",
+            "description": "The queried IP address."
+          },
+          "countryCode": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code."
+          },
+          "countryName": {
+            "type": "string",
+            "description": "Full country name."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "string",
+            "description": "ERROR status code.",
+            "example": "ERROR"
+          },
+          "statusMessage": {
+            "type": "string",
+            "description": "Status message."
+          },
+          "message": {
+            "type": "string",
+            "description": "Error detail message.",
+            "example": "Invalid API key."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/ipinfodb.com/ipinfodb/meta.json
+++ b/apis/openapi/ipinfodb.com/ipinfodb/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "d10886f4b46ebf122322c4dcc51a5f95",
+    "format": "openapi",
+    "vendor": "ipinfodb.com",
+    "api_name": "ipinfodb",
+    "friendly_id": "ipinfodb.com/ipinfodb"
+  }
+}

--- a/apis/openapi/ipstack.com/ipstack/1.0.0/openapi.json
+++ b/apis/openapi/ipstack.com/ipstack/1.0.0/openapi.json
@@ -1,0 +1,572 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "IPstack API",
+    "description": "IPstack offers a powerful, real-time IP to geolocation API capable of looking up accurate location data and assessing security threats originating from risky IP addresses. Results are delivered in milliseconds in JSON or XML format.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "IPstack Support",
+      "url": "https://ipstack.com/contact"
+    },
+    "x-jentic-source-url": "https://ipstack.com/"
+  },
+  "servers": [
+    {
+      "url": "https://api.ipstack.com",
+      "description": "IPstack Production API (HTTPS - paid plans)"
+    },
+    {
+      "url": "http://api.ipstack.com",
+      "description": "IPstack Production API (HTTP - free plan)"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "IP Lookup",
+      "description": "IP address geolocation lookups"
+    },
+    {
+      "name": "Bulk Lookup",
+      "description": "Bulk IP address geolocation lookups"
+    }
+  ],
+  "paths": {
+    "/check": {
+      "get": {
+        "operationId": "lookupRequesterIp",
+        "summary": "Requester IP Lookup",
+        "description": "Look up the geolocation data for the IP address of the client making the API request.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{ip}": {
+      "get": {
+        "operationId": "lookupSingleIp",
+        "summary": "Standard IP Lookup",
+        "description": "Look up geolocation data for a single IPv4 or IPv6 address.",
+        "tags": ["IP Lookup"],
+        "parameters": [
+          {
+            "name": "ip",
+            "in": "path",
+            "required": true,
+            "description": "IPv4 or IPv6 address to look up.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "134.201.250.155"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeolocationResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{ips}": {
+      "get": {
+        "operationId": "lookupBulkIps",
+        "summary": "Bulk IP Lookup",
+        "description": "Look up geolocation data for multiple IPv4 or IPv6 addresses at once (comma-separated). Available on Professional Plus plan and higher.",
+        "tags": ["Bulk Lookup"],
+        "parameters": [
+          {
+            "name": "ips",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of IPv4 or IPv6 addresses (up to 50).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "134.201.250.155,72.229.28.185,110.174.165.78"
+          },
+          {
+            "$ref": "#/components/parameters/AccessKey"
+          },
+          {
+            "$ref": "#/components/parameters/Fields"
+          },
+          {
+            "$ref": "#/components/parameters/Hostname"
+          },
+          {
+            "$ref": "#/components/parameters/Security"
+          },
+          {
+            "$ref": "#/components/parameters/Language"
+          },
+          {
+            "$ref": "#/components/parameters/Callback"
+          },
+          {
+            "$ref": "#/components/parameters/Output"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful bulk geolocation lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeolocationResponse"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "access_key",
+        "description": "API access key obtained from the IPstack dashboard."
+      }
+    },
+    "parameters": {
+      "AccessKey": {
+        "name": "access_key",
+        "in": "query",
+        "required": true,
+        "description": "Your IPstack API access key.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Fields": {
+        "name": "fields",
+        "in": "query",
+        "required": false,
+        "description": "Comma-separated list of response fields to return (e.g. 'ip,city,region_name').",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Hostname": {
+        "name": "hostname",
+        "in": "query",
+        "required": false,
+        "description": "Set to 1 to include the hostname for the IP address in the response.",
+        "schema": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      },
+      "Security": {
+        "name": "security",
+        "in": "query",
+        "required": false,
+        "description": "Set to 1 to include the security module data in the response (Professional Plus plan).",
+        "schema": {
+          "type": "integer",
+          "enum": [0, 1]
+        }
+      },
+      "Language": {
+        "name": "language",
+        "in": "query",
+        "required": false,
+        "description": "2-letter language code to localize output (e.g. 'en', 'de', 'es').",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Callback": {
+        "name": "callback",
+        "in": "query",
+        "required": false,
+        "description": "JSONP callback function name.",
+        "schema": {
+          "type": "string"
+        }
+      },
+      "Output": {
+        "name": "output",
+        "in": "query",
+        "required": false,
+        "description": "Set to 'xml' to receive output in XML format instead of JSON.",
+        "schema": {
+          "type": "string",
+          "enum": ["json", "xml"]
+        }
+      }
+    },
+    "schemas": {
+      "GeolocationResponse": {
+        "type": "object",
+        "properties": {
+          "ip": {
+            "type": "string",
+            "description": "The requested IP address."
+          },
+          "hostname": {
+            "type": "string",
+            "description": "Hostname associated with the IP (if hostname lookup is enabled)."
+          },
+          "type": {
+            "type": "string",
+            "description": "IP address type: ipv4 or ipv6.",
+            "enum": ["ipv4", "ipv6"]
+          },
+          "continent_code": {
+            "type": "string",
+            "description": "2-letter continent code."
+          },
+          "continent_name": {
+            "type": "string",
+            "description": "Full continent name."
+          },
+          "country_code": {
+            "type": "string",
+            "description": "2-letter country code (ISO 3166-1 alpha-2)."
+          },
+          "country_name": {
+            "type": "string",
+            "description": "Full country name."
+          },
+          "region_code": {
+            "type": "string",
+            "description": "Region/state code."
+          },
+          "region_name": {
+            "type": "string",
+            "description": "Full region/state name."
+          },
+          "city": {
+            "type": "string",
+            "description": "City name."
+          },
+          "zip": {
+            "type": "string",
+            "description": "ZIP or postal code."
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude of the location."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude of the location."
+          },
+          "location": {
+            "$ref": "#/components/schemas/Location"
+          },
+          "time_zone": {
+            "$ref": "#/components/schemas/TimeZone"
+          },
+          "currency": {
+            "$ref": "#/components/schemas/Currency"
+          },
+          "connection": {
+            "$ref": "#/components/schemas/Connection"
+          },
+          "security": {
+            "$ref": "#/components/schemas/Security"
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "geoname_id": {
+            "type": "integer",
+            "description": "GeoNames ID for the location."
+          },
+          "capital": {
+            "type": "string",
+            "description": "Capital city of the country."
+          },
+          "languages": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "description": "Languages spoken in the country."
+          },
+          "country_flag": {
+            "type": "string",
+            "description": "URL of the country flag image (SVG)."
+          },
+          "country_flag_emoji": {
+            "type": "string",
+            "description": "Country flag emoji."
+          },
+          "country_flag_emoji_unicode": {
+            "type": "string",
+            "description": "Country flag emoji unicode."
+          },
+          "calling_code": {
+            "type": "string",
+            "description": "International calling code."
+          },
+          "is_eu": {
+            "type": "boolean",
+            "description": "Whether the country is in the European Union."
+          }
+        }
+      },
+      "Language": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "2-letter language code."
+          },
+          "name": {
+            "type": "string",
+            "description": "Language name."
+          },
+          "native": {
+            "type": "string",
+            "description": "Language name in its native script."
+          }
+        }
+      },
+      "TimeZone": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Timezone identifier (e.g. 'America/Los_Angeles')."
+          },
+          "current_time": {
+            "type": "string",
+            "description": "Current date and time in the timezone."
+          },
+          "gmt_offset": {
+            "type": "integer",
+            "description": "GMT offset in seconds."
+          },
+          "code": {
+            "type": "string",
+            "description": "Timezone abbreviation (e.g. 'PST')."
+          },
+          "is_daylight_saving": {
+            "type": "boolean",
+            "description": "Whether daylight saving time is active."
+          }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "3-letter currency code (ISO 4217)."
+          },
+          "name": {
+            "type": "string",
+            "description": "Currency name."
+          },
+          "plural": {
+            "type": "string",
+            "description": "Plural name of the currency."
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Currency symbol."
+          },
+          "symbol_native": {
+            "type": "string",
+            "description": "Native currency symbol."
+          }
+        }
+      },
+      "Connection": {
+        "type": "object",
+        "properties": {
+          "asn": {
+            "type": "integer",
+            "description": "Autonomous System Number."
+          },
+          "isp": {
+            "type": "string",
+            "description": "Internet Service Provider name."
+          }
+        }
+      },
+      "Security": {
+        "type": "object",
+        "description": "Security assessment data (Professional Plus plan).",
+        "properties": {
+          "is_proxy": {
+            "type": "boolean",
+            "description": "Whether the IP is associated with a known proxy."
+          },
+          "proxy_type": {
+            "type": "string",
+            "nullable": true,
+            "description": "Type of proxy."
+          },
+          "is_crawler": {
+            "type": "boolean",
+            "description": "Whether the IP is associated with a known crawler."
+          },
+          "crawler_name": {
+            "type": "string",
+            "nullable": true,
+            "description": "Name of the crawler."
+          },
+          "crawler_type": {
+            "type": "string",
+            "nullable": true,
+            "description": "Type of the crawler."
+          },
+          "is_tor": {
+            "type": "boolean",
+            "description": "Whether the IP is a known Tor exit node."
+          },
+          "threat_level": {
+            "type": "string",
+            "description": "Assessed threat level.",
+            "enum": ["low", "medium", "high"]
+          },
+          "threat_types": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Types of threats associated with the IP."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "integer",
+                "description": "Error code.",
+                "example": 101
+              },
+              "type": {
+                "type": "string",
+                "description": "Error type identifier.",
+                "example": "missing_access_key"
+              },
+              "info": {
+                "type": "string",
+                "description": "Human-readable error description.",
+                "example": "You have not supplied an API Access Key."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/ipstack.com/ipstack/meta.json
+++ b/apis/openapi/ipstack.com/ipstack/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "ab011cad0b977493a7e1df0e124fac9e",
+    "format": "openapi",
+    "vendor": "ipstack.com",
+    "api_name": "ipstack",
+    "friendly_id": "ipstack.com/ipstack"
+  }
+}

--- a/apis/openapi/lichess.org/lichess/2.0.130/openapi.json
+++ b/apis/openapi/lichess.org/lichess/2.0.130/openapi.json
@@ -1,0 +1,674 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "2.0.130",
+    "title": "Lichess.org API reference",
+    "contact": {
+      "name": "Lichess.org API",
+      "url": "https://lichess.org/api",
+      "email": "contact@lichess.org"
+    },
+    "x-logo": {
+      "url": "https://lichess1.org/assets/logo/lichess-pad12.svg"
+    },
+    "license": {
+      "name": "AGPL-3.0-or-later",
+      "url": "https://www.gnu.org/licenses/agpl-3.0.txt"
+    },
+    "description": "# Introduction\nWelcome to the reference for the Lichess API! Lichess is free/libre,\nopen-source chess server powered by volunteers and donations.\n- Get help in the [Lichess Discord channel](https://discord.gg/lichess)\n- API demo app with OAuth2 login and gameplay: [source](https://github.com/lichess-org/api-demo) / [demo](https://lichess-org.github.io/api-demo/)\n- API UI app with OAuth2 login and endpoint forms: [source](https://github.com/lichess-org/api-ui) / [website](https://lichess.org/api/ui)\n- [Contribute to this documentation on Github](https://github.com/lichess-org/api)\n- Check out [Lichess widgets to embed in your website](https://lichess.org/developers)\n- [Download all Lichess rated games](https://database.lichess.org/)\n- [Download all Lichess puzzles with themes, ratings and votes](https://database.lichess.org/#puzzles)\n- [Download all evaluated positions](https://database.lichess.org/#evals)\n\n## Endpoint\nAll requests go to `https://lichess.org` (unless otherwise specified).\n\n## Clients\n- [Python general API](https://github.com/lichess-org/berserk)\n- [MicroPython general API](https://github.com/mkomon/uberserk)\n- [Python general API - async](https://pypi.org/project/async-lichess-sdk)\n- [Python Lichess Bot](https://github.com/lichess-bot-devs/lichess-bot)\n- [Python Board API for Certabo](https://github.com/haklein/certabo-lichess)\n- [Java general API](https://github.com/tors42/chariot)\n- [JavaScript & TypeScript general API](https://github.com/devjiwonchoi/equine)\n- [LichessNET - C# API Wrapper](https://github.com/Rabergsel/LichessNET)\n- [.NET general API](https://github.com/Dblike/LichessSharp)\n\n## Rate limiting\nAll requests are rate limited using various strategies,\nto ensure the API remains responsive for everyone.\nOnly make one request at a time.\nIf you receive an HTTP response with a [429 status](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#429),\nyou have exceded one of the rate limits.\nIn most cases, waiting one minute before retrying will be sufficient, but some limits may require longer.\nReduce your request frequency before retrying.\n\n## Streaming with ND-JSON\nSome API endpoints stream their responses as [Newline Delimited JSON a.k.a. **nd-json**](https://github.com/ndjson/ndjson-spec), with one JSON object per line.\n\nHere's a [JavaScript utility function](https://gist.github.com/ornicar/a097406810939cf7be1df8ea30e94f3e) to help reading NDJSON streamed responses.\n\n## Authentication\n### Which authentication method is right for me?\n[Read about the Lichess API authentication methods and code examples](https://github.com/lichess-org/api/blob/master/example/README.md)\n\n### Personal Access Token\nPersonal API access tokens allow you to quickly interact with Lichess API without going through an OAuth flow.\n- [Generate a personal access token](https://lichess.org/account/oauth/token)\n- `curl https://lichess.org/api/account -H \"Authorization: Bearer {token}\"`\n- [NodeJS example](https://github.com/lichess-org/api/tree/master/example/oauth-personal-token)\n\n### Token Security\n- Keep your tokens secret. Do not share them in public repositories or public forums.\n- Your tokens can be used to make your account perform arbitrary actions (within the limits of the tokens' scope). You remain responsible for all activities on your account.\n- Do not hardcode tokens in your application's code. Use environment variables or a secure storage and ensure they are not shipped/exposed to users. Be especially careful that they are not included in frontend bundles or apps that are shipped to users.\n- If you suspect a token has been compromised, revoke it immediately.\n\nTo see your active tokens or revoke them, see [your Personal API access tokens](https://lichess.org/account/oauth/token).\n\n### Authorization Code Flow with PKCE\nThe authorization code flow with PKCE allows your users to **login with Lichess**.\nLichess supports unregistered and public clients (no client authentication, choose any unique client id).\nThe only accepted code challenge method is `S256`.\nAccess tokens are long-lived (expect one year), unless they are revoked.\nRefresh tokens are not supported.\n\nSee the [documentation for the OAuth endpoints](#tag/OAuth) or\nthe [PKCE RFC](https://datatracker.ietf.org/doc/html/rfc7636#section-4) for a precise protocol description.\n\n- [Demo app](https://lichess-org.github.io/api-demo/)\n- [Minimal client-side example](https://github.com/lichess-org/api/tree/master/example/oauth-app)\n- [Flask/Python example](https://github.com/lakinwecker/lichess-oauth-flask)\n- [Java example](https://github.com/tors42/lichess-oauth-pkce-app)\n- [NodeJS Passport strategy to login with Lichess OAuth2](https://www.npmjs.com/package/passport-lichess)\n\n#### Real life examples\n- [PyChess](https://github.com/gbtami/pychess-variants) ([source code](https://github.com/gbtami/pychess-variants))\n- [Lichess4545](https://www.lichess4545.com/) ([source code](https://github.com/cyanfish/heltour))\n- [English Chess Federation](https://ecf.octoknight.com/)\n- [Rotherham Online Chess](https://rotherhamonlinechess.azurewebsites.net/tournaments)\n\n### Token format\nAccess tokens and authorization codes match `^[A-Za-z0-9_]+$`.\nThe length of tokens can be increased without notice. Make sure your application can handle at least 512 characters.\nBy convention tokens have a recognizable prefix, but do not rely on this.\n",
+    "x-jentic-source-url": "https://lichess.org/api"
+  },
+  "servers": [
+    {
+      "url": "https://lichess.org"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Account",
+      "description": "Read and write account information and preferences.\n<https://lichess.org/account/preferences/game-display>\n"
+    },
+    {
+      "name": "Analysis",
+      "description": "Access Lichess cloud evaluations database.\n<https://lichess.org/analysis>\n"
+    },
+    {
+      "name": "Board",
+      "description": "Play on Lichess with physical boards and third-party clients.\nWorks with normal Lichess accounts. Engine play or assistance is [forbidden](https://lichess.org/page/fair-play).\n\n### Features\n- [Stream incoming chess moves](#tag/board/GET/api/board/game/stream/{gameId})\n- [Play chess moves](#tag/board/POST/api/board/game/{gameId}/move/{move})\n- [Read](#tag/board/GET/api/board/game/stream/{gameId}) and [write](#tag/board/POST/api/board/game/{gameId}/chat) in the player and spectator chats\n- [Receive](#tag/board/GET/api/stream/event), [create](#tag/challenges/POST/api/challenge/{username}) and [accept](#tag/challenges/POST/api/challenge/{challengeId}/accept) (or [decline](#tag/challenges/POST/api/challenge/{challengeId}/decline)) challenges\n- [Abort](#tag/board/POST/api/board/game/{gameId}/abort) and [resign](#tag/board/POST/api/board/game/{gameId}/resign) games\n- Compatible with normal Lichess accounts\n\n### Restrictions\n- Engine assistance, or any kind of outside help, is [forbidden](https://lichess.org/page/fair-play)\n- Time controls: [Rapid, Classical and Correspondence](https://lichess.org/faq#time-controls) only.\n  For direct challenges, games vs AI, and bulk pairing, Blitz is also possible.\n\n### Links\n- [Announcement](https://lichess.org/blog/XlRW5REAAB8AUJJ-/welcome-lichess-boards)\n- [Implementation example](https://github.com/lichess-org/api-demo) and [live demo](https://lichess-org.github.io/api-demo/)\n- [Certabo support](https://github.com/haklein/certabo-lichess)\n- [Lichs (play from command-line)](https://github.com/Cqsi/lichs)\n- [Lichess discord bot](https://top.gg/bot/707287095911120968)\n- [cli-chess](https://github.com/trevorbayless/cli-chess/)\n- [Blunderly 3D board](https://github.com/maurimo/blunderly)\n- Yours? Please make [an issue or pull request](https://github.com/lichess-org/api).\n"
+    },
+    {
+      "name": "Bot",
+      "description": "Play on Lichess as a bot. Allows engine play.\nRead the [blog post announcement of lichess bots](https://lichess.org/blog/WvDNticAAMu_mHKP/welcome-lichess-bots).\n\nOnly works with [Bot accounts](#tag/bot/POST/api/bot/account/upgrade).\n\n### Features\n- [Stream incoming chess moves](#tag/bot/GET/api/bot/game/stream/{gameId})\n- [Play chess moves](#tag/bot/POST/api/bot/game/{gameId}/move/{move})\n- [Read](#tag/bot/GET/api/bot/game/stream/{gameId}) and [write](#tag/bot/POST/api/bot/game/{gameId}/chat) in the player and spectator chats\n- [Receive](#tag/bot/GET/api/stream/event), [create](#tag/challenges/POST/api/challenge/{username}) and [accept](#tag/challenges/POST/api/challenge/{challengeId}/accept) (or [decline](#tag/challenges/POST/api/challenge/{challengeId}/decline)) challenges\n- [Abort](#tag/bot/POST/api/bot/game/{gameId}/abort) and [resign](#tag/bot/POST/api/bot/game/{gameId}/resign) games\n- Engine assistance is [allowed](https://lichess.org/page/fair-play)\n### Restrictions\n- Bots can only play challenge games:  pools and tournaments are off-limits\n- Bots cannot play UltraBullet (\u00bc+0) because it requires making too many requests. But 0+1 and \u00bd+0 are allowed.\n- Bots must follow [Lichess TOS](https://lichess.org/terms-of-service) specifically Sandbagging, Constant Aborting, Boosting, etc\n- Bot devs are advised to make their Bots play casual only when testing their Bots logic and to avoid breaking Lichess TOS.\n### Integrations\n- [Python3 lichess-bot](https://github.com/lichess-bot-devs/lichess-bot) (official)\n- [Python3 lichess UCI bot](https://github.com/Torom/BotLi)\n- [JavaScript bot-o-tron](https://github.com/tailuge/bot-o-tron)\n- [Golang lichess-bot](https://github.com/dolegi/lichess-bot)\n- [Electronic Chessboard](http://www.oliviermercier.com/res/projects/chessboard/)\n- Yours? Please make [an issue or pull request](https://github.com/lichess-org/api).\n### Links\n- [Announcement](https://lichess.org/blog/WvDNticAAMu_mHKP/welcome-lichess-bots)\n- Join the [Lichess Bots team](https://lichess.org/team/lichess-bots) with your bot account\n- [Get help in the discord channel](https://discord.gg/quwueFd)\n- Watch [Lichess Bot TV](https://lichess.org/tv/bot)\n"
+    },
+    {
+      "name": "Broadcasts",
+      "description": "Relay chess events on Lichess.\n[Official broadcasts](https://lichess.org/broadcast) are maintained by Lichess,\nbut you can [create your own broadcasts](https://lichess.org/broadcast/new) to cover any live game or chess event.\nYou will need to publish PGN on a public URL so that Lichess can pull updates from it.\nAlternatively, you can push PGN updates to Lichess using [this API endpoint](#tag/broadcasts/POST/api/broadcast/round/{broadcastRoundId}/push).\n\nBroadcasts are organized in tournaments, which have several rounds, which have several games.\nYou must first create a tournament, then you can add rounds to them.\n"
+    },
+    {
+      "name": "Bulk pairings",
+      "description": "Create many games for other players.\n\nThese endpoints are intended for tournament organisers.\n"
+    },
+    {
+      "name": "Challenges",
+      "description": "Send and receive challenges to play.\n\nTo create a lot of challenges, consider [bulk pairing](#tag/bulk-pairings/POST/api/bulk-pairing) instead.\n"
+    },
+    {
+      "name": "External engine",
+      "description": "**This API is in alpha and subject to change.**\n\nUse or provide external engine analysis.\n\nExternal engines can provide analysis on pages like the\n[analysis board](https://lichess.org/analysis), running as a service\noutside of the browser, or even on a different machine.\n"
+    },
+    {
+      "name": "FIDE",
+      "description": "FIDE players and federations from [their public download](https://ratings.fide.com/download_lists.phtml).\n\n<https://lichess.org/fide>\n"
+    },
+    {
+      "name": "Games",
+      "description": "Access games played on Lichess.\n<https://lichess.org/games>\n"
+    },
+    {
+      "name": "Messaging",
+      "description": "Private messages with other players.\n<https://lichess.org/inbox>\n"
+    },
+    {
+      "name": "Opening Explorer",
+      "description": "Lookup positions from the [Lichess opening explorer](https://lichess.org/analysis#explorer).\n\nRuns <https://github.com/lichess-org/lila-openingexplorer>.\n\n**The endpoint hostname is not lichess.org but explorer.lichess.org.**\n"
+    },
+    {
+      "name": "Puzzles",
+      "description": "Fetch and solve [puzzles](https://lichess.org/training), view your puzzle history and dashboard.\n\nOur collection of puzzles is in the public domain, you can [download it here](https://database.lichess.org/#puzzles).\nFor a list of our [puzzle themes](https://lichess.org/training/themes) with their description, check out the [theme translation file](https://github.com/ornicar/lila/blob/master/translation/source/puzzleTheme.xml).\nThe daily puzzle can be [posted in your slack workspace](https://lichess.org/daily-puzzle-slack).\n"
+    },
+    {
+      "name": "Relations",
+      "description": "Access relations between users.\n"
+    },
+    {
+      "name": "Simuls",
+      "description": "Access simuls played on Lichess.\n<https://lichess.org/simul>\n"
+    },
+    {
+      "name": "Studies",
+      "description": "Access Lichess studies.\n<https://lichess.org/study>\n"
+    },
+    {
+      "name": "Tablebase",
+      "description": "Lookup positions from the [Lichess tablebase server](https://lichess.org/blog/W3WeMyQAACQAdfAL/7-piece-syzygy-tablebases-are-complete).\n\n**The endpoint hostname is not lichess.org but tablebase.lichess.org.**\n"
+    },
+    {
+      "name": "Teams",
+      "description": "Access and manage Lichess teams and their members.\n<https://lichess.org/team>\n"
+    },
+    {
+      "name": "Tournaments (Arena)",
+      "description": "Access Arena tournaments played on Lichess.\n[Official Arena tournaments](https://lichess.org/tournament) are maintained by Lichess,\nbut you can [create your own Arena tournaments](https://lichess.org/tournament/new) as well.\n"
+    },
+    {
+      "name": "Tournaments (Swiss)",
+      "description": "Access Swiss tournaments played on Lichess.\n[Read more about Swiss tournaments.](https://lichess.org/swiss).\n"
+    },
+    {
+      "name": "TV",
+      "description": "Access Lichess TV channels and games.\n<https://lichess.org/tv> & <https://lichess.org/games>\n"
+    },
+    {
+      "name": "Users",
+      "description": "Access registered users on Lichess.\n<https://lichess.org/player>\n\n- Each user blog exposes an atom (RSS) feed, like <https://lichess.org/@/thibault/blog.atom>\n- User blogs mashup feed: https://lichess.org/blog/community.atom\n- User blogs mashup feed for a language: https://lichess.org/blog/community/fr.atom\n"
+    },
+    {
+      "name": "OAuth",
+      "description": "Obtaining and revoking OAuth tokens.\n\n[Read about the Lichess API authentication methods and code examples](https://github.com/lichess-org/api/blob/master/example/README.md).\n"
+    }
+  ],
+  "paths": {
+    "/api/users/status": {
+      "$ref": "./tags/users/api-users-status.yaml"
+    },
+    "/api/player": {
+      "$ref": "./tags/users/api-player.yaml"
+    },
+    "/api/player/top/{nb}/{perfType}": {
+      "$ref": "./tags/users/api-player-top-nb-perfType.yaml"
+    },
+    "/api/user/{username}": {
+      "$ref": "./tags/users/api-user-username.yaml"
+    },
+    "/api/user/{username}/rating-history": {
+      "$ref": "./tags/users/api-user-username-rating-history.yaml"
+    },
+    "/api/user/{username}/perf/{perf}": {
+      "$ref": "./tags/users/api-user-username-perf-perf.yaml"
+    },
+    "/api/user/{username}/activity": {
+      "$ref": "./tags/users/api-user-username-activity.yaml"
+    },
+    "/api/puzzle/daily": {
+      "$ref": "./tags/puzzles/api-puzzle-daily.yaml"
+    },
+    "/api/puzzle/{id}": {
+      "$ref": "./tags/puzzles/api-puzzle-id.yaml"
+    },
+    "/api/puzzle/next": {
+      "$ref": "./tags/puzzles/api-puzzle-next.yaml"
+    },
+    "/api/puzzle/batch/{angle}": {
+      "$ref": "./tags/puzzles/api-puzzle-batch-angle.yaml"
+    },
+    "/api/puzzle/activity": {
+      "$ref": "./tags/puzzles/api-puzzle-activity.yaml"
+    },
+    "/api/puzzle/replay/{days}/{theme}": {
+      "$ref": "./tags/puzzles/api-puzzle-replay-days-theme.yaml"
+    },
+    "/api/puzzle/dashboard/{days}": {
+      "$ref": "./tags/puzzles/api-puzzle-dashboard-days.yaml"
+    },
+    "/api/storm/dashboard/{username}": {
+      "$ref": "./tags/puzzles/api-storm-dashboard-username.yaml"
+    },
+    "/api/racer": {
+      "$ref": "./tags/puzzles/api-racer.yaml"
+    },
+    "/api/racer/{id}": {
+      "$ref": "./tags/puzzles/api-racer-id.yaml"
+    },
+    "/api/users": {
+      "$ref": "./tags/users/api-users.yaml"
+    },
+    "/api/account": {
+      "$ref": "./tags/account/api-account.yaml"
+    },
+    "/api/account/email": {
+      "$ref": "./tags/account/api-account-email.yaml"
+    },
+    "/api/account/preferences": {
+      "$ref": "./tags/account/api-account-preferences.yaml"
+    },
+    "/api/account/kid": {
+      "$ref": "./tags/account/api-account-kid.yaml"
+    },
+    "/api/timeline": {
+      "$ref": "./tags/account/api-timeline.yaml"
+    },
+    "/game/export/{gameId}": {
+      "$ref": "./tags/games/game-export-gameId.yaml"
+    },
+    "/game/{gameId}/chat": {
+      "$ref": "./tags/games/api-game-gameId-chat.yaml"
+    },
+    "/api/user/{username}/current-game": {
+      "$ref": "./tags/games/api-user-username-current-game.yaml"
+    },
+    "/api/games/user/{username}": {
+      "$ref": "./tags/games/api-games-user-username.yaml"
+    },
+    "/api/games/export/_ids": {
+      "$ref": "./tags/games/api-games-export-_ids.yaml"
+    },
+    "/api/stream/games-by-users": {
+      "$ref": "./tags/games/api-stream-games-by-users.yaml"
+    },
+    "/api/stream/games/{streamId}": {
+      "$ref": "./tags/games/api-stream-games-streamId.yaml"
+    },
+    "/api/stream/games/{streamId}/add": {
+      "$ref": "./tags/games/api-stream-games-streamId-add.yaml"
+    },
+    "/api/account/playing": {
+      "$ref": "./tags/games/api-account-playing.yaml"
+    },
+    "/api/stream/game/{id}": {
+      "$ref": "./tags/games/api-stream-game-id.yaml"
+    },
+    "/api/import": {
+      "$ref": "./tags/games/api-import.yaml"
+    },
+    "/api/games/export/imports": {
+      "$ref": "./tags/games/api-games-export-imports.yaml"
+    },
+    "/api/games/export/bookmarks": {
+      "$ref": "./tags/games/api-games-export-bookmarks.yaml"
+    },
+    "/api/tv/channels": {
+      "$ref": "./tags/tv/api-tv-channels.yaml"
+    },
+    "/api/tv/feed": {
+      "$ref": "./tags/tv/api-tv-feed.yaml"
+    },
+    "/api/tv/{channel}/feed": {
+      "$ref": "./tags/tv/api-tv-channel-feed.yaml"
+    },
+    "/api/tv/{channel}": {
+      "$ref": "./tags/tv/api-tv-channel.yaml"
+    },
+    "/api/tournament": {
+      "$ref": "./tags/arenatournaments/api-tournament.yaml"
+    },
+    "/api/tournament/{id}": {
+      "$ref": "./tags/arenatournaments/api-tournament-id.yaml"
+    },
+    "/api/tournament/{id}/join": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-join.yaml"
+    },
+    "/api/tournament/{id}/withdraw": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-withdraw.yaml"
+    },
+    "/api/tournament/{id}/terminate": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-terminate.yaml"
+    },
+    "/api/tournament/team-battle/{id}": {
+      "$ref": "./tags/arenatournaments/api-tournament-team-battle-id.yaml"
+    },
+    "/api/tournament/{id}/games": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-games.yaml"
+    },
+    "/api/tournament/{id}/results": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-results.yaml"
+    },
+    "/api/tournament/{id}/teams": {
+      "$ref": "./tags/arenatournaments/api-tournament-id-teams.yaml"
+    },
+    "/api/user/{username}/tournament/created": {
+      "$ref": "./tags/arenatournaments/api-user-username-tournament-created.yaml"
+    },
+    "/api/user/{username}/tournament/played": {
+      "$ref": "./tags/arenatournaments/api-user-username-tournament-played.yaml"
+    },
+    "/api/swiss/new/{teamId}": {
+      "$ref": "./tags/swisstournaments/api-swiss-new-teamId.yaml"
+    },
+    "/api/swiss/{id}": {
+      "$ref": "./tags/swisstournaments/api-swiss-id.yaml"
+    },
+    "/api/swiss/{id}/edit": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-edit.yaml"
+    },
+    "/api/swiss/{id}/schedule-next-round": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-schedule-next-round.yaml"
+    },
+    "/api/swiss/{id}/join": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-join.yaml"
+    },
+    "/api/swiss/{id}/withdraw": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-withdraw.yaml"
+    },
+    "/api/swiss/{id}/terminate": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-terminate.yaml"
+    },
+    "/swiss/{id}.trf": {
+      "$ref": "./tags/swisstournaments/swiss-id.trf.yaml"
+    },
+    "/api/swiss/{id}/games": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-games.yaml"
+    },
+    "/api/swiss/{id}/results": {
+      "$ref": "./tags/swisstournaments/api-swiss-id-results.yaml"
+    },
+    "/api/team/{teamId}/swiss": {
+      "$ref": "./tags/teams/api-team-teamId-swiss.yaml"
+    },
+    "/api/study/{studyId}/{chapterId}.pgn": {
+      "$ref": "./tags/studies/api-study-studyId-chapterId.pgn.yaml"
+    },
+    "/api/study/{studyId}.pgn": {
+      "$ref": "./tags/studies/api-study-studyId.pgn.yaml"
+    },
+    "/api/study": {
+      "$ref": "./tags/studies/api-study.yaml"
+    },
+    "/api/study/{studyId}/import-pgn": {
+      "$ref": "./tags/studies/api-study-studyId-import-pgn.yaml"
+    },
+    "/api/study/{studyId}/{chapterId}/tags": {
+      "$ref": "./tags/studies/api-study-studyId-chapterId-tags.yaml"
+    },
+    "/api/study/by/{username}/export.pgn": {
+      "$ref": "./tags/studies/api-study-by-username-export.pgn.yaml"
+    },
+    "/api/study/by/{username}": {
+      "$ref": "./tags/studies/api-study-by-username.yaml"
+    },
+    "/api/study/{studyId}/{chapterId}": {
+      "$ref": "./tags/studies/api-study-studyId-chapterId.yaml"
+    },
+    "/api/broadcast": {
+      "$ref": "./tags/broadcasts/api-broadcasts-official.yaml"
+    },
+    "/api/broadcast/top": {
+      "$ref": "./tags/broadcasts/api-broadcasts-top.yaml"
+    },
+    "/api/broadcast/by/{username}": {
+      "$ref": "./tags/broadcasts/api-broadcasts-by-user.yaml"
+    },
+    "/api/broadcast/search": {
+      "$ref": "./tags/broadcasts/api-broadcasts-search.yaml"
+    },
+    "/broadcast/new": {
+      "$ref": "./tags/broadcasts/broadcast-new.yaml"
+    },
+    "/api/broadcast/{broadcastTournamentId}": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId.yaml"
+    },
+    "/broadcast/{broadcastTournamentId}/players": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId-players.yaml"
+    },
+    "/broadcast/{broadcastTournamentId}/players/{playerId}": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId-players-playerId.yaml"
+    },
+    "/broadcast/{broadcastTournamentId}/teams/standings": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId-teams-standings.yaml"
+    },
+    "/broadcast/{broadcastTournamentId}/edit": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId-edit.yaml"
+    },
+    "/broadcast/{broadcastTournamentId}/new": {
+      "$ref": "./tags/broadcasts/broadcast-broadcastTournamentId-new.yaml"
+    },
+    "/api/broadcast/{broadcastTournamentSlug}/{broadcastRoundSlug}/{broadcastRoundId}": {
+      "$ref": "./tags/broadcasts/api-broadcast-broadcastTournamentSlug-broadcastRoundSlug-broadcastRoundId.yaml"
+    },
+    "/broadcast/round/{broadcastRoundId}/edit": {
+      "$ref": "./tags/broadcasts/broadcast-round-broadcastRoundId-edit.yaml"
+    },
+    "/api/broadcast/round/{broadcastRoundId}/reset": {
+      "$ref": "./tags/broadcasts/broadcast-round-broadcastRoundId-reset.yaml"
+    },
+    "/api/broadcast/round/{broadcastRoundId}/push": {
+      "$ref": "./tags/broadcasts/broadcast-round-broadcastRoundId-push.yaml"
+    },
+    "/api/stream/broadcast/round/{broadcastRoundId}.pgn": {
+      "$ref": "./tags/broadcasts/api-stream-broadcast-round-broadcastRoundId-pgn.yaml"
+    },
+    "/api/broadcast/round/{broadcastRoundId}.pgn": {
+      "$ref": "./tags/broadcasts/api-broadcast-round-broadcastRoundId-pgn.yaml"
+    },
+    "/api/broadcast/{broadcastTournamentId}.pgn": {
+      "$ref": "./tags/broadcasts/api-broadcast-broadcastTournamentId-pgn.yaml"
+    },
+    "/api/broadcast/my-rounds": {
+      "$ref": "./tags/broadcasts/api-broadcast-my-rounds.yaml"
+    },
+    "/api/fide/player/{playerId}": {
+      "$ref": "./tags/fide/api-fide-player-playerId.yaml"
+    },
+    "/api/fide/player/{playerId}/ratings": {
+      "$ref": "./tags/fide/api-fide-player-playerId-ratings.yaml"
+    },
+    "/api/fide/player": {
+      "$ref": "./tags/fide/api-fide-player-search.yaml"
+    },
+    "/api/simul": {
+      "$ref": "./tags/simuls/api-simul.yaml"
+    },
+    "/api/team/{teamId}": {
+      "$ref": "./tags/teams/api-team-teamId.yaml"
+    },
+    "/api/team/all": {
+      "$ref": "./tags/teams/api-team-all.yaml"
+    },
+    "/api/team/of/{username}": {
+      "$ref": "./tags/teams/api-team-of-username.yaml"
+    },
+    "/api/team/search": {
+      "$ref": "./tags/teams/api-team-search.yaml"
+    },
+    "/api/team/{teamId}/users": {
+      "$ref": "./tags/teams/api-team-teamId-users.yaml"
+    },
+    "/api/team/{teamId}/arena": {
+      "$ref": "./tags/teams/api-team-teamId-arena.yaml"
+    },
+    "/team/{teamId}/join": {
+      "$ref": "./tags/teams/team-teamId-join.yaml"
+    },
+    "/team/{teamId}/quit": {
+      "$ref": "./tags/teams/team-teamId-quit.yaml"
+    },
+    "/api/team/{teamId}/requests": {
+      "$ref": "./tags/teams/api-team-teamId-requests.yaml"
+    },
+    "/api/team/{teamId}/request/{userId}/accept": {
+      "$ref": "./tags/teams/api-team-teamId-request-userId-accept.yaml"
+    },
+    "/api/team/{teamId}/request/{userId}/decline": {
+      "$ref": "./tags/teams/api-team-teamId-request-userId-decline.yaml"
+    },
+    "/api/team/{teamId}/kick/{userId}": {
+      "$ref": "./tags/teams/api-team-teamId-kick-userId.yaml"
+    },
+    "/team/{teamId}/pm-all": {
+      "$ref": "./tags/teams/team-teamId-pm-all.yaml"
+    },
+    "/api/streamer/live": {
+      "$ref": "./tags/users/api-streamer-live.yaml"
+    },
+    "/api/crosstable/{user1}/{user2}": {
+      "$ref": "./tags/users/api-crosstable-user1-user2.yaml"
+    },
+    "/api/player/autocomplete": {
+      "$ref": "./tags/users/api-player-autocomplete.yaml"
+    },
+    "/api/user/{username}/note": {
+      "$ref": "./tags/users/api-user-username-note.yaml"
+    },
+    "/api/rel/following": {
+      "$ref": "./tags/relations/api-rel-following.yaml"
+    },
+    "/api/rel/follow/{username}": {
+      "$ref": "./tags/relations/api-rel-follow-username.yaml"
+    },
+    "/api/rel/unfollow/{username}": {
+      "$ref": "./tags/relations/api-rel-unfollow-username.yaml"
+    },
+    "/api/rel/block/{username}": {
+      "$ref": "./tags/relations/api-rel-block-username.yaml"
+    },
+    "/api/rel/unblock/{username}": {
+      "$ref": "./tags/relations/api-rel-unblock-username.yaml"
+    },
+    "/api/stream/event": {
+      "$ref": "./tags/board/api-stream-event.yaml"
+    },
+    "/api/board/seek": {
+      "$ref": "./tags/board/api-board-seek.yaml"
+    },
+    "/api/board/game/stream/{gameId}": {
+      "$ref": "./tags/board/api-board-game-stream-gameId.yaml"
+    },
+    "/api/board/game/{gameId}/move/{move}": {
+      "$ref": "./tags/board/api-board-game-gameId-move-move.yaml"
+    },
+    "/api/board/game/{gameId}/chat": {
+      "$ref": "./tags/board/api-board-game-gameId-chat.yaml"
+    },
+    "/api/board/game/{gameId}/abort": {
+      "$ref": "./tags/board/api-board-game-gameId-abort.yaml"
+    },
+    "/api/board/game/{gameId}/resign": {
+      "$ref": "./tags/board/api-board-game-gameId-resign.yaml"
+    },
+    "/api/board/game/{gameId}/draw/{accept}": {
+      "$ref": "./tags/board/api-board-game-gameId-draw-accept.yaml"
+    },
+    "/api/board/game/{gameId}/takeback/{accept}": {
+      "$ref": "./tags/board/api-board-game-gameId-takeback-accept.yaml"
+    },
+    "/api/board/game/{gameId}/claim-victory": {
+      "$ref": "./tags/board/api-board-game-gameId-claim-victory.yaml"
+    },
+    "/api/board/game/{gameId}/claim-draw": {
+      "$ref": "./tags/board/api-board-game-gameId-claim-draw.yaml"
+    },
+    "/api/board/game/{gameId}/berserk": {
+      "$ref": "./tags/board/api-board-game-gameId-berserk.yaml"
+    },
+    "/api/bot/online": {
+      "$ref": "./tags/bot/api-bot-online.yaml"
+    },
+    "/api/bot/account/upgrade": {
+      "$ref": "./tags/bot/api-bot-account-upgrade.yaml"
+    },
+    "/api/bot/game/stream/{gameId}": {
+      "$ref": "./tags/bot/api-bot-game-stream-gameId.yaml"
+    },
+    "/api/bot/game/{gameId}/move/{move}": {
+      "$ref": "./tags/bot/api-bot-game-gameId-move-move.yaml"
+    },
+    "/api/bot/game/{gameId}/chat": {
+      "$ref": "./tags/bot/api-bot-game-gameId-chat.yaml"
+    },
+    "/api/bot/game/{gameId}/abort": {
+      "$ref": "./tags/bot/api-bot-game-gameId-abort.yaml"
+    },
+    "/api/bot/game/{gameId}/resign": {
+      "$ref": "./tags/bot/api-bot-game-gameId-resign.yaml"
+    },
+    "/api/bot/game/{gameId}/draw/{accept}": {
+      "$ref": "./tags/bot/api-bot-game-gameId-draw-accept.yaml"
+    },
+    "/api/bot/game/{gameId}/takeback/{accept}": {
+      "$ref": "./tags/bot/api-bot-game-gameId-takeback-accept.yaml"
+    },
+    "/api/bot/game/{gameId}/claim-victory": {
+      "$ref": "./tags/bot/api-bot-game-gameId-claim-victory.yaml"
+    },
+    "/api/bot/game/{gameId}/claim-draw": {
+      "$ref": "./tags/bot/api-bot-game-gameId-claim-draw.yaml"
+    },
+    "/api/challenge": {
+      "$ref": "./tags/challenges/api-challenge.yaml"
+    },
+    "/api/challenge/{username}": {
+      "$ref": "./tags/challenges/api-challenge-username.yaml"
+    },
+    "/api/challenge/{challengeId}/show": {
+      "$ref": "./tags/challenges/api-challenge-id-show.yaml"
+    },
+    "/api/challenge/{challengeId}/accept": {
+      "$ref": "./tags/challenges/api-challenge-challengeId-accept.yaml"
+    },
+    "/api/challenge/{challengeId}/decline": {
+      "$ref": "./tags/challenges/api-challenge-challengeId-decline.yaml"
+    },
+    "/api/challenge/{challengeId}/cancel": {
+      "$ref": "./tags/challenges/api-challenge-challengeId-cancel.yaml"
+    },
+    "/api/challenge/ai": {
+      "$ref": "./tags/challenges/api-challenge-ai.yaml"
+    },
+    "/api/challenge/open": {
+      "$ref": "./tags/challenges/api-challenge-open.yaml"
+    },
+    "/api/challenge/{gameId}/start-clocks": {
+      "$ref": "./tags/challenges/api-challenge-gameId-start-clocks.yaml"
+    },
+    "/api/bulk-pairing": {
+      "$ref": "./tags/bulkpairings/api-bulk-pairing.yaml"
+    },
+    "/api/bulk-pairing/{id}/start-clocks": {
+      "$ref": "./tags/bulkpairings/api-bulk-pairing-id-start-clocks.yaml"
+    },
+    "/api/bulk-pairing/{id}": {
+      "$ref": "./tags/bulkpairings/api-bulk-pairing-id.yaml"
+    },
+    "/api/bulk-pairing/{id}/games": {
+      "$ref": "./tags/bulkpairings/api-bulk-pairing-id-games.yaml"
+    },
+    "/api/round/{gameId}/add-time/{seconds}": {
+      "$ref": "./tags/challenges/api-round-gameId-add-time-seconds.yaml"
+    },
+    "/api/token/admin-challenge": {
+      "$ref": "./tags/challenges/api-token-admin-challenge.yaml"
+    },
+    "/inbox/{username}": {
+      "$ref": "./tags/messaging/inbox-username.yaml"
+    },
+    "/api/cloud-eval": {
+      "$ref": "./tags/analysis/api-cloud-eval.yaml"
+    },
+    "/api/external-engine": {
+      "$ref": "./tags/externalengine/api-external-engine.yaml"
+    },
+    "/api/external-engine/{id}": {
+      "$ref": "./tags/externalengine/api-external-engine-id.yaml"
+    },
+    "/api/external-engine/{id}/analyse": {
+      "$ref": "./tags/externalengine/api-external-engine-id-analyse.yaml"
+    },
+    "/api/external-engine/work": {
+      "$ref": "./tags/externalengine/api-external-engine-work.yaml"
+    },
+    "/api/external-engine/work/{id}": {
+      "$ref": "./tags/externalengine/api-external-engine-work-id.yaml"
+    },
+    "/oauth": {
+      "$ref": "./tags/oauth/oauth.yaml"
+    },
+    "/api/token": {
+      "$ref": "./tags/oauth/api-token.yaml"
+    },
+    "/api/token/test": {
+      "$ref": "./tags/oauth/api-token-test.yaml"
+    },
+    "/masters": {
+      "$ref": "./tags/openingexplorer/masters.yaml"
+    },
+    "/lichess": {
+      "$ref": "./tags/openingexplorer/lichess.yaml"
+    },
+    "/player": {
+      "$ref": "./tags/openingexplorer/player.yaml"
+    },
+    "/masters/pgn/{gameId}": {
+      "$ref": "./tags/openingexplorer/masters-pgn-gameId.yaml"
+    },
+    "/standard": {
+      "$ref": "./tags/tablebase/standard.yaml"
+    },
+    "/atomic": {
+      "$ref": "./tags/tablebase/atomic.yaml"
+    },
+    "/antichess": {
+      "$ref": "./tags/tablebase/antichess.yaml"
+    }
+  },
+  "components": {
+    "schemas": {
+      "$ref": "./schemas/_index.yaml"
+    },
+    "securitySchemes": {
+      "OAuth2": {
+        "type": "oauth2",
+        "description": "Read [the introduction for how to make authenticated requests](#description/authentication).\n",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://lichess.org/oauth",
+            "tokenUrl": "https://lichess.org/api/token",
+            "scopes": {
+              "preference:read": "Read your preferences",
+              "preference:write": "Write your preferences",
+              "email:read": "Read your email address",
+              "engine:read": "Read your external engines",
+              "engine:write": "Create, update, delete your external engines",
+              "challenge:read": "Read incoming challenges",
+              "challenge:write": "Create, accept, decline challenges",
+              "challenge:bulk": "Create, delete, query bulk pairings",
+              "study:read": "Read private studies and broadcasts",
+              "study:write": "Create, update, delete studies and broadcasts",
+              "tournament:write": "Create tournaments",
+              "racer:write": "Create and join puzzle races",
+              "puzzle:read": "Read puzzle activity",
+              "puzzle:write": "Write puzzle activity",
+              "team:read": "Read private team information",
+              "team:write": "Join, leave teams",
+              "team:lead": "Manage teams (kick members, send PMs)",
+              "follow:read": "Read followed players",
+              "follow:write": "Follow and unfollow other players",
+              "msg:write": "Send private messages to other players",
+              "board:play": "Play with the Board API",
+              "bot:play": "Play with the Bot API. Only for [Bot accounts](#tag/bot/POST/api/bot/account/upgrade)",
+              "web:mod": "Use moderator tools (within the bounds of your permissions)"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/lichess.org/lichess/meta.json
+++ b/apis/openapi/lichess.org/lichess/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "cf969314a7cc3b49d6bdaa13701e33b3",
+    "format": "openapi",
+    "vendor": "lichess.org",
+    "api_name": "lichess",
+    "friendly_id": "lichess.org/lichess"
+  }
+}

--- a/apis/openapi/locationiq.com/locationiq/1.0.0/openapi.json
+++ b/apis/openapi/locationiq.com/locationiq/1.0.0/openapi.json
@@ -1,0 +1,1565 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "LocationIQ API",
+    "description": "LocationIQ provides forward and reverse geocoding, autocomplete, nearby POI search, timezone lookup, and routing (directions) APIs. Built on OpenStreetMap data with additional proprietary datasets. Authentication is via API key passed as a query parameter.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "LocationIQ",
+      "url": "https://locationiq.com"
+    },
+    "x-jentic-source-url": "https://locationiq.org/docs/"
+  },
+  "servers": [
+    {
+      "url": "https://us1.locationiq.com/v1",
+      "description": "US region server"
+    },
+    {
+      "url": "https://eu1.locationiq.com/v1",
+      "description": "EU region server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Forward geocoding (address to coordinates)"
+    },
+    {
+      "name": "Reverse Geocoding",
+      "description": "Reverse geocoding (coordinates to address)"
+    },
+    {
+      "name": "Autocomplete",
+      "description": "Address autocomplete suggestions"
+    },
+    {
+      "name": "Nearby",
+      "description": "Nearby points of interest search (BETA)"
+    },
+    {
+      "name": "Timezone",
+      "description": "Timezone lookup by coordinates"
+    },
+    {
+      "name": "Directions",
+      "description": "Routing and directions"
+    },
+    {
+      "name": "Account",
+      "description": "Account and balance information"
+    }
+  ],
+  "paths": {
+    "/search": {
+      "get": {
+        "operationId": "forwardGeocode",
+        "summary": "Forward geocoding (free-form query)",
+        "description": "Converts a free-form address string into geographic coordinates (latitude and longitude).",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Free-form query string to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Output format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "xmlv1.1"],
+              "default": "xml"
+            }
+          },
+          {
+            "name": "addressdetails",
+            "in": "query",
+            "required": false,
+            "description": "Include a breakdown of the address into elements (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "statecode",
+            "in": "query",
+            "required": false,
+            "description": "Add state or province code to address details (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "viewbox",
+            "in": "query",
+            "required": false,
+            "description": "Preferred area for results as comma-separated coordinates (lon1,lat1,lon2,lat2).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bounded",
+            "in": "query",
+            "required": false,
+            "description": "Restrict results to the viewbox area (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return (1-50).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "accept-language",
+            "in": "query",
+            "required": false,
+            "description": "Preferred language for results.",
+            "schema": {
+              "type": "string",
+              "default": "en"
+            }
+          },
+          {
+            "name": "countrycodes",
+            "in": "query",
+            "required": false,
+            "description": "Comma-separated list of ISO 3166-1 alpha-2 country codes to restrict results.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "normalizeaddress",
+            "in": "query",
+            "required": false,
+            "description": "Standardize address elements (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "normalizecity",
+            "in": "query",
+            "required": false,
+            "description": "Normalize the city field (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "postaladdress",
+            "in": "query",
+            "required": false,
+            "description": "Return country-specific postal address format (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "matchquality",
+            "in": "query",
+            "required": false,
+            "description": "Include match quality information (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "source",
+            "in": "query",
+            "required": false,
+            "description": "Data source. Use 'nom' for OpenStreetMap only.",
+            "schema": {
+              "type": "string",
+              "enum": ["nom"]
+            }
+          },
+          {
+            "name": "dedupe",
+            "in": "query",
+            "required": false,
+            "description": "Remove duplicate results (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 1
+            }
+          },
+          {
+            "name": "namedetails",
+            "in": "query",
+            "required": false,
+            "description": "Include alternative names and language variants (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "extratags",
+            "in": "query",
+            "required": false,
+            "description": "Include additional metadata like Wikipedia links, opening hours (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "polygon_geojson",
+            "in": "query",
+            "required": false,
+            "description": "Return geometry as GeoJSON (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "polygon_kml",
+            "in": "query",
+            "required": false,
+            "description": "Return geometry as KML (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "polygon_svg",
+            "in": "query",
+            "required": false,
+            "description": "Return geometry as SVG (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "polygon_text",
+            "in": "query",
+            "required": false,
+            "description": "Return geometry as WKT (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "polygon_threshold",
+            "in": "query",
+            "required": false,
+            "description": "Geometry simplification tolerance.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "json_callback",
+            "in": "query",
+            "required": false,
+            "description": "JSONP callback function name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeocodingResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized. Invalid API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. Access restricted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found. Unable to geocode.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/structured": {
+      "get": {
+        "operationId": "structuredGeocode",
+        "summary": "Structured forward geocoding",
+        "description": "Geocodes an address using separate address components (street, city, state, country, postalcode).",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "street",
+            "in": "query",
+            "required": false,
+            "description": "Street address.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "county",
+            "in": "query",
+            "required": false,
+            "description": "County name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "State or province.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postalcode",
+            "in": "query",
+            "required": false,
+            "description": "Postal code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "xmlv1.1"],
+              "default": "xml"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          },
+          {
+            "name": "accept-language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "en"
+            }
+          },
+          {
+            "name": "countrycodes",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "addressdetails",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful structured geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeocodingResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/postalcode": {
+      "get": {
+        "operationId": "postalCodeSearch",
+        "summary": "Postal code search",
+        "description": "Locate details when only a postal code match is necessary.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "postalcode",
+            "in": "query",
+            "required": true,
+            "description": "Postal code to search for.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "countrycodes",
+            "in": "query",
+            "required": false,
+            "description": "ISO 3166-1 alpha-2 country codes.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "xml"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 50,
+              "default": 10
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful postal code search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeocodingResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reverse": {
+      "get": {
+        "operationId": "reverseGeocode",
+        "summary": "Reverse geocoding",
+        "description": "Converts coordinates (latitude, longitude) to a readable address.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "xml"
+            }
+          },
+          {
+            "name": "addressdetails",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "namedetails",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "extratags",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "accept-language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "en"
+            }
+          },
+          {
+            "name": "polygon_geojson",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "normalizeaddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "normalizecity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodingResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Unable to geocode.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/autocomplete": {
+      "get": {
+        "operationId": "autocomplete",
+        "summary": "Autocomplete suggestions",
+        "description": "Returns address autocomplete suggestions for a partial query string. Uses anycast IP routing for optimal performance.",
+        "tags": ["Autocomplete"],
+        "servers": [
+          {
+            "url": "https://api.locationiq.com/v1",
+            "description": "Autocomplete API server (anycast)"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Query string to search for (max 200 characters).",
+            "schema": {
+              "type": "string",
+              "maxLength": 200
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results (1-20).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 20,
+              "default": 10
+            }
+          },
+          {
+            "name": "countrycodes",
+            "in": "query",
+            "required": false,
+            "description": "Restrict search to specific countries.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "normalizecity",
+            "in": "query",
+            "required": false,
+            "description": "Normalize city field from address hierarchy (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "accept-language",
+            "in": "query",
+            "required": false,
+            "description": "Preferred language (e.g., en, fr, de, es, ru).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful autocomplete.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutocompleteResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/nearby": {
+      "get": {
+        "operationId": "nearbyPOI",
+        "summary": "Nearby places search (BETA)",
+        "description": "Returns nearby places around a specified location, including points of interest like cafes, hospitals, and place-level features such as cities.",
+        "tags": ["Nearby"],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude of the center point.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude of the center point.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Type of places to return (e.g., restaurant, hospital, cafe, city).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "required": false,
+            "description": "Search radius in meters.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful nearby search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/GeocodingResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/timezone": {
+      "get": {
+        "operationId": "getTimezone",
+        "summary": "Timezone lookup",
+        "description": "Returns timezone information for a given location.",
+        "tags": ["Timezone"],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "description": "Latitude of the location.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "description": "Longitude of the location.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "timestamp",
+            "in": "query",
+            "required": false,
+            "description": "Unix epoch timestamp in seconds. Defaults to current time if omitted.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful timezone lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TimezoneResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/{profile}/{coordinates}": {
+      "get": {
+        "operationId": "getDirections",
+        "summary": "Get directions",
+        "description": "Returns routing directions between waypoints for the specified profile.",
+        "tags": ["Directions"],
+        "parameters": [
+          {
+            "name": "profile",
+            "in": "path",
+            "required": true,
+            "description": "Routing profile.",
+            "schema": {
+              "type": "string",
+              "enum": ["driving", "cycling", "walking", "foot"]
+            }
+          },
+          {
+            "name": "coordinates",
+            "in": "path",
+            "required": true,
+            "description": "Semicolon-separated list of coordinates (lon,lat;lon,lat).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "steps",
+            "in": "query",
+            "required": false,
+            "description": "Include turn-by-turn instructions.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "alternatives",
+            "in": "query",
+            "required": false,
+            "description": "Return alternative routes.",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "geometries",
+            "in": "query",
+            "required": false,
+            "description": "Geometry encoding format.",
+            "schema": {
+              "type": "string",
+              "enum": ["polyline", "polyline6", "geojson"]
+            }
+          },
+          {
+            "name": "overview",
+            "in": "query",
+            "required": false,
+            "description": "Level of overview geometry detail.",
+            "schema": {
+              "type": "string",
+              "enum": ["simplified", "full", "false"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful directions response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DirectionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/balance": {
+      "get": {
+        "operationId": "getBalance",
+        "summary": "Check account balance",
+        "description": "Returns the count of request credits remaining for the current day. Balance resets at midnight UTC.",
+        "tags": ["Account"],
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "Successful balance check.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalanceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "key",
+        "in": "query",
+        "description": "LocationIQ access token passed as a query parameter."
+      }
+    },
+    "schemas": {
+      "GeocodingResult": {
+        "type": "object",
+        "properties": {
+          "place_id": {
+            "type": "string",
+            "description": "Unique location identifier."
+          },
+          "licence": {
+            "type": "string",
+            "description": "Data attribution licence."
+          },
+          "osm_type": {
+            "type": "string",
+            "description": "OpenStreetMap object type."
+          },
+          "osm_id": {
+            "type": "string",
+            "description": "OpenStreetMap object identifier."
+          },
+          "lat": {
+            "type": "string",
+            "description": "Latitude coordinate."
+          },
+          "lon": {
+            "type": "string",
+            "description": "Longitude coordinate."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Formatted address for display."
+          },
+          "class": {
+            "type": "string",
+            "description": "Result category."
+          },
+          "type": {
+            "type": "string",
+            "description": "Result type within category."
+          },
+          "importance": {
+            "type": "number",
+            "description": "Relevance score (0-1)."
+          },
+          "icon": {
+            "type": "string",
+            "description": "Result icon URL."
+          },
+          "boundingbox": {
+            "type": "array",
+            "description": "Bounding box [min_lat, max_lat, min_lon, max_lon].",
+            "items": {
+              "type": "string"
+            }
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDetails"
+          },
+          "namedetails": {
+            "type": "object",
+            "description": "Alternative names and language variants.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "extratags": {
+            "type": "object",
+            "description": "Additional metadata (Wikipedia, opening hours, etc.).",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "matchquality": {
+            "type": "object",
+            "properties": {
+              "matchcode": {
+                "type": "string"
+              },
+              "matchtype": {
+                "type": "string"
+              },
+              "matchlevel": {
+                "type": "string"
+              }
+            }
+          },
+          "postaladdress": {
+            "type": "string",
+            "description": "Country-specific formatted postal address."
+          }
+        }
+      },
+      "AddressDetails": {
+        "type": "object",
+        "description": "Breakdown of the address into components.",
+        "properties": {
+          "house_number": {
+            "type": "string"
+          },
+          "road": {
+            "type": "string"
+          },
+          "neighbourhood": {
+            "type": "string"
+          },
+          "suburb": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "county": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "country_code": {
+            "type": "string"
+          }
+        }
+      },
+      "AutocompleteResult": {
+        "type": "object",
+        "properties": {
+          "place_id": {
+            "type": "string",
+            "description": "Unique place identifier."
+          },
+          "osm_id": {
+            "type": "string"
+          },
+          "osm_type": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "string",
+            "description": "Latitude."
+          },
+          "lon": {
+            "type": "string",
+            "description": "Longitude."
+          },
+          "display_name": {
+            "type": "string",
+            "description": "Full address with complete details."
+          },
+          "display_place": {
+            "type": "string",
+            "description": "Place name or road name portion only."
+          },
+          "display_address": {
+            "type": "string",
+            "description": "Complete address without the display_place text."
+          },
+          "boundingbox": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "address": {
+            "$ref": "#/components/schemas/AddressDetails"
+          }
+        }
+      },
+      "TimezoneResponse": {
+        "type": "object",
+        "properties": {
+          "timezone": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "IANA timezone identifier (e.g., America/New_York)."
+              },
+              "now_in_dst": {
+                "type": "integer",
+                "description": "Whether DST is currently active (0 or 1).",
+                "enum": [0, 1]
+              },
+              "offset_sec": {
+                "type": "integer",
+                "description": "UTC offset in seconds, accounting for DST."
+              },
+              "short_name": {
+                "type": "string",
+                "description": "Timezone abbreviation (e.g., EDT, CEST)."
+              },
+              "full_name": {
+                "type": "string",
+                "description": "Full timezone name (e.g., Eastern Daylight Time)."
+              }
+            }
+          }
+        }
+      },
+      "DirectionsResponse": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "description": "Status code (e.g., Ok)."
+          },
+          "routes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "geometry": {
+                  "type": "string",
+                  "description": "Route geometry in the requested format."
+                },
+                "distance": {
+                  "type": "number",
+                  "description": "Total distance in meters."
+                },
+                "duration": {
+                  "type": "number",
+                  "description": "Total duration in seconds."
+                },
+                "legs": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "distance": {
+                        "type": "number"
+                      },
+                      "duration": {
+                        "type": "number"
+                      },
+                      "steps": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "geometry": {
+                              "type": "string"
+                            },
+                            "distance": {
+                              "type": "number"
+                            },
+                            "duration": {
+                              "type": "number"
+                            },
+                            "name": {
+                              "type": "string"
+                            },
+                            "maneuver": {
+                              "type": "object",
+                              "properties": {
+                                "type": {
+                                  "type": "string"
+                                },
+                                "modifier": {
+                                  "type": "string"
+                                },
+                                "location": {
+                                  "type": "array",
+                                  "items": {
+                                    "type": "number"
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "waypoints": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "array",
+                  "items": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "BalanceResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Status of the request."
+          },
+          "balance": {
+            "type": "object",
+            "properties": {
+              "day": {
+                "type": "integer",
+                "description": "Remaining daily request credits."
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "description": "Error message."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/locationiq.com/locationiq/meta.json
+++ b/apis/openapi/locationiq.com/locationiq/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "8ef6c621434d7602921c083a45499763",
+    "format": "openapi",
+    "vendor": "locationiq.com",
+    "api_name": "locationiq",
+    "friendly_id": "locationiq.com/locationiq"
+  }
+}

--- a/apis/openapi/map.longdo.com/longdo-map/1.0.0/openapi.json
+++ b/apis/openapi/map.longdo.com/longdo-map/1.0.0/openapi.json
@@ -1,0 +1,2168 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Longdo Map API",
+    "description": "Longdo Map provides online mapping services for Thailand and the world, including search, suggest, geocoding, reverse geocoding, address extraction, routing, traffic, TSP (route planning), and POI services. All endpoints require an API key passed as a query parameter.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Longdo Map",
+      "url": "https://map.longdo.com"
+    },
+    "x-jentic-source-url": "https://map.longdo.com/docs/"
+  },
+  "servers": [
+    {
+      "url": "https://search.longdo.com",
+      "description": "Longdo Search server"
+    },
+    {
+      "url": "https://api.longdo.com",
+      "description": "Longdo API server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Search",
+      "description": "Place and keyword search"
+    },
+    {
+      "name": "Geocoding",
+      "description": "Address geocoding and reverse geocoding"
+    },
+    {
+      "name": "Address",
+      "description": "Address extraction and lookup"
+    },
+    {
+      "name": "Routing",
+      "description": "Route calculation and navigation"
+    },
+    {
+      "name": "Traffic",
+      "description": "Traffic speed and road info"
+    },
+    {
+      "name": "POI",
+      "description": "Points of interest"
+    },
+    {
+      "name": "Area",
+      "description": "Area information services"
+    }
+  ],
+  "paths": {
+    "/mapsearch/json/suggest": {
+      "get": {
+        "operationId": "suggest",
+        "summary": "Search suggestions",
+        "description": "Returns search suggestions for the given keyword.",
+        "tags": ["Search"],
+        "servers": [
+          {
+            "url": "https://search.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": true,
+            "description": "Search suggestion term.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "area",
+            "in": "query",
+            "required": false,
+            "description": "Geocode filter (comma-separated values).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Result offset.",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results.",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": false,
+            "description": "Dataset filter (comma-separated values).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "API key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "description": "JSONP callback function name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful suggest response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SuggestResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/mapsearch/json/search": {
+      "get": {
+        "operationId": "search",
+        "summary": "Place search",
+        "description": "Searches for places matching the given keyword.",
+        "tags": ["Search"],
+        "servers": [
+          {
+            "url": "https://search.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": true,
+            "description": "Search keyword.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "area",
+            "in": "query",
+            "required": false,
+            "description": "Geocode area filter (CSV).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "description": "Search center longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "description": "Search center latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": false,
+            "description": "Distance with unit (e.g., 1000m, 5km, 0.1deg).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Tag filter (CSV).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "description": "Language locale.",
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/smartsearch/json/search": {
+      "get": {
+        "operationId": "smartSearch",
+        "summary": "Smart search",
+        "description": "Enhanced search with smart matching and extended search capabilities.",
+        "tags": ["Search"],
+        "servers": [
+          {
+            "url": "https://search.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "keyword",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "forcesmartsearch",
+            "in": "query",
+            "required": false,
+            "description": "0=only when few results (default), 1=always.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "forcelimit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "extendedsearch",
+            "in": "query",
+            "required": false,
+            "description": "0=no, 1=when few results, 2=always, 3=extended only.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1, 2, 3],
+              "default": 0
+            }
+          },
+          {
+            "name": "extendedlimit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 3
+            }
+          },
+          {
+            "name": "extendedtype",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["findplacefromtext", "textsearch"]
+            }
+          },
+          {
+            "name": "extractaddress",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful smart search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/smartsearch/json/extract_address/v2": {
+      "get": {
+        "operationId": "extractAddress",
+        "summary": "Extract address from text",
+        "description": "Parses and extracts structured address components from free-form text.",
+        "tags": ["Address"],
+        "servers": [
+          {
+            "url": "https://search.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "description": "Address text to parse.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "correction",
+            "in": "query",
+            "required": false,
+            "description": "Enable text correction (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 1
+            }
+          },
+          {
+            "name": "censor",
+            "in": "query",
+            "required": false,
+            "description": "Remove phone numbers and emails (0 or 1).",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful address extraction.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExtractAddressResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/addresslookup/api/addr/geocoding": {
+      "get": {
+        "operationId": "geocode",
+        "summary": "Geocode address",
+        "description": "Converts an address text into geographic coordinates.",
+        "tags": ["Geocoding"],
+        "servers": [
+          {
+            "url": "https://search.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "text",
+            "in": "query",
+            "required": true,
+            "description": "Address text to geocode.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodingResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/map/services/address": {
+      "get": {
+        "operationId": "reverseGeocode",
+        "summary": "Reverse geocode",
+        "description": "Converts coordinates or a Longdo Map ID to a readable address with administrative divisions.",
+        "tags": ["Geocoding"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "description": "Longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "description": "Latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "id",
+            "in": "query",
+            "required": false,
+            "description": "Longdo Map ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "noaddress",
+            "in": "query",
+            "required": false,
+            "description": "Exclude administrative data.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "noelevation",
+            "in": "query",
+            "required": false,
+            "description": "Exclude elevation data.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "noroad",
+            "in": "query",
+            "required": false,
+            "description": "Exclude road information.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReverseGeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/map/services/addresses": {
+      "get": {
+        "operationId": "batchReverseGeocode",
+        "summary": "Batch reverse geocode",
+        "description": "Reverse geocodes multiple coordinates at once (max 100).",
+        "tags": ["Geocoding"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lon[]",
+            "in": "query",
+            "required": false,
+            "description": "Array of longitudes (max 100).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 100
+            }
+          },
+          {
+            "name": "lat[]",
+            "in": "query",
+            "required": false,
+            "description": "Array of latitudes (max 100).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 100
+            }
+          },
+          {
+            "name": "wkt",
+            "in": "query",
+            "required": false,
+            "description": "Well-known text as alternative to lon[]/lat[] arrays.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful batch reverse geocoding.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ReverseGeocodeResponse"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/POIService/json/address": {
+      "get": {
+        "operationId": "lookupGeocodePostcode",
+        "summary": "Geocode/postcode lookup",
+        "description": "Looks up administrative area information by geocode or postcode.",
+        "tags": ["Address"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "geocode",
+            "in": "query",
+            "required": false,
+            "description": "Area geocode.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postcode",
+            "in": "query",
+            "required": false,
+            "description": "Postal code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostcodeLookupResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/POIService/json/search": {
+      "get": {
+        "operationId": "nearbyPOI",
+        "summary": "Nearby POI search",
+        "description": "Searches for nearby points of interest.",
+        "tags": ["POI"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lon",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "area",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tag",
+            "in": "query",
+            "required": false,
+            "description": "Tag filter (CSV).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "zoom",
+            "in": "query",
+            "required": false,
+            "description": "POI importance level.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "dataset",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful POI search.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/route/guide": {
+      "get": {
+        "operationId": "calculateRoute",
+        "summary": "Calculate route with turn-by-turn guide",
+        "description": "Calculates a route between two points with step-by-step navigation instructions.",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "flon",
+            "in": "query",
+            "required": true,
+            "description": "Start longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "flat",
+            "in": "query",
+            "required": true,
+            "description": "Start latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "tlon",
+            "in": "query",
+            "required": true,
+            "description": "Destination longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "tlat",
+            "in": "query",
+            "required": true,
+            "description": "Destination latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "description": "Route mode: t=fastest+avoid traffic, c=fastest, d=shortest, e=shortest+traffic.",
+            "schema": {
+              "type": "string",
+              "enum": ["t", "c", "d", "e"],
+              "default": "t"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Route type (bitwise OR): 1=Road, 8=Ferry, 16=Tollway.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "restrict",
+            "in": "query",
+            "required": false,
+            "description": "Route restrictions: 0=none, 1=no motorcycle restrictions.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "time",
+            "in": "query",
+            "required": false,
+            "description": "Departure time as Unix timestamp.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "maxresult",
+            "in": "query",
+            "required": false,
+            "description": "Maximum alternative routes (1-8).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 8,
+              "default": 1
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful route calculation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteGuideResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Route not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/route/path": {
+      "get": {
+        "operationId": "getRoutePath",
+        "summary": "Get route path coordinates",
+        "description": "Returns the coordinate array for a route line by path ID.",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "query",
+            "required": true,
+            "description": "Path ID from calculateRoute response.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful path retrieval.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Path not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/route/matrix": {
+      "get": {
+        "operationId": "calculateRouteMatrix",
+        "summary": "Calculate route matrix",
+        "description": "Calculates distance and time between multiple origin-destination pairs (max 25 each).",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "flon[]",
+            "in": "query",
+            "required": true,
+            "description": "Array of start longitudes (max 25).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 25
+            }
+          },
+          {
+            "name": "flat[]",
+            "in": "query",
+            "required": true,
+            "description": "Array of start latitudes (max 25).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 25
+            }
+          },
+          {
+            "name": "tlon[]",
+            "in": "query",
+            "required": true,
+            "description": "Array of destination longitudes (max 25).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 25
+            }
+          },
+          {
+            "name": "tlat[]",
+            "in": "query",
+            "required": true,
+            "description": "Array of destination latitudes (max 25).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "number",
+                "format": "double"
+              },
+              "maxItems": 25
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["t", "c", "d", "e"],
+              "default": "t"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful matrix calculation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteMatrixResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/route/snap": {
+      "get": {
+        "operationId": "snapToRoad",
+        "summary": "Snap coordinates to road",
+        "description": "Snaps GPS coordinates to the nearest road.",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "wkt",
+            "in": "query",
+            "required": true,
+            "description": "LineString in WKT format.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful snap to road.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/traffic/speed": {
+      "get": {
+        "operationId": "getTrafficSpeed",
+        "summary": "Get traffic speed",
+        "description": "Returns traffic speed data for roads near the specified location.",
+        "tags": ["Traffic"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "lon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "range",
+            "in": "query",
+            "required": false,
+            "description": "Search range (default 0.001, max ~100m equivalent).",
+            "schema": {
+              "type": "number",
+              "default": 0.001
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["th", "en"],
+              "default": "th"
+            }
+          },
+          {
+            "name": "time",
+            "in": "query",
+            "required": false,
+            "description": "Unix timestamp for predicted traffic data.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful traffic speed lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrafficSpeedResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No road found at location.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/RouteService/json/span/get": {
+      "get": {
+        "operationId": "getSpanArea",
+        "summary": "Get reachable area (isochrone)",
+        "description": "Returns the area reachable from a starting point within a given distance or time.",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "flon",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "flat",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "span",
+            "in": "query",
+            "required": true,
+            "description": "Distance or time limit (e.g., 5000m, 1800s). Max 30000m or 1800s.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "flag",
+            "in": "query",
+            "required": false,
+            "description": "Response content: 1=road lines, 2=boundary, 3=both.",
+            "schema": {
+              "type": "integer",
+              "enum": [1, 2, 3]
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful span area calculation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SpanAreaResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/route-tsp-v2": {
+      "post": {
+        "operationId": "solveTSP",
+        "summary": "Travelling Salesman Problem solver",
+        "description": "Optimizes visit order for multiple locations (route planning).",
+        "tags": ["Routing"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["lon[]", "lat[]"],
+                "properties": {
+                  "lon[]": {
+                    "type": "array",
+                    "items": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "description": "Array of longitudes."
+                  },
+                  "lat[]": {
+                    "type": "array",
+                    "items": {
+                      "type": "number",
+                      "format": "double"
+                    },
+                    "description": "Array of latitudes."
+                  },
+                  "cost": {
+                    "type": "boolean",
+                    "description": "Include step details.",
+                    "default": false
+                  },
+                  "otsp": {
+                    "type": "boolean",
+                    "description": "Open loop (do not return to start).",
+                    "default": false
+                  },
+                  "mode": {
+                    "type": "string",
+                    "description": "Route mode.",
+                    "enum": ["t", "c", "d", "e"],
+                    "default": "t"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "API key."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful TSP solution.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TSPResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/GeoServiceMS/json/areainfo": {
+      "get": {
+        "operationId": "getAreaInfo",
+        "summary": "Get area information",
+        "description": "Returns information about the given area polygon, such as building count.",
+        "tags": ["Area"],
+        "servers": [
+          {
+            "url": "https://api.longdo.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "polygon",
+            "in": "query",
+            "required": true,
+            "description": "Area polygon in GeoJSON format.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful area info.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AreaInfoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "key",
+        "in": "query",
+        "description": "Longdo Map API key."
+      }
+    },
+    "schemas": {
+      "SuggestResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "w": {
+                  "type": "string",
+                  "description": "Suggested keyword."
+                },
+                "c": {
+                  "type": "integer",
+                  "description": "Result count."
+                }
+              }
+            }
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "total": {
+                "type": "integer"
+              },
+              "offset": {
+                "type": "integer"
+              },
+              "limit": {
+                "type": "integer"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlaceResult"
+            }
+          }
+        }
+      },
+      "PlaceResult": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Place ID."
+          },
+          "name": {
+            "type": "string",
+            "description": "Place name."
+          },
+          "name_en": {
+            "type": "string",
+            "description": "Place name in English."
+          },
+          "lat": {
+            "type": "number",
+            "format": "double"
+          },
+          "lon": {
+            "type": "number",
+            "format": "double"
+          },
+          "address": {
+            "type": "string"
+          },
+          "tel": {
+            "type": "string"
+          },
+          "tag": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "geocode": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "verified": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ExtractAddressResponse": {
+        "type": "object",
+        "properties": {
+          "house_number": {
+            "type": "string"
+          },
+          "floor": {
+            "type": "string"
+          },
+          "building": {
+            "type": "string"
+          },
+          "road": {
+            "type": "string"
+          },
+          "subdistrict": {
+            "type": "string"
+          },
+          "district": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number",
+            "description": "Confidence score."
+          }
+        }
+      },
+      "GeocodingResponse": {
+        "type": "object",
+        "properties": {
+          "confidence": {
+            "type": "number",
+            "description": "Geocoding confidence score."
+          },
+          "point": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "format": "double"
+              },
+              "lon": {
+                "type": "number",
+                "format": "double"
+              }
+            }
+          },
+          "road": {
+            "type": "string"
+          },
+          "village": {
+            "type": "string"
+          },
+          "subdistrict": {
+            "type": "string"
+          },
+          "district": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          }
+        }
+      },
+      "ReverseGeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "geocode": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          },
+          "province": {
+            "type": "string"
+          },
+          "district": {
+            "type": "string"
+          },
+          "subdistrict": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "elevation": {
+            "type": "number",
+            "description": "Elevation in meters."
+          },
+          "road": {
+            "type": "string"
+          }
+        }
+      },
+      "PostcodeLookupResponse": {
+        "type": "object",
+        "properties": {
+          "province": {
+            "type": "string"
+          },
+          "district": {
+            "type": "string"
+          },
+          "subdistrict": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number",
+            "format": "double"
+          },
+          "lon": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "RouteGuideResponse": {
+        "type": "object",
+        "properties": {
+          "meta": {
+            "type": "object",
+            "properties": {
+              "from": {
+                "type": "string"
+              },
+              "to": {
+                "type": "string"
+              }
+            }
+          },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "distance": {
+                  "type": "number",
+                  "description": "Distance in meters."
+                },
+                "interval": {
+                  "type": "number",
+                  "description": "Estimated time in seconds."
+                },
+                "guide": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "name": {
+                        "type": "string",
+                        "description": "Road name."
+                      },
+                      "turn": {
+                        "type": "integer",
+                        "description": "Turn code (0-3=turn, 5=straight, 9=arrive)."
+                      },
+                      "distance": {
+                        "type": "number"
+                      },
+                      "interval": {
+                        "type": "number"
+                      },
+                      "path": {
+                        "type": "integer",
+                        "description": "Path ID for getRoutePath."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "RouteMatrixResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "2D array of distance/time pairs.",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "distance": {
+                    "type": "number"
+                  },
+                  "interval": {
+                    "type": "number"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "TrafficSpeedResponse": {
+        "type": "object",
+        "properties": {
+          "road": {
+            "type": "string",
+            "description": "Road name."
+          },
+          "direction": {
+            "type": "string",
+            "description": "Traffic direction."
+          },
+          "speed": {
+            "type": "number",
+            "description": "Speed in m/s."
+          },
+          "source": {
+            "type": "string",
+            "description": "Data source (real-time or predicted)."
+          },
+          "nearest": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "format": "double"
+              },
+              "lon": {
+                "type": "number",
+                "format": "double"
+              }
+            }
+          }
+        }
+      },
+      "SpanAreaResponse": {
+        "type": "object",
+        "properties": {
+          "start": {
+            "type": "object",
+            "properties": {
+              "lat": {
+                "type": "number",
+                "format": "double"
+              },
+              "lon": {
+                "type": "number",
+                "format": "double"
+              }
+            }
+          },
+          "lines": {
+            "type": "array",
+            "description": "Road line coordinates.",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "polygon": {
+            "type": "string",
+            "description": "Boundary polygon in WKT format."
+          }
+        }
+      },
+      "TSPResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "otsp": {
+            "type": "boolean",
+            "description": "Whether open loop was used."
+          },
+          "sequence": {
+            "type": "array",
+            "description": "Optimal visit order.",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "locations": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "lat": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "lon": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          },
+          "total_distance": {
+            "type": "number",
+            "description": "Total distance in meters."
+          },
+          "total_time": {
+            "type": "number",
+            "description": "Total time in seconds."
+          },
+          "time_step": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          },
+          "distance_step": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "AreaInfoResponse": {
+        "type": "object",
+        "properties": {
+          "building_count": {
+            "type": "integer",
+            "description": "Number of buildings in the area."
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code."
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/map.longdo.com/longdo-map/meta.json
+++ b/apis/openapi/map.longdo.com/longdo-map/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "3efa5bb6e80ed4ffdb4b97d0931c5387",
+    "format": "openapi",
+    "vendor": "map.longdo.com",
+    "api_name": "longdo-map",
+    "friendly_id": "map.longdo.com/longdo-map"
+  }
+}

--- a/apis/openapi/mapquest.com/mapquest/1.0.0/openapi.json
+++ b/apis/openapi/mapquest.com/mapquest/1.0.0/openapi.json
@@ -1,0 +1,2116 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "MapQuest API",
+    "description": "MapQuest provides a suite of mapping APIs including geocoding, directions, static maps, search ahead, place search, and traffic data. These APIs enable address geocoding, route calculation, map image generation, predictive search, and real-time traffic information.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "MapQuest Developer",
+      "url": "https://developer.mapquest.com"
+    },
+    "x-jentic-source-url": "https://developer.mapquest.com/"
+  },
+  "servers": [
+    {
+      "url": "https://www.mapquestapi.com",
+      "description": "MapQuest API server"
+    },
+    {
+      "url": "https://api.mapquest.com",
+      "description": "MapQuest Directions API server"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Forward and reverse geocoding of addresses and coordinates"
+    },
+    {
+      "name": "Batch Geocoding",
+      "description": "Batch and async batch geocoding operations"
+    },
+    {
+      "name": "Directions",
+      "description": "Route calculation, optimization, and alternatives"
+    },
+    {
+      "name": "Search Ahead",
+      "description": "Spatially-aware predictive search"
+    },
+    {
+      "name": "Static Map",
+      "description": "Generate static map images"
+    },
+    {
+      "name": "Place Search",
+      "description": "Search for places, businesses, and points of interest"
+    }
+  ],
+  "paths": {
+    "/geocoding/v1/address": {
+      "get": {
+        "operationId": "geocodeAddress",
+        "summary": "Forward Geocode Address",
+        "description": "Convert a street address to geographic coordinates (latitude/longitude). Supports single-line and 5-box input formats.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "MapQuest API key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": false,
+            "description": "Single-line address to geocode.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1600 Pennsylvania Ave NW,Washington,DC,20500"
+          },
+          {
+            "name": "street",
+            "in": "query",
+            "required": false,
+            "description": "Street address (5-box format).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "required": false,
+            "description": "City name (5-box format).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "description": "State or province (5-box format).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postalCode",
+            "in": "query",
+            "required": false,
+            "description": "Postal/ZIP code (5-box format).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Country code (5-box format).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "description": "Output format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "thumbMaps",
+            "in": "query",
+            "required": false,
+            "description": "Whether to return thumbnail map URLs.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          },
+          {
+            "name": "maxResults",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results to return.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API key.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - API key does not have access.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "geocodeAddressPost",
+        "summary": "Forward Geocode Address (POST)",
+        "description": "Convert a street address to geographic coordinates using POST method.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "MapQuest API key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "string",
+                    "description": "Single-line address to geocode."
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "thumbMaps": {
+                        "type": "boolean"
+                      },
+                      "maxResults": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geocoding/v1/reverse": {
+      "get": {
+        "operationId": "reverseGeocode",
+        "summary": "Reverse Geocode",
+        "description": "Convert a latitude/longitude pair to a street address.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "description": "MapQuest API key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": true,
+            "description": "Latitude,longitude pair.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "38.8976633,-77.0365739"
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "description": "Output format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "thumbMaps",
+            "in": "query",
+            "required": false,
+            "description": "Whether to return thumbnail map URLs.",
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "reverseGeocodePost",
+        "summary": "Reverse Geocode (POST)",
+        "description": "Convert a latitude/longitude pair to a street address using POST.",
+        "tags": ["Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "location": {
+                    "type": "object",
+                    "properties": {
+                      "latLng": {
+                        "type": "object",
+                        "properties": {
+                          "lat": {
+                            "type": "number"
+                          },
+                          "lng": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geocoding/v1/batch": {
+      "get": {
+        "operationId": "batchGeocode",
+        "summary": "Batch Geocode",
+        "description": "Geocode up to 100 addresses in a single request.",
+        "tags": ["Batch Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": true,
+            "description": "Address(es) to geocode. Use multiple location parameters for batch.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": true
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "thumbMaps",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful batch geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "batchGeocodePost",
+        "summary": "Batch Geocode (POST)",
+        "description": "Geocode up to 100 addresses in a single POST request.",
+        "tags": ["Batch Geocoding"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "locations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of addresses to geocode."
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "thumbMaps": {
+                        "type": "boolean"
+                      },
+                      "maxResults": {
+                        "type": "integer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/v2/route": {
+      "get": {
+        "operationId": "getRoute",
+        "summary": "Get Route",
+        "description": "Calculate a route between two or more locations with turn-by-turn narrative, distance, and time.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "description": "Starting location.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "description": "Destination location(s). Can specify multiple.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": true
+          },
+          {
+            "name": "routeType",
+            "in": "query",
+            "required": false,
+            "description": "Type of route to calculate.",
+            "schema": {
+              "type": "string",
+              "enum": ["fastest", "shortest", "pedestrian", "bicycle"],
+              "default": "fastest"
+            }
+          },
+          {
+            "name": "unit",
+            "in": "query",
+            "required": false,
+            "description": "Distance unit.",
+            "schema": {
+              "type": "string",
+              "enum": ["m", "k"],
+              "default": "m"
+            }
+          },
+          {
+            "name": "locale",
+            "in": "query",
+            "required": false,
+            "description": "Locale for narrative text.",
+            "schema": {
+              "type": "string",
+              "default": "en_US"
+            }
+          },
+          {
+            "name": "avoids",
+            "in": "query",
+            "required": false,
+            "description": "Road features to avoid.",
+            "schema": {
+              "type": "string",
+              "enum": ["Limited Access", "Toll Road", "Ferry", "Unpaved", "Seasonal Closure", "Country Border Crossing"]
+            }
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful route response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "getRoutePost",
+        "summary": "Get Route (POST)",
+        "description": "Calculate a route using POST method for complex requests.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RouteRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful route response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/v2/optimizedroute": {
+      "get": {
+        "operationId": "getOptimizedRoute",
+        "summary": "Get Optimized Route",
+        "description": "Calculate an optimized route that reorders waypoints for the most efficient path.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "description": "Starting location.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "description": "Destination location(s).",
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "explode": true
+          },
+          {
+            "name": "routeType",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["fastest", "shortest", "pedestrian", "bicycle"],
+              "default": "fastest"
+            }
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful optimized route response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/v2/alternateroutes": {
+      "get": {
+        "operationId": "getAlternateRoutes",
+        "summary": "Get Alternate Routes",
+        "description": "Get multiple route alternatives between locations.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "maxRoutes",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of alternate routes to return.",
+            "schema": {
+              "type": "integer",
+              "default": 3
+            }
+          },
+          {
+            "name": "timeOverage",
+            "in": "query",
+            "required": false,
+            "description": "Maximum percentage of time overage for alternate routes.",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful alternate routes response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlternateRoutesResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/v2/routematrix": {
+      "post": {
+        "operationId": "getRouteMatrix",
+        "summary": "Get Route Matrix",
+        "description": "Calculate distances and times between multiple locations in a matrix.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "locations": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of locations."
+                  },
+                  "options": {
+                    "type": "object",
+                    "properties": {
+                      "allToAll": {
+                        "type": "boolean",
+                        "description": "If true, compute all-to-all matrix."
+                      },
+                      "manyToOne": {
+                        "type": "boolean",
+                        "description": "If true, compute many-to-one matrix."
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful route matrix response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteMatrixResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/directions/v2/routeshape": {
+      "get": {
+        "operationId": "getRouteShape",
+        "summary": "Get Route Shape",
+        "description": "Retrieve the shape/geometry of a previously computed route.",
+        "tags": ["Directions"],
+        "servers": [
+          {
+            "url": "https://api.mapquest.com"
+          }
+        ],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sessionId",
+            "in": "query",
+            "required": true,
+            "description": "Session ID from a previous route request.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "outFormat",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "json"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful route shape response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RouteShapeResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/staticmap/v5/map": {
+      "get": {
+        "operationId": "getStaticMap",
+        "summary": "Get Static Map",
+        "description": "Generate a static map image with optional locations, routes, and overlays.",
+        "tags": ["Static Map"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "center",
+            "in": "query",
+            "required": false,
+            "description": "Center of the map as latitude,longitude or address.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "zoom",
+            "in": "query",
+            "required": false,
+            "description": "Map zoom level (0-20).",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "maximum": 20
+            }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "required": false,
+            "description": "Map image dimensions as width,height in pixels.",
+            "schema": {
+              "type": "string",
+              "default": "400,200"
+            }
+          },
+          {
+            "name": "type",
+            "in": "query",
+            "required": false,
+            "description": "Map type.",
+            "schema": {
+              "type": "string",
+              "enum": ["map", "sat", "hyb", "light", "dark"],
+              "default": "map"
+            }
+          },
+          {
+            "name": "locations",
+            "in": "query",
+            "required": false,
+            "description": "Pipe-separated list of marker locations.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "scalebar",
+            "in": "query",
+            "required": false,
+            "description": "Whether to show scale bar.",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "required": false,
+            "description": "Image format.",
+            "schema": {
+              "type": "string",
+              "enum": ["png", "jpg", "gif"],
+              "default": "png"
+            }
+          },
+          {
+            "name": "margin",
+            "in": "query",
+            "required": false,
+            "description": "Margin in pixels.",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map image.",
+            "content": {
+              "image/png": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/gif": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/v4/place": {
+      "get": {
+        "operationId": "searchPlaces",
+        "summary": "Search Places",
+        "description": "Search for places, businesses, and points of interest around the world.",
+        "tags": ["Place Search"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": false,
+            "description": "Search query string.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": false,
+            "description": "Center point as latitude,longitude.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "required": false,
+            "description": "Sort order for results.",
+            "schema": {
+              "type": "string",
+              "enum": ["relevance", "distance"]
+            }
+          },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page.",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number.",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "required": false,
+            "description": "Filter by category (e.g., restaurant, hotel).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlaceSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/v3/prediction": {
+      "get": {
+        "operationId": "searchAhead",
+        "summary": "Search Ahead (Predictive)",
+        "description": "Spatially-aware predictive search engine for type-ahead functionality.",
+        "tags": ["Search Ahead"],
+        "parameters": [
+          {
+            "name": "key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string (partial or complete).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "required": false,
+            "description": "Center point as latitude,longitude for spatial bias.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "collection",
+            "in": "query",
+            "required": false,
+            "description": "Collection to search (e.g., address, adminArea, poi, category, franchise, airport).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Maximum number of results.",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "countryCode",
+            "in": "query",
+            "required": false,
+            "description": "Filter by 2-letter country code.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search ahead response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchAheadResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "key",
+        "description": "MapQuest API key obtained from the developer portal."
+      }
+    },
+    "schemas": {
+      "GeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer",
+                "description": "Status code (0 = success)."
+              },
+              "copyright": {
+                "type": "object",
+                "properties": {
+                  "text": {
+                    "type": "string"
+                  },
+                  "imageUrl": {
+                    "type": "string"
+                  },
+                  "imageAltText": {
+                    "type": "string"
+                  }
+                }
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "options": {
+            "type": "object",
+            "properties": {
+              "maxResults": {
+                "type": "integer"
+              },
+              "thumbMaps": {
+                "type": "boolean"
+              },
+              "ignoreLatLngInput": {
+                "type": "boolean"
+              }
+            }
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "providedLocation": {
+                  "type": "object",
+                  "properties": {
+                    "location": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "locations": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Location"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "street": {
+            "type": "string"
+          },
+          "adminArea6": {
+            "type": "string",
+            "description": "Neighborhood."
+          },
+          "adminArea6Type": {
+            "type": "string"
+          },
+          "adminArea5": {
+            "type": "string",
+            "description": "City."
+          },
+          "adminArea5Type": {
+            "type": "string"
+          },
+          "adminArea4": {
+            "type": "string",
+            "description": "County."
+          },
+          "adminArea4Type": {
+            "type": "string"
+          },
+          "adminArea3": {
+            "type": "string",
+            "description": "State."
+          },
+          "adminArea3Type": {
+            "type": "string"
+          },
+          "adminArea1": {
+            "type": "string",
+            "description": "Country."
+          },
+          "adminArea1Type": {
+            "type": "string"
+          },
+          "postalCode": {
+            "type": "string"
+          },
+          "geocodeQualityCode": {
+            "type": "string",
+            "description": "Quality code indicating geocode precision."
+          },
+          "geocodeQuality": {
+            "type": "string",
+            "description": "Quality description (e.g., POINT, ADDRESS, CITY)."
+          },
+          "dragPoint": {
+            "type": "boolean"
+          },
+          "sideOfStreet": {
+            "type": "string"
+          },
+          "linkId": {
+            "type": "string"
+          },
+          "unknownInput": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "latLng": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "displayLatLng": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "mapUrl": {
+            "type": "string",
+            "description": "URL to a thumbnail map of the location."
+          }
+        }
+      },
+      "LatLng": {
+        "type": "object",
+        "properties": {
+          "lat": {
+            "type": "number",
+            "format": "double"
+          },
+          "lng": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "RouteRequest": {
+        "type": "object",
+        "properties": {
+          "locations": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Array of locations (first is origin, last is destination, middle are waypoints)."
+          },
+          "options": {
+            "type": "object",
+            "properties": {
+              "routeType": {
+                "type": "string",
+                "enum": ["fastest", "shortest", "pedestrian", "bicycle"]
+              },
+              "avoids": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "unit": {
+                "type": "string",
+                "enum": ["m", "k"]
+              },
+              "locale": {
+                "type": "string"
+              },
+              "narrativeType": {
+                "type": "string",
+                "enum": ["text", "html", "microformat"]
+              },
+              "enhancedNarrative": {
+                "type": "boolean"
+              },
+              "drivingStyle": {
+                "type": "integer",
+                "description": "1=cautious, 2=normal, 3=aggressive"
+              },
+              "highwayEfficiency": {
+                "type": "number",
+                "description": "Highway fuel efficiency multiplier."
+              }
+            }
+          }
+        }
+      },
+      "RouteResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer"
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "route": {
+            "type": "object",
+            "properties": {
+              "sessionId": {
+                "type": "string"
+              },
+              "realTime": {
+                "type": "integer"
+              },
+              "distance": {
+                "type": "number",
+                "format": "double"
+              },
+              "time": {
+                "type": "integer",
+                "description": "Estimated travel time in seconds."
+              },
+              "formattedTime": {
+                "type": "string"
+              },
+              "hasHighway": {
+                "type": "boolean"
+              },
+              "hasTollRoad": {
+                "type": "boolean"
+              },
+              "hasFerry": {
+                "type": "boolean"
+              },
+              "hasUnpaved": {
+                "type": "boolean"
+              },
+              "hasSeasonalClosure": {
+                "type": "boolean"
+              },
+              "hasCountryCross": {
+                "type": "boolean"
+              },
+              "fuelUsed": {
+                "type": "number",
+                "format": "double"
+              },
+              "legs": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/RouteLeg"
+                }
+              },
+              "boundingBox": {
+                "type": "object",
+                "properties": {
+                  "ul": {
+                    "$ref": "#/components/schemas/LatLng"
+                  },
+                  "lr": {
+                    "$ref": "#/components/schemas/LatLng"
+                  }
+                }
+              },
+              "shape": {
+                "type": "object",
+                "properties": {
+                  "shapePoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "RouteLeg": {
+        "type": "object",
+        "properties": {
+          "index": {
+            "type": "integer"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "formattedTime": {
+            "type": "string"
+          },
+          "maneuvers": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Maneuver"
+            }
+          }
+        }
+      },
+      "Maneuver": {
+        "type": "object",
+        "properties": {
+          "narrative": {
+            "type": "string"
+          },
+          "distance": {
+            "type": "number",
+            "format": "double"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "direction": {
+            "type": "integer"
+          },
+          "directionName": {
+            "type": "string"
+          },
+          "turnType": {
+            "type": "integer"
+          },
+          "streets": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "startPoint": {
+            "$ref": "#/components/schemas/LatLng"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "mapUrl": {
+            "type": "string"
+          }
+        }
+      },
+      "AlternateRoutesResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer"
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "route": {
+            "$ref": "#/components/schemas/RouteResponse/properties/route"
+          },
+          "alternateRoutes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "route": {
+                  "$ref": "#/components/schemas/RouteResponse/properties/route"
+                }
+              }
+            }
+          }
+        }
+      },
+      "RouteMatrixResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer"
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "allToAll": {
+            "type": "boolean"
+          },
+          "distance": {
+            "type": "array",
+            "items": {
+              "type": "number"
+            },
+            "description": "Flat array of distances between locations."
+          },
+          "time": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            },
+            "description": "Flat array of times (seconds) between locations."
+          },
+          "locations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Location"
+            }
+          }
+        }
+      },
+      "RouteShapeResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer"
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "route": {
+            "type": "object",
+            "properties": {
+              "shape": {
+                "type": "object",
+                "properties": {
+                  "shapePoints": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    }
+                  },
+                  "maneuverIndexes": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "PlaceSearchResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "displayString": {
+                  "type": "string"
+                },
+                "place": {
+                  "type": "object",
+                  "properties": {
+                    "geometry": {
+                      "type": "object",
+                      "properties": {
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "number"
+                          }
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "street": {
+                          "type": "string"
+                        },
+                        "city": {
+                          "type": "string"
+                        },
+                        "state": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "country": {
+                          "type": "string"
+                        },
+                        "countryCode": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                },
+                "categories": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "distance": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          },
+          "resultsCount": {
+            "type": "integer"
+          },
+          "totalPages": {
+            "type": "integer"
+          },
+          "currentPage": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchAheadResponse": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "displayString": {
+                  "type": "string"
+                },
+                "slug": {
+                  "type": "string"
+                },
+                "collection": {
+                  "type": "string",
+                  "description": "Type of result (address, adminArea, poi, etc.)."
+                },
+                "recordType": {
+                  "type": "string"
+                },
+                "language": {
+                  "type": "string"
+                },
+                "place": {
+                  "type": "object",
+                  "properties": {
+                    "geometry": {
+                      "type": "object",
+                      "properties": {
+                        "coordinates": {
+                          "type": "array",
+                          "items": {
+                            "type": "number"
+                          }
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    },
+                    "properties": {
+                      "type": "object",
+                      "properties": {
+                        "city": {
+                          "type": "string"
+                        },
+                        "stateCode": {
+                          "type": "string"
+                        },
+                        "countryCode": {
+                          "type": "string"
+                        },
+                        "county": {
+                          "type": "string"
+                        },
+                        "postalCode": {
+                          "type": "string"
+                        },
+                        "street": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "info": {
+            "type": "object",
+            "properties": {
+              "statuscode": {
+                "type": "integer",
+                "description": "MapQuest status code."
+              },
+              "messages": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Error messages."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/mapquest.com/mapquest/meta.json
+++ b/apis/openapi/mapquest.com/mapquest/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "527e5b9b3b887842b2223333c0c0d878",
+    "format": "openapi",
+    "vendor": "mapquest.com",
+    "api_name": "mapquest",
+    "friendly_id": "mapquest.com/mapquest"
+  }
+}

--- a/apis/openapi/mapserv.utah.gov/utah-agrc/1.0.0/openapi.json
+++ b/apis/openapi/mapserv.utah.gov/utah-agrc/1.0.0/openapi.json
@@ -1,0 +1,802 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Utah AGRC Web API",
+    "description": "The Utah Geospatial Resource Center (UGRC) API provides geocoding, reverse geocoding, milepost geocoding, and spatial data searching across 300+ data layers and 1,000,000+ rows of SGID (State Geographic Information Datasource) data for the state of Utah.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "UGRC",
+      "email": "ugrc-developers@utah.gov",
+      "url": "https://gis.utah.gov"
+    },
+    "x-jentic-source-url": "https://api.mapserv.utah.gov"
+  },
+  "servers": [
+    {
+      "url": "https://api.mapserv.utah.gov/api/v1",
+      "description": "UGRC API v1 production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Address and milepost geocoding operations"
+    },
+    {
+      "name": "Reverse Geocoding",
+      "description": "Reverse geocoding from coordinates to addresses"
+    },
+    {
+      "name": "Search",
+      "description": "Spatial data search across SGID layers"
+    },
+    {
+      "name": "Info",
+      "description": "Metadata about available feature classes and attributes"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "paths": {
+    "/geocode/{street}/{zone}": {
+      "get": {
+        "tags": ["Geocoding"],
+        "summary": "Geocode a Utah street address",
+        "description": "Convert a Utah street address and zone (city name or ZIP code) to geographic coordinates.",
+        "operationId": "geocodeAddress",
+        "parameters": [
+          {
+            "name": "street",
+            "in": "path",
+            "required": true,
+            "description": "A Utah street address (e.g., '326 east south temple st')",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "zone",
+            "in": "path",
+            "required": true,
+            "description": "A Utah place name or 5-digit ZIP code (e.g., 'slc' or '84111')",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "acceptScore",
+            "in": "query",
+            "description": "Minimum confidence score threshold (0-100)",
+            "schema": {
+              "type": "integer",
+              "default": 70,
+              "minimum": 0,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "pobox",
+            "in": "query",
+            "description": "Enable P.O. Box location matching",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "locators",
+            "in": "query",
+            "description": "Data source selection for geocoding",
+            "schema": {
+              "type": "string",
+              "enum": ["all", "addressPoints", "roadCenterlines"],
+              "default": "all"
+            }
+          },
+          {
+            "name": "suggest",
+            "in": "query",
+            "description": "Number of alternative candidates to return (0-5)",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 5
+            }
+          },
+          {
+            "name": "scoreDifference",
+            "in": "query",
+            "description": "Return score gap between top matches",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "spatialReference",
+            "in": "query",
+            "description": "Coordinate system WKID (e.g., 26912 for UTM Zone 12N, 4326 for WGS84)",
+            "schema": {
+              "type": "integer",
+              "default": 26912
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Output format",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "esrijson", "geojson"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocode result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/geocode/reverse/{x}/{y}": {
+      "get": {
+        "tags": ["Reverse Geocoding"],
+        "summary": "Reverse geocode coordinates",
+        "description": "Convert geographic coordinates to a Utah street address.",
+        "operationId": "reverseGeocode",
+        "parameters": [
+          {
+            "name": "x",
+            "in": "path",
+            "required": true,
+            "description": "Longitude, easting, or horizontal coordinate value",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "y",
+            "in": "path",
+            "required": true,
+            "description": "Latitude, northing, or vertical coordinate value",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "distance",
+            "in": "query",
+            "description": "Search radius in meters (0-2000)",
+            "schema": {
+              "type": "number",
+              "default": 5,
+              "minimum": 0,
+              "maximum": 2000
+            }
+          },
+          {
+            "name": "spatialReference",
+            "in": "query",
+            "description": "Coordinate system WKID",
+            "schema": {
+              "type": "integer",
+              "default": 26912
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocode result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReverseGeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/geocode/milepost/{route}/{milepost}": {
+      "get": {
+        "tags": ["Geocoding"],
+        "summary": "Geocode a route and milepost",
+        "description": "Convert a Utah highway route and milepost number to geographic coordinates.",
+        "operationId": "geocodeMilepost",
+        "parameters": [
+          {
+            "name": "route",
+            "in": "path",
+            "required": true,
+            "description": "Utah highway identifier without prefix (e.g., '15')",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "milepost",
+            "in": "path",
+            "required": true,
+            "description": "Position along route, precise to 1/1000 mile (e.g., '309.001')",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "side",
+            "in": "query",
+            "description": "Side of the route",
+            "schema": {
+              "type": "string",
+              "enum": ["increasing", "decreasing"],
+              "default": "increasing"
+            }
+          },
+          {
+            "name": "fullRoute",
+            "in": "query",
+            "description": "Search the full route or just the main route",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
+          },
+          {
+            "name": "spatialReference",
+            "in": "query",
+            "description": "Coordinate system WKID",
+            "schema": {
+              "type": "integer",
+              "default": 26912
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Output format",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "esrijson", "geojson"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful milepost geocode result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MilepostGeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/search/{table}/{fields}": {
+      "get": {
+        "tags": ["Search"],
+        "summary": "Search SGID spatial data",
+        "description": "Query spatial data from 300+ SGID layers with optional spatial and attribute filtering.",
+        "operationId": "searchSgidData",
+        "parameters": [
+          {
+            "name": "table",
+            "in": "path",
+            "required": true,
+            "description": "Schema-qualified Open SGID table name (e.g., 'boundaries.county_boundaries')",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated field names. Use 'shape@' for geometry and 'shape@envelope' for bounding box.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "predicate",
+            "in": "query",
+            "description": "PostgreSQL filter predicate (e.g., \"UPPER(name) like '%K'\")",
+            "schema": {
+              "type": "string",
+              "default": "1=1"
+            }
+          },
+          {
+            "name": "geometry",
+            "in": "query",
+            "description": "Spatial filter in format 'geometryType:ArcGIS JSON'. Supports point, polyline, polygon, multipoint, envelope.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "buffer",
+            "in": "query",
+            "description": "Buffer distance in meters (max 2000)",
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0,
+              "maximum": 2000
+            }
+          },
+          {
+            "name": "attributeStyle",
+            "in": "query",
+            "description": "Controls response key casing",
+            "schema": {
+              "type": "string",
+              "enum": ["lower", "upper", "input"],
+              "default": "lower"
+            }
+          },
+          {
+            "name": "spatialReference",
+            "in": "query",
+            "description": "Coordinate system WKID",
+            "schema": {
+              "type": "integer",
+              "default": 26912
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Output format",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "esrijson", "geojson"]
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/info/featureClassNames": {
+      "get": {
+        "tags": ["Info"],
+        "summary": "List feature class names",
+        "description": "Returns a list of Open SGID table names usable by the search endpoint.",
+        "operationId": "listFeatureClassNames",
+        "parameters": [
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "sgidCategory",
+            "in": "query",
+            "description": "Filter by SGID category (e.g., boundaries, cadastre, water)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of feature class names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/info/fieldnames/{tableName}": {
+      "get": {
+        "tags": ["Info"],
+        "summary": "List feature class attributes",
+        "description": "Returns a list of attribute names for a given Open SGID table.",
+        "operationId": "listFieldNames",
+        "parameters": [
+          {
+            "name": "tableName",
+            "in": "path",
+            "required": true,
+            "description": "Open SGID table name (e.g., 'county_boundaries')",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "category",
+            "in": "query",
+            "description": "SGID category filter",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "description": "JSONP callback function name",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of field names",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/InfoListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apikey",
+        "description": "API key obtained from the UGRC developer portal at developer.mapserv.utah.gov"
+      }
+    },
+    "schemas": {
+      "GeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "location": {
+                "$ref": "#/components/schemas/Location"
+              },
+              "score": {
+                "type": "number",
+                "description": "Confidence score (0-100)"
+              },
+              "locator": {
+                "type": "string",
+                "description": "Data source used for match"
+              },
+              "matchAddress": {
+                "type": "string",
+                "description": "The matched address"
+              },
+              "inputAddress": {
+                "type": "string",
+                "description": "The original input address"
+              },
+              "standardizedAddress": {
+                "type": "string",
+                "description": "Standardized version of the input address"
+              },
+              "addressGrid": {
+                "type": "string",
+                "description": "The address grid used for matching"
+              },
+              "scoreDifference": {
+                "type": "integer",
+                "description": "Score gap between top matches (if requested)"
+              },
+              "candidates": {
+                "type": "array",
+                "description": "Alternative match candidates (if suggest > 0)",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "address": {
+                      "type": "string"
+                    },
+                    "location": {
+                      "$ref": "#/components/schemas/Location"
+                    },
+                    "score": {
+                      "type": "number"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "integer",
+            "description": "HTTP status code"
+          }
+        }
+      },
+      "ReverseGeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "inputLocation": {
+                "$ref": "#/components/schemas/Location"
+              },
+              "address": {
+                "type": "object",
+                "properties": {
+                  "street": {
+                    "type": "string",
+                    "description": "The matched street address"
+                  }
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "MilepostGeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "object",
+            "properties": {
+              "source": {
+                "type": "string",
+                "description": "Data source (e.g., 'UDOT Roads and Highways')"
+              },
+              "location": {
+                "$ref": "#/components/schemas/Location"
+              },
+              "matchRoute": {
+                "type": "string",
+                "description": "The matched route identifier"
+              }
+            }
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "attributes": {
+                  "type": "object",
+                  "additionalProperties": true,
+                  "description": "Key-value pairs of requested field values"
+                }
+              }
+            }
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "InfoListResponse": {
+        "type": "object",
+        "properties": {
+          "result": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "status": {
+            "type": "integer"
+          }
+        }
+      },
+      "Location": {
+        "type": "object",
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double",
+            "description": "X coordinate (longitude or easting)"
+          },
+          "y": {
+            "type": "number",
+            "format": "double",
+            "description": "Y coordinate (latitude or northing)"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "API key is missing, invalid, or expired",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found or no match",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/mapserv.utah.gov/utah-agrc/meta.json
+++ b/apis/openapi/mapserv.utah.gov/utah-agrc/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "d2e9ad84e9f2f3d6cde5ca04afd9fee7",
+    "format": "openapi",
+    "vendor": "mapserv.utah.gov",
+    "api_name": "utah-agrc",
+    "friendly_id": "mapserv.utah.gov/utah-agrc"
+  }
+}

--- a/apis/openapi/mario-kart-tour-api.herokuapp.com/mario-kart-tour/1.0.0/openapi.json
+++ b/apis/openapi/mario-kart-tour-api.herokuapp.com/mario-kart-tour/1.0.0/openapi.json
@@ -1,0 +1,424 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Mario Kart Tour API",
+    "description": "An unofficial API for Mario Kart Tour game data, providing information about drivers, karts, gliders, and courses. The API scrapes leaderboard data from the Mario Kart Tour game.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Mario Kart Tour API",
+      "url": "https://mario-kart-tour-api.herokuapp.com"
+    },
+    "x-jentic-source-url": "https://mario-kart-tour-api.herokuapp.com/"
+  },
+  "servers": [
+    {
+      "url": "https://mario-kart-tour-api.herokuapp.com",
+      "description": "Mario Kart Tour API (Heroku)"
+    }
+  ],
+  "tags": [
+    { "name": "Leaderboard", "description": "Leaderboard and ranking data" },
+    { "name": "Drivers", "description": "Mario Kart Tour driver characters" },
+    { "name": "Karts", "description": "Mario Kart Tour kart bodies" },
+    { "name": "Gliders", "description": "Mario Kart Tour gliders" },
+    { "name": "Courses", "description": "Mario Kart Tour race courses" }
+  ],
+  "paths": {
+    "/api": {
+      "get": {
+        "operationId": "getLeaderboard",
+        "summary": "Get leaderboard data",
+        "description": "Retrieves Mario Kart Tour leaderboard/ranking data. Supports filtering by language and cup.",
+        "tags": ["Leaderboard"],
+        "parameters": [
+          {
+            "name": "language",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "en-US"
+            },
+            "description": "Language code for the leaderboard data (e.g., en-US, ja-JP, es-ES)"
+          },
+          {
+            "name": "cup",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "default": "allcup"
+            },
+            "description": "The cup to get leaderboard data for. Use 'allcup' for all cups."
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with leaderboard data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LeaderboardResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Server error - likely an invalid query parameter",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/drivers": {
+      "get": {
+        "operationId": "getDrivers",
+        "summary": "List all drivers",
+        "description": "Retrieves a list of all available Mario Kart Tour drivers/characters.",
+        "tags": ["Drivers"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Driver"
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/drivers/{driverId}": {
+      "get": {
+        "operationId": "getDriverById",
+        "summary": "Get driver by ID",
+        "description": "Retrieves detailed information about a specific driver.",
+        "tags": ["Drivers"],
+        "parameters": [
+          {
+            "name": "driverId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The driver identifier or slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Driver" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/karts": {
+      "get": {
+        "operationId": "getKarts",
+        "summary": "List all karts",
+        "description": "Retrieves a list of all available Mario Kart Tour kart bodies.",
+        "tags": ["Karts"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Kart"
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/karts/{kartId}": {
+      "get": {
+        "operationId": "getKartById",
+        "summary": "Get kart by ID",
+        "description": "Retrieves detailed information about a specific kart.",
+        "tags": ["Karts"],
+        "parameters": [
+          {
+            "name": "kartId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The kart identifier or slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Kart" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/gliders": {
+      "get": {
+        "operationId": "getGliders",
+        "summary": "List all gliders",
+        "description": "Retrieves a list of all available Mario Kart Tour gliders.",
+        "tags": ["Gliders"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Glider"
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/gliders/{gliderId}": {
+      "get": {
+        "operationId": "getGliderById",
+        "summary": "Get glider by ID",
+        "description": "Retrieves detailed information about a specific glider.",
+        "tags": ["Gliders"],
+        "parameters": [
+          {
+            "name": "gliderId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The glider identifier or slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Glider" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/courses": {
+      "get": {
+        "operationId": "getCourses",
+        "summary": "List all courses",
+        "description": "Retrieves a list of all available Mario Kart Tour courses.",
+        "tags": ["Courses"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Course"
+                  }
+                }
+              }
+            }
+          },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    },
+    "/api/courses/{courseId}": {
+      "get": {
+        "operationId": "getCourseById",
+        "summary": "Get course by ID",
+        "description": "Retrieves detailed information about a specific course.",
+        "tags": ["Courses"],
+        "parameters": [
+          {
+            "name": "courseId",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" },
+            "description": "The course identifier or slug"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Course" }
+              }
+            }
+          },
+          "404": { "$ref": "#/components/responses/NotFound" },
+          "500": { "$ref": "#/components/responses/ServerError" }
+        }
+      }
+    }
+  },
+  "components": {
+    "responses": {
+      "NotFound": {
+        "description": "The requested resource was not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "ServerError": {
+        "description": "Internal server error",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string",
+            "example": "likely an invalid query"
+          }
+        }
+      },
+      "LeaderboardResponse": {
+        "type": "object",
+        "properties": {
+          "rankings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RankingEntry"
+            }
+          }
+        }
+      },
+      "RankingEntry": {
+        "type": "object",
+        "properties": {
+          "rank": { "type": "integer", "description": "Player ranking position" },
+          "player": { "type": "string", "description": "Player name" },
+          "score": { "type": "integer", "description": "Player score" },
+          "driver": { "type": "string", "description": "Driver used" },
+          "kart": { "type": "string", "description": "Kart used" },
+          "glider": { "type": "string", "description": "Glider used" }
+        }
+      },
+      "Driver": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Unique driver identifier" },
+          "name": { "type": "string", "description": "Driver display name" },
+          "rarity": {
+            "type": "string",
+            "enum": ["Normal", "Super", "High-End"],
+            "description": "Driver rarity tier"
+          },
+          "specialItem": { "type": "string", "description": "The driver's special item" },
+          "favoriteCourses": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Courses where this driver has a bonus"
+          },
+          "image": { "type": "string", "format": "uri", "description": "URL to driver image" }
+        }
+      },
+      "Kart": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Unique kart identifier" },
+          "name": { "type": "string", "description": "Kart display name" },
+          "rarity": {
+            "type": "string",
+            "enum": ["Normal", "Super", "High-End"],
+            "description": "Kart rarity tier"
+          },
+          "specialSkill": { "type": "string", "description": "The kart's special skill" },
+          "favoriteCourses": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Courses where this kart has a bonus"
+          },
+          "image": { "type": "string", "format": "uri", "description": "URL to kart image" }
+        }
+      },
+      "Glider": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Unique glider identifier" },
+          "name": { "type": "string", "description": "Glider display name" },
+          "rarity": {
+            "type": "string",
+            "enum": ["Normal", "Super", "High-End"],
+            "description": "Glider rarity tier"
+          },
+          "specialSkill": { "type": "string", "description": "The glider's special skill" },
+          "favoriteCourses": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Courses where this glider has a bonus"
+          },
+          "image": { "type": "string", "format": "uri", "description": "URL to glider image" }
+        }
+      },
+      "Course": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string", "description": "Unique course identifier" },
+          "name": { "type": "string", "description": "Course display name" },
+          "cup": { "type": "string", "description": "The cup this course belongs to" },
+          "favoriteDrivers": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Drivers that have a bonus on this course"
+          },
+          "favoriteKarts": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Karts that have a bonus on this course"
+          },
+          "favoriteGliders": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": "Gliders that have a bonus on this course"
+          },
+          "image": { "type": "string", "format": "uri", "description": "URL to course image" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/mario-kart-tour-api.herokuapp.com/mario-kart-tour/meta.json
+++ b/apis/openapi/mario-kart-tour-api.herokuapp.com/mario-kart-tour/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "59b757995b87b8d14f3fee380a2d7a47",
+    "format": "openapi",
+    "vendor": "mario-kart-tour-api.herokuapp.com",
+    "api_name": "mario-kart-tour",
+    "friendly_id": "mario-kart-tour-api.herokuapp.com/mario-kart-tour"
+  }
+}

--- a/apis/openapi/mod.io/mod-io/1.0.0/openapi.json
+++ b/apis/openapi/mod.io/mod-io/1.0.0/openapi.json
@@ -1,0 +1,1017 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "mod.io API",
+    "description": "mod.io is a cross-platform mod API for game developers. It provides a complete UGC (User Generated Content) solution including mod hosting, security scanning, content moderation, and SDK integration for managing mods across multiple platforms.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "mod.io Support",
+      "url": "https://mod.io"
+    },
+    "x-jentic-source-url": "https://docs.mod.io"
+  },
+  "servers": [
+    {
+      "url": "https://api.mod.io/v1",
+      "description": "Production"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {"name": "Authentication", "description": "Authentication and authorization endpoints"},
+    {"name": "Games", "description": "Browse and retrieve game information"},
+    {"name": "Mods", "description": "Browse, create, update, and delete mods"},
+    {"name": "Files", "description": "Manage modfiles (uploads and versions)"},
+    {"name": "Comments", "description": "Mod comment management"},
+    {"name": "User", "description": "Authenticated user profile and subscriptions"},
+    {"name": "Subscriptions", "description": "Subscribe and unsubscribe to mods"}
+  ],
+  "paths": {
+    "/authenticate/terms": {
+      "get": {
+        "tags": ["Authentication"],
+        "summary": "Get terms of use",
+        "description": "Retrieve the terms of use text and agreement buttons that must be shown to users before authentication.",
+        "operationId": "getTerms",
+        "responses": {
+          "200": {
+            "description": "Terms of use returned successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TermsObject"
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/external/steamauth": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Authenticate via Steam",
+        "description": "Request an access token on behalf of a Steam user using an encrypted app ticket.",
+        "operationId": "steamAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["appdata", "terms_agreed"],
+                "properties": {
+                  "appdata": {"type": "string", "description": "Base64-encoded encrypted Steam app ticket"},
+                  "email": {"type": "string", "format": "email", "description": "User email address"},
+                  "date_expires": {"type": "integer", "description": "Unix timestamp for token expiry"},
+                  "terms_agreed": {"type": "boolean", "description": "Whether user agreed to terms"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccessTokenObject"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/external/xboxauth": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Authenticate via Xbox Live",
+        "description": "Request an access token on behalf of an Xbox Live user.",
+        "operationId": "xboxAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["xbox_token", "terms_agreed"],
+                "properties": {
+                  "xbox_token": {"type": "string", "description": "Xbox Live token"},
+                  "email": {"type": "string", "format": "email"},
+                  "date_expires": {"type": "integer"},
+                  "terms_agreed": {"type": "boolean"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccessTokenObject"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/external/psnauth": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Authenticate via PlayStation Network",
+        "description": "Request an access token on behalf of a PlayStation Network user.",
+        "operationId": "psnAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["auth_code", "terms_agreed"],
+                "properties": {
+                  "auth_code": {"type": "string", "description": "PSN authorization code"},
+                  "env": {"type": "string", "description": "PSN environment"},
+                  "email": {"type": "string", "format": "email"},
+                  "date_expires": {"type": "integer"},
+                  "terms_agreed": {"type": "boolean"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccessTokenObject"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/external/switchauth": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Authenticate via Nintendo Switch",
+        "description": "Request an access token on behalf of a Nintendo Switch user.",
+        "operationId": "switchAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["id_token", "terms_agreed"],
+                "properties": {
+                  "id_token": {"type": "string", "description": "NSA ID from Switch SDK"},
+                  "email": {"type": "string", "format": "email"},
+                  "date_expires": {"type": "integer"},
+                  "terms_agreed": {"type": "boolean"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccessTokenObject"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/external/oculusauth": {
+      "post": {
+        "tags": ["Authentication"],
+        "summary": "Authenticate via Meta Quest",
+        "description": "Request an access token on behalf of a Meta Quest (Oculus) user.",
+        "operationId": "oculusAuth",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["device", "nonce", "user_id", "access_token", "terms_agreed"],
+                "properties": {
+                  "device": {"type": "string", "description": "Device type"},
+                  "nonce": {"type": "string", "description": "Nonce value"},
+                  "user_id": {"type": "string", "description": "Oculus user ID"},
+                  "access_token": {"type": "string", "description": "Oculus access token"},
+                  "email": {"type": "string", "format": "email"},
+                  "date_expires": {"type": "integer"},
+                  "terms_agreed": {"type": "boolean"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Access token issued",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/AccessTokenObject"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/games": {
+      "get": {
+        "tags": ["Games"],
+        "summary": "Get all games",
+        "description": "Browse all games on mod.io.",
+        "operationId": "getGames",
+        "parameters": [
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}, "description": "Results per page"},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}, "description": "Results to skip"},
+          {"name": "_sort", "in": "query", "schema": {"type": "string"}, "description": "Sort column (prefix - for descending)"},
+          {"name": "_q", "in": "query", "schema": {"type": "string"}, "description": "Full-text search"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of games",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedGameList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/games/{game_id}": {
+      "get": {
+        "tags": ["Games"],
+        "summary": "Get a game",
+        "description": "Retrieve details for a specific game.",
+        "operationId": "getGame",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}, "description": "Unique game ID"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Game details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Game"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/games/{game_id}/mods": {
+      "get": {
+        "tags": ["Mods"],
+        "summary": "Get all mods",
+        "description": "Browse all mods for a game.",
+        "operationId": "getMods",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}},
+          {"name": "_sort", "in": "query", "schema": {"type": "string"}},
+          {"name": "_q", "in": "query", "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of mods",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedModList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      },
+      "post": {
+        "tags": ["Mods"],
+        "summary": "Add a mod",
+        "description": "Create a new mod for a game.",
+        "operationId": "addMod",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["name", "summary", "logo"],
+                "properties": {
+                  "name": {"type": "string", "description": "Mod name"},
+                  "summary": {"type": "string", "description": "Brief mod summary"},
+                  "logo": {"type": "string", "format": "binary", "description": "Mod logo image"},
+                  "description": {"type": "string", "description": "Detailed description"},
+                  "homepage_url": {"type": "string", "format": "uri"},
+                  "metadata_blob": {"type": "string"},
+                  "tags": {"type": "array", "items": {"type": "string"}}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Mod created",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Mod"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "422": {"$ref": "#/components/responses/ValidationError"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}": {
+      "get": {
+        "tags": ["Mods"],
+        "summary": "Get a mod",
+        "description": "Retrieve details for a specific mod.",
+        "operationId": "getMod",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Mod details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Mod"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      },
+      "put": {
+        "tags": ["Mods"],
+        "summary": "Edit a mod",
+        "description": "Update details for an existing mod.",
+        "operationId": "editMod",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "name": {"type": "string"},
+                  "summary": {"type": "string"},
+                  "description": {"type": "string"},
+                  "homepage_url": {"type": "string", "format": "uri"},
+                  "metadata_blob": {"type": "string"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Mod updated",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Mod"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      },
+      "delete": {
+        "tags": ["Mods"],
+        "summary": "Delete a mod",
+        "description": "Delete a mod.",
+        "operationId": "deleteMod",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "204": {"description": "Mod deleted"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}/files": {
+      "get": {
+        "tags": ["Files"],
+        "summary": "Get modfiles",
+        "description": "List all modfiles for a specific mod.",
+        "operationId": "getModfiles",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of modfiles",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedModfileList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      },
+      "post": {
+        "tags": ["Files"],
+        "summary": "Add a modfile",
+        "description": "Upload a new modfile for a mod.",
+        "operationId": "addModfile",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["filedata", "version"],
+                "properties": {
+                  "filedata": {"type": "string", "format": "binary", "description": "The mod file to upload"},
+                  "version": {"type": "string", "description": "Version string"},
+                  "changelog": {"type": "string", "description": "Changelog text"},
+                  "active": {"type": "boolean", "description": "Set as active release"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Modfile created",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Modfile"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "422": {"$ref": "#/components/responses/ValidationError"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}/files/{file_id}": {
+      "get": {
+        "tags": ["Files"],
+        "summary": "Get a modfile",
+        "description": "Retrieve details for a specific modfile.",
+        "operationId": "getModfile",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "file_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Modfile details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Modfile"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      },
+      "put": {
+        "tags": ["Files"],
+        "summary": "Edit a modfile",
+        "description": "Update details for an existing modfile.",
+        "operationId": "editModfile",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "file_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "version": {"type": "string"},
+                  "changelog": {"type": "string"},
+                  "active": {"type": "boolean"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Modfile updated",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Modfile"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      },
+      "delete": {
+        "tags": ["Files"],
+        "summary": "Delete a modfile",
+        "description": "Delete a modfile.",
+        "operationId": "deleteModfile",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "file_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "204": {"description": "Modfile deleted"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}/comments": {
+      "get": {
+        "tags": ["Comments"],
+        "summary": "Get mod comments",
+        "description": "Retrieve comments for a mod.",
+        "operationId": "getModComments",
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}},
+          {"name": "_sort", "in": "query", "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of comments",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedCommentList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      },
+      "post": {
+        "tags": ["Comments"],
+        "summary": "Add a mod comment",
+        "description": "Add a comment to a mod.",
+        "operationId": "addModComment",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["content"],
+                "properties": {
+                  "content": {"type": "string", "description": "Comment text"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Comment created",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Comment"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}/comments/{comment_id}": {
+      "delete": {
+        "tags": ["Comments"],
+        "summary": "Delete a mod comment",
+        "description": "Delete a comment from a mod.",
+        "operationId": "deleteModComment",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "comment_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "204": {"description": "Comment deleted"},
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"}
+        }
+      }
+    },
+    "/games/{game_id}/mods/{mod_id}/subscribe": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "summary": "Subscribe to a mod",
+        "description": "Subscribe the authenticated user to a mod.",
+        "operationId": "subscribeMod",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "201": {
+            "description": "Subscribed successfully",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Mod"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "summary": "Unsubscribe from a mod",
+        "description": "Unsubscribe the authenticated user from a mod.",
+        "operationId": "unsubscribeMod",
+        "security": [{"oAuth2": ["write"]}],
+        "parameters": [
+          {"name": "game_id", "in": "path", "required": true, "schema": {"type": "integer"}},
+          {"name": "mod_id", "in": "path", "required": true, "schema": {"type": "integer"}}
+        ],
+        "responses": {
+          "204": {"description": "Unsubscribed successfully"},
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/me": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get authenticated user",
+        "description": "Retrieve the profile details of the authenticated user.",
+        "operationId": "getAuthenticatedUser",
+        "security": [{"oAuth2": ["read"]}],
+        "responses": {
+          "200": {
+            "description": "User profile",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/User"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/me/subscriptions": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get user subscriptions",
+        "description": "Retrieve all mods the authenticated user is subscribed to.",
+        "operationId": "getUserSubscriptions",
+        "security": [{"oAuth2": ["read"]}],
+        "parameters": [
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of subscribed mods",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedModList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/me/mods": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get user mods",
+        "description": "Retrieve all mods created by the authenticated user.",
+        "operationId": "getUserMods",
+        "security": [{"oAuth2": ["read"]}],
+        "parameters": [
+          {"name": "_limit", "in": "query", "schema": {"type": "integer", "default": 100}},
+          {"name": "_offset", "in": "query", "schema": {"type": "integer", "default": 0}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated list of user mods",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PaginatedModList"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    },
+    "/me/ratings": {
+      "post": {
+        "tags": ["User"],
+        "summary": "Add mod rating",
+        "description": "Submit a rating for a mod.",
+        "operationId": "addModRating",
+        "security": [{"oAuth2": ["write"]}],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "required": ["mod_id", "rating"],
+                "properties": {
+                  "mod_id": {"type": "integer", "description": "ID of the mod to rate"},
+                  "rating": {"type": "integer", "enum": [1, -1], "description": "1 for positive, -1 for negative"}
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {"description": "Rating submitted"},
+          "401": {"$ref": "#/components/responses/Unauthorized"}
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "description": "API key for read-only GET requests."
+      },
+      "oAuth2": {
+        "type": "oauth2",
+        "description": "OAuth 2.0 access token for full CRUD operations.",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://mod.io/oauth",
+            "scopes": {
+              "read": "Read access",
+              "write": "Write access"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "AccessTokenObject": {
+        "type": "object",
+        "properties": {
+          "code": {"type": "integer"},
+          "access_token": {"type": "string"},
+          "date_expires": {"type": "integer"}
+        }
+      },
+      "TermsObject": {
+        "type": "object",
+        "properties": {
+          "plaintext": {"type": "string"},
+          "html": {"type": "string"},
+          "buttons": {
+            "type": "object",
+            "properties": {
+              "agree": {"type": "object", "properties": {"text": {"type": "string"}}},
+              "disagree": {"type": "object", "properties": {"text": {"type": "string"}}}
+            }
+          },
+          "links": {
+            "type": "object",
+            "properties": {
+              "website": {"type": "object", "properties": {"text": {"type": "string"}, "url": {"type": "string", "format": "uri"}}},
+              "terms": {"type": "object", "properties": {"text": {"type": "string"}, "url": {"type": "string", "format": "uri"}}},
+              "privacy": {"type": "object", "properties": {"text": {"type": "string"}, "url": {"type": "string", "format": "uri"}}}
+            }
+          }
+        }
+      },
+      "Game": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "status": {"type": "integer"},
+          "date_added": {"type": "integer"},
+          "date_updated": {"type": "integer"},
+          "date_live": {"type": "integer"},
+          "presentation_option": {"type": "integer"},
+          "submission_option": {"type": "integer"},
+          "curation_option": {"type": "integer"},
+          "community_options": {"type": "integer"},
+          "revenue_options": {"type": "integer"},
+          "api_access_options": {"type": "integer"},
+          "ugc_name": {"type": "string"},
+          "name": {"type": "string"},
+          "name_id": {"type": "string"},
+          "summary": {"type": "string"},
+          "instructions": {"type": "string"},
+          "instructions_url": {"type": "string", "format": "uri"},
+          "profile_url": {"type": "string", "format": "uri"}
+        }
+      },
+      "Mod": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "game_id": {"type": "integer"},
+          "status": {"type": "integer"},
+          "visible": {"type": "integer"},
+          "date_added": {"type": "integer"},
+          "date_updated": {"type": "integer"},
+          "date_live": {"type": "integer"},
+          "name": {"type": "string"},
+          "name_id": {"type": "string"},
+          "summary": {"type": "string"},
+          "description": {"type": "string"},
+          "description_plaintext": {"type": "string"},
+          "homepage_url": {"type": "string", "format": "uri"},
+          "profile_url": {"type": "string", "format": "uri"},
+          "metadata_blob": {"type": "string"},
+          "tags": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "date_added": {"type": "integer"}}}}
+        }
+      },
+      "Modfile": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "mod_id": {"type": "integer"},
+          "date_added": {"type": "integer"},
+          "date_scanned": {"type": "integer"},
+          "virus_status": {"type": "integer"},
+          "virus_positive": {"type": "integer"},
+          "filesize": {"type": "integer", "format": "int64"},
+          "filehash": {"type": "object", "properties": {"md5": {"type": "string"}}},
+          "filename": {"type": "string"},
+          "version": {"type": "string"},
+          "changelog": {"type": "string"},
+          "download": {"type": "object", "properties": {"binary_url": {"type": "string", "format": "uri"}, "date_expires": {"type": "integer"}}}
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "mod_id": {"type": "integer"},
+          "user": {"$ref": "#/components/schemas/User"},
+          "date_added": {"type": "integer"},
+          "reply_id": {"type": "integer"},
+          "thread_position": {"type": "string"},
+          "karma": {"type": "integer"},
+          "content": {"type": "string"}
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "integer"},
+          "name_id": {"type": "string"},
+          "username": {"type": "string"},
+          "date_online": {"type": "integer"},
+          "avatar": {"type": "object", "properties": {"filename": {"type": "string"}, "original": {"type": "string", "format": "uri"}}},
+          "timezone": {"type": "string"},
+          "language": {"type": "string"},
+          "profile_url": {"type": "string", "format": "uri"}
+        }
+      },
+      "PaginatedGameList": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Game"}},
+          "result_count": {"type": "integer"},
+          "result_limit": {"type": "integer"},
+          "result_offset": {"type": "integer"},
+          "result_total": {"type": "integer"}
+        }
+      },
+      "PaginatedModList": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Mod"}},
+          "result_count": {"type": "integer"},
+          "result_limit": {"type": "integer"},
+          "result_offset": {"type": "integer"},
+          "result_total": {"type": "integer"}
+        }
+      },
+      "PaginatedModfileList": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Modfile"}},
+          "result_count": {"type": "integer"},
+          "result_limit": {"type": "integer"},
+          "result_offset": {"type": "integer"},
+          "result_total": {"type": "integer"}
+        }
+      },
+      "PaginatedCommentList": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Comment"}},
+          "result_count": {"type": "integer"},
+          "result_limit": {"type": "integer"},
+          "result_offset": {"type": "integer"},
+          "result_total": {"type": "integer"}
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {"type": "integer"},
+              "error_ref": {"type": "integer"},
+              "message": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication credentials missing or invalid",
+        "content": {
+          "application/json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      },
+      "ValidationError": {
+        "description": "Validation error",
+        "content": {
+          "application/json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/mod.io/mod-io/meta.json
+++ b/apis/openapi/mod.io/mod-io/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "4a539d4f3566e12225f16c1e40cc55c2",
+    "format": "openapi",
+    "vendor": "mod.io",
+    "api_name": "mod-io",
+    "friendly_id": "mod.io/mod-io"
+  }
+}

--- a/apis/openapi/mojang.com/mojang/1.0.0/openapi.json
+++ b/apis/openapi/mojang.com/mojang/1.0.0/openapi.json
@@ -1,0 +1,1068 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Mojang API",
+    "description": "The Mojang API provides access to Minecraft player profiles, authentication, skin management, and server-related operations. It allows querying player UUIDs, managing skins and capes, checking name availability, and handling Microsoft/Xbox authentication for Minecraft.",
+    "version": "1.0.0",
+    "x-jentic-source-url": "https://wiki.vg/Mojang_API"
+  },
+  "servers": [
+    {
+      "url": "https://api.mojang.com",
+      "description": "Mojang API server"
+    },
+    {
+      "url": "https://api.minecraftservices.com",
+      "description": "Minecraft Services API server"
+    },
+    {
+      "url": "https://sessionserver.mojang.com",
+      "description": "Minecraft Session server"
+    }
+  ],
+  "tags": [
+    { "name": "Players", "description": "Player profile lookups and queries" },
+    { "name": "Authentication", "description": "Microsoft/Xbox authentication flow" },
+    { "name": "Profile Management", "description": "Manage player profile, skins, capes, and settings" },
+    { "name": "Server", "description": "Server-related operations including join verification and blocked servers" }
+  ],
+  "paths": {
+    "/users/profiles/minecraft/{playerName}": {
+      "get": {
+        "operationId": "getPlayerByName",
+        "summary": "Get player UUID by username",
+        "description": "Returns the UUID and username for a given Minecraft player name. Case-insensitive lookup.",
+        "tags": ["Players"],
+        "parameters": [
+          {
+            "name": "playerName",
+            "in": "path",
+            "required": true,
+            "description": "Minecraft player name (case-insensitive)",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player profile found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerProfile" }
+              }
+            }
+          },
+          "404": {
+            "description": "Player not found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/profiles/minecraft": {
+      "post": {
+        "operationId": "getPlayersByNames",
+        "summary": "Batch query UUIDs by usernames",
+        "description": "Returns UUIDs for up to 10 player names in a single request.",
+        "tags": ["Players"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "type": "string" },
+                "maxItems": 10,
+                "example": ["Notch", "jeb_"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Array of player profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/PlayerProfile" }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - constraint violation (e.g., more than 10 names)",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session/minecraft/profile/{uuid}": {
+      "get": {
+        "operationId": "getPlayerSkinAndCape",
+        "summary": "Get player skin and cape textures",
+        "description": "Returns the player profile including Base64-encoded texture data for skin and cape. Rate limited to approximately 400 requests per 10 seconds.",
+        "tags": ["Players"],
+        "servers": [
+          { "url": "https://sessionserver.mojang.com" }
+        ],
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "description": "Player UUID (with or without dashes)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "unsigned",
+            "in": "query",
+            "required": false,
+            "description": "Set to false to include signature in response",
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player profile with textures",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProfileWithTextures" }
+              }
+            }
+          },
+          "204": {
+            "description": "UUID has no associated player"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/minecraft/profile": {
+      "get": {
+        "operationId": "getOwnProfile",
+        "summary": "Get the authenticated player's profile",
+        "description": "Returns the profile of the authenticated user, including skins and capes.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Authenticated player's profile",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing bearer token",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/minecraft/profile/lookup/name/{playerName}": {
+      "get": {
+        "operationId": "lookupPlayerByName",
+        "summary": "Look up player by name (Minecraft Services)",
+        "description": "Alternative endpoint on Minecraft Services to look up a player by username.",
+        "tags": ["Players"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "parameters": [
+          {
+            "name": "playerName",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player profile found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerProfile" }
+              }
+            }
+          },
+          "404": {
+            "description": "Player not found"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/lookup/{uuid}": {
+      "get": {
+        "operationId": "lookupPlayerByUuid",
+        "summary": "Look up player by UUID",
+        "description": "Look up a player profile by UUID via Minecraft Services.",
+        "tags": ["Players"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "parameters": [
+          {
+            "name": "uuid",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player profile found",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerProfile" }
+              }
+            }
+          },
+          "404": {
+            "description": "Player not found"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/lookup/bulk/byname": {
+      "post": {
+        "operationId": "bulkLookupPlayersByName",
+        "summary": "Batch lookup players by name (Minecraft Services)",
+        "description": "Look up up to 10 player profiles by name via Minecraft Services.",
+        "tags": ["Players"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": { "type": "string" },
+                "maxItems": 10
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Array of player profiles",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/PlayerProfile" }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/namechange": {
+      "get": {
+        "operationId": "getNameChangeInfo",
+        "summary": "Get name change information",
+        "description": "Returns information about the authenticated player's name change history and eligibility.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Name change information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "changedAt": { "type": "string", "format": "date-time" },
+                    "createdAt": { "type": "string", "format": "date-time" },
+                    "nameChangeAllowed": { "type": "boolean" }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/name/{name}/available": {
+      "get": {
+        "operationId": "checkNameAvailability",
+        "summary": "Check if a name is available",
+        "description": "Check whether a Minecraft username is available for use. Rate limited to 20 requests per 5 minutes per account.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Name availability status",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string",
+                      "enum": ["DUPLICATE", "AVAILABLE", "NOT_ALLOWED"]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/name/{newName}": {
+      "put": {
+        "operationId": "changeName",
+        "summary": "Change player name",
+        "description": "Change the authenticated player's Minecraft username.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "newName",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Name changed successfully",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid name"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Name change not allowed"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/skins": {
+      "post": {
+        "operationId": "changeSkin",
+        "summary": "Change or upload skin",
+        "description": "Change skin by URL or upload a skin image file. Supports both JSON body (URL) and multipart form (file upload).",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["variant", "url"],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": ["classic", "slim"],
+                    "description": "Skin model variant"
+                  },
+                  "url": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "URL of the skin image"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "required": ["variant", "file"],
+                "properties": {
+                  "variant": {
+                    "type": "string",
+                    "enum": ["classic", "slim"]
+                  },
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "PNG skin image file"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Skin changed successfully",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/skins/active": {
+      "delete": {
+        "operationId": "resetSkin",
+        "summary": "Reset skin to default",
+        "description": "Reset the authenticated player's skin to the default.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Skin reset successfully",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/minecraft/profile/capes/active": {
+      "put": {
+        "operationId": "showCape",
+        "summary": "Show a cape",
+        "description": "Set the active cape for the authenticated player.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["capeId"],
+                "properties": {
+                  "capeId": {
+                    "type": "string",
+                    "description": "The ID of the cape to show"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Cape activated",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "operationId": "hideCape",
+        "summary": "Hide the active cape",
+        "description": "Remove the active cape from the authenticated player's profile.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Cape hidden",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AuthenticatedProfile" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/player/attributes": {
+      "get": {
+        "operationId": "getPlayerAttributes",
+        "summary": "Get player attributes",
+        "description": "Returns the authenticated player's attributes including privileges, profanity filter settings, and ban status.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Player attributes",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerAttributes" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      },
+      "post": {
+        "operationId": "updatePlayerAttributes",
+        "summary": "Update player attributes",
+        "description": "Modify the authenticated player's attributes such as profanity filter settings.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "profanityFilterOn": { "type": "boolean" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated attributes",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerAttributes" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/privacy/blocklist": {
+      "get": {
+        "operationId": "getBlockedUsers",
+        "summary": "Get blocked users list",
+        "description": "Returns the list of UUIDs the authenticated player has blocked.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "List of blocked player UUIDs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "blockedProfiles": {
+                      "type": "array",
+                      "items": { "type": "string" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/player/certificates": {
+      "post": {
+        "operationId": "getPlayerCertificates",
+        "summary": "Get player key pair for chat signing",
+        "description": "Returns a key pair used for signing chat messages, including public key, private key, and signature.",
+        "tags": ["Profile Management"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "responses": {
+          "200": {
+            "description": "Key pair and certificates",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PlayerCertificates" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/entitlements/license": {
+      "get": {
+        "operationId": "checkOwnership",
+        "summary": "Check Minecraft game ownership",
+        "description": "Check whether the authenticated account owns Minecraft.",
+        "tags": ["Authentication"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "requestId",
+            "in": "query",
+            "required": false,
+            "schema": { "type": "string", "format": "uuid" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Entitlement information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "items": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "name": { "type": "string" },
+                          "source": { "type": "string" }
+                        }
+                      }
+                    },
+                    "signature": { "type": "string" },
+                    "keyId": { "type": "string" }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/authentication/login_with_xbox": {
+      "post": {
+        "operationId": "loginWithXbox",
+        "summary": "Get Minecraft access token via Xbox",
+        "description": "Exchange an XSTS token for a Minecraft access token.",
+        "tags": ["Authentication"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["identityToken"],
+                "properties": {
+                  "identityToken": {
+                    "type": "string",
+                    "description": "XSTS token in format: XBL3.0 x={userHash};{xstsToken}"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Minecraft access token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "username": { "type": "string" },
+                    "roles": { "type": "array", "items": { "type": "string" } },
+                    "access_token": { "type": "string" },
+                    "token_type": { "type": "string" },
+                    "expires_in": { "type": "integer" }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Account suspended"
+          }
+        }
+      }
+    },
+    "/publickeys": {
+      "get": {
+        "operationId": "getPublicKeys",
+        "summary": "Get Mojang public keys",
+        "description": "Returns Mojang's public keys used for verifying profile property signatures and player certificates.",
+        "tags": ["Server"],
+        "servers": [
+          { "url": "https://api.minecraftservices.com" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Public key arrays",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profilePropertyKeys": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PublicKey" }
+                    },
+                    "playerCertificateKeys": {
+                      "type": "array",
+                      "items": { "$ref": "#/components/schemas/PublicKey" }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/blockedservers": {
+      "get": {
+        "operationId": "getBlockedServers",
+        "summary": "Get list of blocked servers",
+        "description": "Returns a newline-separated list of SHA-1 hashes of blocked server addresses.",
+        "tags": ["Server"],
+        "servers": [
+          { "url": "https://sessionserver.mojang.com" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of SHA-1 hashes of blocked servers",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "Newline-separated SHA-1 hashes"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/session/minecraft/join": {
+      "post": {
+        "operationId": "clientJoin",
+        "summary": "Client-side join verification",
+        "description": "Called by the Minecraft client to verify login with a server. Rate limited to 6 joins per 30 seconds per account.",
+        "tags": ["Server"],
+        "servers": [
+          { "url": "https://sessionserver.mojang.com" }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["accessToken", "selectedProfile", "serverId"],
+                "properties": {
+                  "accessToken": { "type": "string" },
+                  "selectedProfile": {
+                    "type": "string",
+                    "description": "Player UUID without dashes"
+                  },
+                  "serverId": { "type": "string" }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Join verified successfully"
+          },
+          "403": {
+            "description": "Authentication failed"
+          }
+        }
+      }
+    },
+    "/session/minecraft/hasJoined": {
+      "get": {
+        "operationId": "serverHasJoined",
+        "summary": "Server-side join verification",
+        "description": "Called by the Minecraft server to verify that a client has authenticated.",
+        "tags": ["Server"],
+        "servers": [
+          { "url": "https://sessionserver.mojang.com" }
+        ],
+        "parameters": [
+          {
+            "name": "username",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "serverId",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "ip",
+            "in": "query",
+            "required": false,
+            "description": "Client IP address for additional verification",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player profile with texture data",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ProfileWithTextures" }
+              }
+            }
+          },
+          "204": {
+            "description": "Player has not joined the server"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Minecraft access token obtained through Microsoft/Xbox authentication flow"
+      }
+    },
+    "schemas": {
+      "PlayerProfile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Player UUID without dashes"
+          },
+          "name": {
+            "type": "string",
+            "description": "Current player name"
+          },
+          "legacy": {
+            "type": "boolean",
+            "description": "True if the account has not migrated to Mojang"
+          },
+          "demo": {
+            "type": "boolean",
+            "description": "True if the account is a demo/unpaid account"
+          }
+        },
+        "required": ["id", "name"]
+      },
+      "ProfileWithTextures": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "properties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string", "example": "textures" },
+                "value": {
+                  "type": "string",
+                  "description": "Base64-encoded JSON containing texture URLs"
+                },
+                "signature": {
+                  "type": "string",
+                  "description": "Base64-encoded signature (only if unsigned=false)"
+                }
+              }
+            }
+          }
+        },
+        "required": ["id", "name", "properties"]
+      },
+      "AuthenticatedProfile": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "skins": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "state": { "type": "string", "enum": ["ACTIVE", "INACTIVE"] },
+                "url": { "type": "string", "format": "uri" },
+                "variant": { "type": "string", "enum": ["CLASSIC", "SLIM"] }
+              }
+            }
+          },
+          "capes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "state": { "type": "string", "enum": ["ACTIVE", "INACTIVE"] },
+                "url": { "type": "string", "format": "uri" },
+                "alias": { "type": "string" }
+              }
+            }
+          }
+        },
+        "required": ["id", "name", "skins", "capes"]
+      },
+      "PlayerAttributes": {
+        "type": "object",
+        "properties": {
+          "privileges": {
+            "type": "object",
+            "properties": {
+              "onlineChat": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+              "multiplayerServer": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+              "multiplayerRealms": { "type": "object", "properties": { "enabled": { "type": "boolean" } } },
+              "telemetry": { "type": "object", "properties": { "enabled": { "type": "boolean" } } }
+            }
+          },
+          "profanityFilterPreferences": {
+            "type": "object",
+            "properties": {
+              "profanityFilterOn": { "type": "boolean" }
+            }
+          },
+          "banStatus": {
+            "type": "object",
+            "properties": {
+              "bannedScopes": { "type": "object" }
+            }
+          }
+        }
+      },
+      "PlayerCertificates": {
+        "type": "object",
+        "properties": {
+          "keyPair": {
+            "type": "object",
+            "properties": {
+              "privateKey": { "type": "string" },
+              "publicKey": { "type": "string" }
+            }
+          },
+          "publicKeySignature": { "type": "string" },
+          "publicKeySignatureV2": { "type": "string" },
+          "expiresAt": { "type": "string", "format": "date-time" },
+          "refreshedAfter": { "type": "string", "format": "date-time" }
+        }
+      },
+      "PublicKey": {
+        "type": "object",
+        "properties": {
+          "publicKey": {
+            "type": "string",
+            "description": "Base64-encoded DER public key"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "errorMessage": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/mojang.com/mojang/meta.json
+++ b/apis/openapi/mojang.com/mojang/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "2b54067edd8b83ccbd78ee7caacc7ed5",
+    "format": "openapi",
+    "vendor": "mojang.com",
+    "api_name": "mojang",
+    "friendly_id": "mojang.com/mojang"
+  }
+}

--- a/apis/openapi/nps.gov/national-park-service-us/1.0.0/openapi.json
+++ b/apis/openapi/nps.gov/national-park-service-us/1.0.0/openapi.json
@@ -1,0 +1,1371 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "National Park Service API",
+    "description": "The National Park Service (NPS) API provides access to data about US national parks, including park information, alerts, campgrounds, events, visitor centers, multimedia, and more. Data is sourced from NPS.gov.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "National Park Service",
+      "url": "https://www.nps.gov/subjects/developer/"
+    },
+    "license": {
+      "name": "Public Domain",
+      "url": "https://www.nps.gov/aboutus/disclaimer.htm"
+    },
+    "x-jentic-source-url": "https://www.nps.gov/subjects/developer/"
+  },
+  "servers": [
+    {
+      "url": "https://developer.nps.gov/api/v1",
+      "description": "NPS API production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    { "name": "activities", "description": "Park activities and topics" },
+    { "name": "alerts", "description": "Park alerts and closures" },
+    { "name": "amenities", "description": "Amenities at parks and facilities" },
+    { "name": "articles", "description": "Articles about parks" },
+    { "name": "campgrounds", "description": "Campground information" },
+    { "name": "events", "description": "Park events" },
+    { "name": "fees-passes", "description": "Entrance fees and passes" },
+    { "name": "lesson-plans", "description": "Educational lesson plans" },
+    { "name": "map-data", "description": "Park boundary map data" },
+    { "name": "multimedia", "description": "Audio, video, and gallery content" },
+    { "name": "news-releases", "description": "Park news releases" },
+    { "name": "parking-lots", "description": "Parking lot information" },
+    { "name": "parks", "description": "Park information" },
+    { "name": "passport-stamps", "description": "Passport stamp locations" },
+    { "name": "people", "description": "Historical people related to parks" },
+    { "name": "places", "description": "Places within parks" },
+    { "name": "road-events", "description": "Road incidents and work zones" },
+    { "name": "things-to-do", "description": "Recommended activities" },
+    { "name": "topics", "description": "Topic categories" },
+    { "name": "tours", "description": "Tour information" },
+    { "name": "visitor-centers", "description": "Visitor center information" },
+    { "name": "webcams", "description": "Park webcams" }
+  ],
+  "paths": {
+    "/activities": {
+      "get": {
+        "summary": "List activities",
+        "description": "Retrieve a list of activities available at national parks.",
+        "operationId": "getActivities",
+        "tags": ["activities"],
+        "parameters": [
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/start" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse"
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "500": { "$ref": "#/components/responses/InternalError" }
+        }
+      }
+    },
+    "/activities/parks": {
+      "get": {
+        "summary": "List activities with associated parks",
+        "description": "Retrieve activities and the parks where they are available.",
+        "operationId": "getActivitiesParks",
+        "tags": ["activities"],
+        "parameters": [
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/alerts": {
+      "get": {
+        "summary": "List park alerts",
+        "description": "Retrieve alerts for national parks including danger warnings, cautions, closures, and informational notices.",
+        "operationId": "getAlerts",
+        "tags": ["alerts"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with alerts.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/PaginatedResponse" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Alert" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/amenities": {
+      "get": {
+        "summary": "List amenities",
+        "description": "Retrieve amenities available at national parks.",
+        "operationId": "getAmenities",
+        "tags": ["amenities"],
+        "parameters": [
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/amenities/parksplaces": {
+      "get": {
+        "summary": "List amenities by park places",
+        "description": "Retrieve amenities available at specific places within parks.",
+        "operationId": "getAmenitiesParksPlaces",
+        "tags": ["amenities"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/amenities/parksvisitorcenters": {
+      "get": {
+        "summary": "List amenities by visitor centers",
+        "description": "Retrieve amenities available at visitor centers within parks.",
+        "operationId": "getAmenitiesParksVisitorCenters",
+        "tags": ["amenities"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCodeSingle" },
+          { "$ref": "#/components/parameters/idSingle" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/articles": {
+      "get": {
+        "summary": "List articles",
+        "description": "Retrieve articles about national parks.",
+        "operationId": "getArticles",
+        "tags": ["articles"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/campgrounds": {
+      "get": {
+        "summary": "List campgrounds",
+        "description": "Retrieve campground information for national parks.",
+        "operationId": "getCampgrounds",
+        "tags": ["campgrounds"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with campground data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/PaginatedResponse" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Campground" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/events": {
+      "get": {
+        "summary": "List events",
+        "description": "Retrieve events at national parks with filtering by date, type, tags, and more.",
+        "operationId": "getEvents",
+        "tags": ["events"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          {
+            "name": "organization",
+            "in": "query",
+            "description": "Filter by organization site codes.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "subject",
+            "in": "query",
+            "description": "Filter by subject site codes.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "portal",
+            "in": "query",
+            "description": "Filter by portal site codes.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "tagsAll",
+            "in": "query",
+            "description": "Tags that must all be present.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "tagsOne",
+            "in": "query",
+            "description": "At least one of these tags must be present.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          {
+            "name": "tagsNone",
+            "in": "query",
+            "description": "None of these tags should be present.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          { "$ref": "#/components/parameters/stateCode" },
+          {
+            "name": "dateStart",
+            "in": "query",
+            "description": "Starting date filter (yyyy-mm-dd format).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "dateEnd",
+            "in": "query",
+            "description": "Ending date filter (yyyy-mm-dd format).",
+            "schema": { "type": "string", "format": "date" }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "description": "Filter by event types.",
+            "schema": { "type": "array", "items": { "type": "string" } }
+          },
+          { "$ref": "#/components/parameters/idSingle" },
+          { "$ref": "#/components/parameters/q" },
+          {
+            "name": "pageSize",
+            "in": "query",
+            "description": "Results per page.",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "pageNumber",
+            "in": "query",
+            "description": "Current page number.",
+            "schema": { "type": "integer", "default": 1 }
+          },
+          {
+            "name": "expandRecurring",
+            "in": "query",
+            "description": "Expand recurring events into individual instances.",
+            "schema": { "type": "boolean", "default": false }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with events.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/feespasses": {
+      "get": {
+        "summary": "List fees and passes",
+        "description": "Retrieve entrance fee and pass information for national parks.",
+        "operationId": "getFeesPasses",
+        "tags": ["fees-passes"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/lessonplans": {
+      "get": {
+        "summary": "List lesson plans",
+        "description": "Retrieve educational lesson plans related to national parks.",
+        "operationId": "getLessonPlans",
+        "tags": ["lesson-plans"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/mapdata/parkboundaries/{sitecode}": {
+      "get": {
+        "summary": "Get park boundary data",
+        "description": "Retrieve GIS boundary data for a specific park site.",
+        "operationId": "getParkBoundaries",
+        "tags": ["map-data"],
+        "parameters": [
+          {
+            "name": "sitecode",
+            "in": "path",
+            "required": true,
+            "description": "Park site code (e.g., 'abli').",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with boundary geometry.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "type": "object" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/multimedia/audio": {
+      "get": {
+        "summary": "List audio files",
+        "description": "Retrieve audio content related to national parks.",
+        "operationId": "getMultimediaAudio",
+        "tags": ["multimedia"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/multimedia/galleries": {
+      "get": {
+        "summary": "List photo galleries",
+        "description": "Retrieve photo galleries for national parks.",
+        "operationId": "getMultimediaGalleries",
+        "tags": ["multimedia"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/multimedia/galleries/assets": {
+      "get": {
+        "summary": "List gallery assets",
+        "description": "Retrieve individual assets from photo galleries.",
+        "operationId": "getMultimediaGalleriesAssets",
+        "tags": ["multimedia"],
+        "parameters": [
+          { "$ref": "#/components/parameters/idSingle" },
+          {
+            "name": "galleryId",
+            "in": "query",
+            "description": "Gallery unique identifier.",
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/multimedia/videos": {
+      "get": {
+        "summary": "List videos",
+        "description": "Retrieve video content related to national parks.",
+        "operationId": "getMultimediaVideos",
+        "tags": ["multimedia"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/newsreleases": {
+      "get": {
+        "summary": "List news releases",
+        "description": "Retrieve news releases from national parks.",
+        "operationId": "getNewsReleases",
+        "tags": ["news-releases"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/parkinglots": {
+      "get": {
+        "summary": "List parking lots",
+        "description": "Retrieve parking lot information for national parks.",
+        "operationId": "getParkingLots",
+        "tags": ["parking-lots"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/parks": {
+      "get": {
+        "summary": "List parks",
+        "description": "Retrieve information about national parks including descriptions, addresses, contacts, hours, and more.",
+        "operationId": "getParks",
+        "tags": ["parks"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with park data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "allOf": [
+                    { "$ref": "#/components/schemas/PaginatedResponse" },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "data": {
+                          "type": "array",
+                          "items": { "$ref": "#/components/schemas/Park" }
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/passportstamplocations": {
+      "get": {
+        "summary": "List passport stamp locations",
+        "description": "Retrieve passport stamp locations at national parks.",
+        "operationId": "getPassportStampLocations",
+        "tags": ["passport-stamps"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/people": {
+      "get": {
+        "summary": "List people",
+        "description": "Retrieve information about historical people associated with national parks.",
+        "operationId": "getPeople",
+        "tags": ["people"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/places": {
+      "get": {
+        "summary": "List places",
+        "description": "Retrieve information about places within national parks.",
+        "operationId": "getPlaces",
+        "tags": ["places"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/roadevents": {
+      "get": {
+        "summary": "List road events",
+        "description": "Retrieve road incidents and work zone information for national parks.",
+        "operationId": "getRoadEvents",
+        "tags": ["road-events"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCodeSingle" },
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Filter by event type.",
+            "schema": {
+              "type": "string",
+              "enum": ["incident", "workzone"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": { "type": "object" }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/thingstodo": {
+      "get": {
+        "summary": "List things to do",
+        "description": "Retrieve recommended activities and things to do at national parks.",
+        "operationId": "getThingsToDo",
+        "tags": ["things-to-do"],
+        "parameters": [
+          { "$ref": "#/components/parameters/idSingle" },
+          { "$ref": "#/components/parameters/parkCodeSingle" },
+          {
+            "name": "stateCode",
+            "in": "query",
+            "description": "Filter by 2-character state code.",
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          {
+            "name": "start",
+            "in": "query",
+            "description": "Starting position for results.",
+            "schema": { "type": "string", "default": "0" }
+          },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/topics": {
+      "get": {
+        "summary": "List topics",
+        "description": "Retrieve topic categories used to classify park content.",
+        "operationId": "getTopics",
+        "tags": ["topics"],
+        "parameters": [
+          { "$ref": "#/components/parameters/idSingle" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/topics/parks": {
+      "get": {
+        "summary": "List topics with associated parks",
+        "description": "Retrieve topics and the parks associated with them.",
+        "operationId": "getTopicsParks",
+        "tags": ["topics"],
+        "parameters": [
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/tours": {
+      "get": {
+        "summary": "List tours",
+        "description": "Retrieve tour information for national parks.",
+        "operationId": "getTours",
+        "tags": ["tours"],
+        "parameters": [
+          { "$ref": "#/components/parameters/id" },
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/visitorcenters": {
+      "get": {
+        "summary": "List visitor centers",
+        "description": "Retrieve visitor center information for national parks.",
+        "operationId": "getVisitorCenters",
+        "tags": ["visitor-centers"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" },
+          { "$ref": "#/components/parameters/sort" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/webcams": {
+      "get": {
+        "summary": "List webcams",
+        "description": "Retrieve webcam information and streaming metadata for national parks.",
+        "operationId": "getWebcams",
+        "tags": ["webcams"],
+        "parameters": [
+          { "$ref": "#/components/parameters/parkCode" },
+          { "$ref": "#/components/parameters/stateCode" },
+          { "$ref": "#/components/parameters/idSingle" },
+          { "$ref": "#/components/parameters/q" },
+          { "$ref": "#/components/parameters/limit" },
+          { "$ref": "#/components/parameters/startInt" }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/PaginatedResponse" }
+              }
+            }
+          },
+          "400": { "$ref": "#/components/responses/BadRequest" },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "name": "api_key",
+        "in": "query",
+        "description": "API key obtained from the NPS Developer portal."
+      }
+    },
+    "parameters": {
+      "parkCode": {
+        "name": "parkCode",
+        "in": "query",
+        "description": "Filter by 4-character park codes. Comma-delimited for multiple parks.",
+        "schema": { "type": "array", "items": { "type": "string", "minLength": 4, "maxLength": 10 } }
+      },
+      "parkCodeSingle": {
+        "name": "parkCode",
+        "in": "query",
+        "description": "Filter by 4-character park code.",
+        "schema": { "type": "string", "minLength": 4, "maxLength": 10 }
+      },
+      "stateCode": {
+        "name": "stateCode",
+        "in": "query",
+        "description": "Filter by 2-character state codes. Comma-delimited for multiple states.",
+        "schema": { "type": "array", "items": { "type": "string", "minLength": 2, "maxLength": 2 } }
+      },
+      "q": {
+        "name": "q",
+        "in": "query",
+        "description": "Search term to filter results.",
+        "schema": { "type": "string" }
+      },
+      "limit": {
+        "name": "limit",
+        "in": "query",
+        "description": "Number of results to return per request.",
+        "schema": { "type": "string", "default": "50" }
+      },
+      "start": {
+        "name": "start",
+        "in": "query",
+        "description": "Starting position for results (string).",
+        "schema": { "type": "string", "default": "0" }
+      },
+      "startInt": {
+        "name": "start",
+        "in": "query",
+        "description": "Starting position for results.",
+        "schema": { "type": "integer", "default": 0 }
+      },
+      "sort": {
+        "name": "sort",
+        "in": "query",
+        "description": "Comma-delimited list of fields to sort by. Use unary negative for descending order.",
+        "schema": { "type": "string" }
+      },
+      "id": {
+        "name": "id",
+        "in": "query",
+        "description": "Filter by one or more unique IDs.",
+        "schema": { "type": "array", "items": { "type": "string" } }
+      },
+      "idSingle": {
+        "name": "id",
+        "in": "query",
+        "description": "Filter by a unique identifier.",
+        "schema": { "type": "string" }
+      }
+    },
+    "schemas": {
+      "PaginatedResponse": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "string",
+            "description": "Total number of matching records."
+          },
+          "limit": {
+            "type": "string",
+            "description": "Number of results returned."
+          },
+          "start": {
+            "type": "string",
+            "description": "Starting position of results."
+          },
+          "data": {
+            "type": "array",
+            "items": { "type": "object" },
+            "description": "Array of result objects."
+          }
+        }
+      },
+      "Park": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "parkCode": { "type": "string", "description": "4-character park code." },
+          "fullName": { "type": "string", "description": "Full name of the park." },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "designation": { "type": "string" },
+          "states": { "type": "string", "description": "Comma-separated state codes." },
+          "url": { "type": "string", "format": "uri" },
+          "weatherInfo": { "type": "string" },
+          "directionsInfo": { "type": "string" },
+          "directionsUrl": { "type": "string", "format": "uri" },
+          "latLong": { "type": "string" },
+          "latitude": { "type": "string" },
+          "longitude": { "type": "string" },
+          "addresses": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Address" }
+          },
+          "contacts": { "$ref": "#/components/schemas/Contacts" },
+          "operatingHours": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OperatingHours" }
+          },
+          "entranceFees": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Fee" }
+          },
+          "entrancePasses": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Fee" }
+          },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Image" }
+          },
+          "activities": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" }
+              }
+            }
+          },
+          "topics": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "Alert": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "parkCode": { "type": "string" },
+          "title": { "type": "string" },
+          "description": { "type": "string" },
+          "category": {
+            "type": "string",
+            "enum": ["Danger", "Caution", "Information", "Park Closure"]
+          },
+          "url": { "type": "string", "format": "uri" },
+          "lastIndexedDate": { "type": "string" }
+        }
+      },
+      "Campground": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "string" },
+          "parkCode": { "type": "string" },
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "latLong": { "type": "string" },
+          "latitude": { "type": "string" },
+          "longitude": { "type": "string" },
+          "reservationInfo": { "type": "string" },
+          "reservationUrl": { "type": "string", "format": "uri" },
+          "regulationsOverview": { "type": "string" },
+          "regulationsUrl": { "type": "string", "format": "uri" },
+          "weatherOverview": { "type": "string" },
+          "directionsOverview": { "type": "string" },
+          "directionsUrl": { "type": "string", "format": "uri" },
+          "numberOfSitesReservable": { "type": "string" },
+          "numberOfSitesFirstComeFirstServe": { "type": "string" },
+          "addresses": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Address" }
+          },
+          "contacts": { "$ref": "#/components/schemas/Contacts" },
+          "operatingHours": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/OperatingHours" }
+          },
+          "fees": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Fee" }
+          },
+          "images": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Image" }
+          },
+          "campsites": {
+            "type": "object",
+            "properties": {
+              "totalSites": { "type": "string" },
+              "group": { "type": "string" },
+              "horse": { "type": "string" },
+              "tentOnly": { "type": "string" },
+              "electricalHookups": { "type": "string" },
+              "rvOnly": { "type": "string" },
+              "walkBoatTo": { "type": "string" },
+              "other": { "type": "string" }
+            }
+          },
+          "accessibility": {
+            "type": "object",
+            "properties": {
+              "wheelchairAccess": { "type": "string" },
+              "internetInfo": { "type": "string" },
+              "cellPhoneInfo": { "type": "string" },
+              "fireStovePolicy": { "type": "string" },
+              "rvAllowed": { "type": "string" },
+              "rvMaxLength": { "type": "string" },
+              "trailerAllowed": { "type": "string" },
+              "trailerMaxLength": { "type": "string" },
+              "adaInfo": { "type": "string" },
+              "accessRoads": { "type": "array", "items": { "type": "string" } },
+              "classifications": { "type": "array", "items": { "type": "string" } }
+            }
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string", "enum": ["Physical", "Mailing"] },
+          "line1": { "type": "string" },
+          "line2": { "type": "string" },
+          "line3": { "type": "string" },
+          "city": { "type": "string" },
+          "stateCode": { "type": "string" },
+          "postalCode": { "type": "string" },
+          "countryCode": { "type": "string" }
+        }
+      },
+      "Contacts": {
+        "type": "object",
+        "properties": {
+          "phoneNumbers": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "phoneNumber": { "type": "string" },
+                "description": { "type": "string" },
+                "extension": { "type": "string" },
+                "type": { "type": "string" }
+              }
+            }
+          },
+          "emailAddresses": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "emailAddress": { "type": "string", "format": "email" },
+                "description": { "type": "string" }
+              }
+            }
+          }
+        }
+      },
+      "OperatingHours": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "description": { "type": "string" },
+          "standardHours": {
+            "type": "object",
+            "properties": {
+              "sunday": { "type": "string" },
+              "monday": { "type": "string" },
+              "tuesday": { "type": "string" },
+              "wednesday": { "type": "string" },
+              "thursday": { "type": "string" },
+              "friday": { "type": "string" },
+              "saturday": { "type": "string" }
+            }
+          },
+          "exceptions": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": { "type": "string" },
+                "startDate": { "type": "string" },
+                "endDate": { "type": "string" },
+                "exceptionHours": { "type": "object" }
+              }
+            }
+          }
+        }
+      },
+      "Fee": {
+        "type": "object",
+        "properties": {
+          "cost": { "type": "string" },
+          "description": { "type": "string" },
+          "title": { "type": "string" }
+        }
+      },
+      "Image": {
+        "type": "object",
+        "properties": {
+          "credit": { "type": "string" },
+          "altText": { "type": "string" },
+          "title": { "type": "string" },
+          "caption": { "type": "string" },
+          "url": { "type": "string", "format": "uri" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - invalid parameters.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - missing or invalid API key.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "InternalError": {
+        "description": "Internal server error.",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/nps.gov/national-park-service-us/meta.json
+++ b/apis/openapi/nps.gov/national-park-service-us/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "96288e5510e1fbdfec4dfc65168a8e83",
+    "format": "openapi",
+    "vendor": "nps.gov",
+    "api_name": "national-park-service-us",
+    "friendly_id": "nps.gov/national-park-service-us"
+  }
+}

--- a/apis/openapi/onemap.gov.sg/one-map-singapore/1.0.0/openapi.json
+++ b/apis/openapi/onemap.gov.sg/one-map-singapore/1.0.0/openapi.json
@@ -1,0 +1,1106 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "OneMap Singapore API",
+    "description": "OneMap is the authoritative national map of Singapore, providing a platform for users to search Singapore addresses, retrieve geographical coordinates, perform route calculations, and convert between coordinate systems (SVY21 and WGS84). The API offers search, reverse geocoding, routing, coordinate conversion, and themed data endpoints.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Singapore Land Authority",
+      "url": "https://www.onemap.gov.sg"
+    },
+    "x-jentic-source-url": "https://www.onemap.gov.sg/docs/"
+  },
+  "servers": [
+    {
+      "url": "https://www.onemap.gov.sg",
+      "description": "OneMap production server"
+    }
+  ],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication",
+      "description": "Token generation and management"
+    },
+    {
+      "name": "Search",
+      "description": "Search Singapore addresses and locations"
+    },
+    {
+      "name": "Reverse Geocode",
+      "description": "Reverse geocoding from coordinates to addresses"
+    },
+    {
+      "name": "Coordinate Conversion",
+      "description": "Convert between WGS84 (EPSG:4326), SVY21 (EPSG:3414), and EPSG:3857 coordinate systems"
+    },
+    {
+      "name": "Routing",
+      "description": "Route calculation for driving, walking, cycling, and public transport"
+    },
+    {
+      "name": "Themes",
+      "description": "Themed location data"
+    }
+  ],
+  "paths": {
+    "/api/auth/post/getToken": {
+      "post": {
+        "operationId": "getToken",
+        "summary": "Get Authentication Token",
+        "description": "Generate an authentication token using your registered email and password. Tokens are valid for 3 days.",
+        "tags": ["Authentication"],
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["email", "password"],
+                "properties": {
+                  "email": {
+                    "type": "string",
+                    "format": "email",
+                    "description": "Registered OneMap account email."
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Account password."
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Token generated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "access_token": {
+                      "type": "string",
+                      "description": "JWT access token."
+                    },
+                    "expiry_timestamp": {
+                      "type": "string",
+                      "description": "Token expiry timestamp."
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/common/elastic/search": {
+      "get": {
+        "operationId": "search",
+        "summary": "Search Addresses",
+        "description": "Search for Singapore addresses, buildings, and locations. Returns results with both SVY21 (X, Y) and WGS84 (latitude, longitude) coordinates.",
+        "tags": ["Search"],
+        "parameters": [
+          {
+            "name": "searchVal",
+            "in": "query",
+            "required": true,
+            "description": "Search keyword (address, building name, postal code, or street name).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "revenue house"
+          },
+          {
+            "name": "returnGeom",
+            "in": "query",
+            "required": true,
+            "description": "Whether to return geometry (coordinates) in the response.",
+            "schema": {
+              "type": "string",
+              "enum": ["Y", "N"]
+            }
+          },
+          {
+            "name": "getAddrDetails",
+            "in": "query",
+            "required": true,
+            "description": "Whether to return detailed address information.",
+            "schema": {
+              "type": "string",
+              "enum": ["Y", "N"]
+            }
+          },
+          {
+            "name": "pageNum",
+            "in": "query",
+            "required": false,
+            "description": "Page number for pagination (starts at 1).",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication token missing or expired.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/revgeocodexy": {
+      "get": {
+        "operationId": "reverseGeocodeXY",
+        "summary": "Reverse Geocode (SVY21)",
+        "description": "Retrieve the address of a location by providing SVY21 X and Y coordinates.",
+        "tags": ["Reverse Geocode"],
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "required": true,
+            "description": "SVY21 coordinates in format 'Y,X' (e.g., '24291.97788882,33758.76149132').",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "buffer",
+            "in": "query",
+            "required": false,
+            "description": "Buffer radius in metres to search within.",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "addressType",
+            "in": "query",
+            "required": false,
+            "description": "Type of address to return.",
+            "schema": {
+              "type": "string",
+              "enum": ["All", "HDB"]
+            }
+          },
+          {
+            "name": "otherFeatures",
+            "in": "query",
+            "required": false,
+            "description": "Whether to return other nearby features.",
+            "schema": {
+              "type": "string",
+              "enum": ["Y", "N"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocode response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReverseGeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/revgeocode": {
+      "get": {
+        "operationId": "reverseGeocode",
+        "summary": "Reverse Geocode (WGS84)",
+        "description": "Retrieve the address of a location by providing WGS84 latitude and longitude coordinates.",
+        "tags": ["Reverse Geocode"],
+        "parameters": [
+          {
+            "name": "location",
+            "in": "query",
+            "required": true,
+            "description": "WGS84 coordinates in format 'latitude,longitude' (e.g., '1.3,103.8').",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "buffer",
+            "in": "query",
+            "required": false,
+            "description": "Buffer radius in metres.",
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
+          },
+          {
+            "name": "addressType",
+            "in": "query",
+            "required": false,
+            "description": "Type of address to return.",
+            "schema": {
+              "type": "string",
+              "enum": ["All", "HDB"]
+            }
+          },
+          {
+            "name": "otherFeatures",
+            "in": "query",
+            "required": false,
+            "description": "Whether to return other nearby features.",
+            "schema": {
+              "type": "string",
+              "enum": ["Y", "N"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocode response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReverseGeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/common/convert/4326to3857": {
+      "get": {
+        "operationId": "convert4326To3857",
+        "summary": "Convert WGS84 to EPSG:3857",
+        "description": "Convert coordinates from WGS84 (EPSG:4326) to Web Mercator (EPSG:3857).",
+        "tags": ["Coordinate Conversion"],
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "required": true,
+            "description": "WGS84 latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "required": true,
+            "description": "WGS84 longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Converted coordinates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinateConversionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/common/convert/3857to4326": {
+      "get": {
+        "operationId": "convert3857To4326",
+        "summary": "Convert EPSG:3857 to WGS84",
+        "description": "Convert coordinates from Web Mercator (EPSG:3857) to WGS84 (EPSG:4326).",
+        "tags": ["Coordinate Conversion"],
+        "parameters": [
+          {
+            "name": "X",
+            "in": "query",
+            "required": true,
+            "description": "EPSG:3857 X coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "Y",
+            "in": "query",
+            "required": true,
+            "description": "EPSG:3857 Y coordinate.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Converted coordinates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinateConversionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/common/convert/4326to3414": {
+      "get": {
+        "operationId": "convert4326To3414",
+        "summary": "Convert WGS84 to SVY21",
+        "description": "Convert coordinates from WGS84 (EPSG:4326) to SVY21 (EPSG:3414).",
+        "tags": ["Coordinate Conversion"],
+        "parameters": [
+          {
+            "name": "latitude",
+            "in": "query",
+            "required": true,
+            "description": "WGS84 latitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "longitude",
+            "in": "query",
+            "required": true,
+            "description": "WGS84 longitude.",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Converted coordinates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinateConversionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/common/convert/3414to4326": {
+      "get": {
+        "operationId": "convert3414To4326",
+        "summary": "Convert SVY21 to WGS84",
+        "description": "Convert coordinates from SVY21 (EPSG:3414) to WGS84 (EPSG:4326).",
+        "tags": ["Coordinate Conversion"],
+        "parameters": [
+          {
+            "name": "X",
+            "in": "query",
+            "required": true,
+            "description": "SVY21 X coordinate (Easting).",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "Y",
+            "in": "query",
+            "required": true,
+            "description": "SVY21 Y coordinate (Northing).",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Converted coordinates.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoordinateConversionResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/routingsvc/route": {
+      "get": {
+        "operationId": "getRoute",
+        "summary": "Get Route",
+        "description": "Calculate a route between two points in Singapore with support for driving, walking, cycling, and public transport modes.",
+        "tags": ["Routing"],
+        "parameters": [
+          {
+            "name": "start",
+            "in": "query",
+            "required": true,
+            "description": "Starting point as 'latitude,longitude'.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1.319728,103.8421"
+          },
+          {
+            "name": "end",
+            "in": "query",
+            "required": true,
+            "description": "Ending point as 'latitude,longitude'.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1.319728905,103.8421581"
+          },
+          {
+            "name": "routeType",
+            "in": "query",
+            "required": true,
+            "description": "Mode of transport for route calculation.",
+            "schema": {
+              "type": "string",
+              "enum": ["drive", "walk", "cycle", "pt"]
+            }
+          },
+          {
+            "name": "date",
+            "in": "query",
+            "required": false,
+            "description": "Date of travel in MM-DD-YYYY format (required for public transport).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "time",
+            "in": "query",
+            "required": false,
+            "description": "Time of travel in HH:MM:SS format (required for public transport).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "mode",
+            "in": "query",
+            "required": false,
+            "description": "Public transport mode preference.",
+            "schema": {
+              "type": "string",
+              "enum": ["TRANSIT", "BUS", "RAIL"]
+            }
+          },
+          {
+            "name": "maxWalkDistance",
+            "in": "query",
+            "required": false,
+            "description": "Maximum walking distance in metres for public transport routing.",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "numItineraries",
+            "in": "query",
+            "required": false,
+            "description": "Number of itineraries to return (public transport only).",
+            "schema": {
+              "type": "integer",
+              "default": 3
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful routing response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RoutingResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/themesvc/getAllThemesInfo": {
+      "get": {
+        "operationId": "getAllThemesInfo",
+        "summary": "Get All Themes Info",
+        "description": "Retrieve a list of all available themed data layers and their details.",
+        "tags": ["Themes"],
+        "parameters": [
+          {
+            "name": "moreInfo",
+            "in": "query",
+            "required": false,
+            "description": "Whether to return extended theme information.",
+            "schema": {
+              "type": "string",
+              "enum": ["Y", "N"],
+              "default": "N"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of available themes.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThemesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/public/themesvc/retrieveTheme": {
+      "get": {
+        "operationId": "retrieveTheme",
+        "summary": "Retrieve Theme Data",
+        "description": "Retrieve location data for a specific theme.",
+        "tags": ["Themes"],
+        "parameters": [
+          {
+            "name": "queryName",
+            "in": "query",
+            "required": true,
+            "description": "Name of the theme to query.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "extents",
+            "in": "query",
+            "required": false,
+            "description": "Bounding box extents in format 'minX,minY,maxX,maxY' (SVY21).",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Theme data response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ThemeDataResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT token obtained from the /api/auth/post/getToken endpoint. Tokens are valid for 3 days."
+      }
+    },
+    "schemas": {
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "found": {
+            "type": "integer",
+            "description": "Total number of results found."
+          },
+          "totalNumPages": {
+            "type": "integer",
+            "description": "Total number of pages."
+          },
+          "pageNum": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            }
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "properties": {
+          "SEARCHVAL": {
+            "type": "string",
+            "description": "Search value / building or landmark name."
+          },
+          "BLK_NO": {
+            "type": "string",
+            "description": "Block number."
+          },
+          "ROAD_NAME": {
+            "type": "string",
+            "description": "Road/street name."
+          },
+          "BUILDING": {
+            "type": "string",
+            "description": "Building name."
+          },
+          "ADDRESS": {
+            "type": "string",
+            "description": "Full address."
+          },
+          "POSTAL": {
+            "type": "string",
+            "description": "Postal code."
+          },
+          "X": {
+            "type": "string",
+            "description": "SVY21 X coordinate (Easting)."
+          },
+          "Y": {
+            "type": "string",
+            "description": "SVY21 Y coordinate (Northing)."
+          },
+          "LATITUDE": {
+            "type": "string",
+            "description": "WGS84 latitude."
+          },
+          "LONGITUDE": {
+            "type": "string",
+            "description": "WGS84 longitude."
+          }
+        }
+      },
+      "ReverseGeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "GeocodeInfo": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "BUILDINGNAME": {
+                  "type": "string"
+                },
+                "BLOCK": {
+                  "type": "string"
+                },
+                "ROAD": {
+                  "type": "string"
+                },
+                "POSTALCODE": {
+                  "type": "string"
+                },
+                "XCOORD": {
+                  "type": "string"
+                },
+                "YCOORD": {
+                  "type": "string"
+                },
+                "LATITUDE": {
+                  "type": "string"
+                },
+                "LONGITUDE": {
+                  "type": "string"
+                },
+                "LONGTITUDE": {
+                  "type": "string",
+                  "description": "Alternative spelling field for longitude."
+                }
+              }
+            }
+          }
+        }
+      },
+      "CoordinateConversionResponse": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude in the target coordinate system."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude in the target coordinate system."
+          },
+          "X": {
+            "type": "number",
+            "format": "double",
+            "description": "X coordinate in the target coordinate system."
+          },
+          "Y": {
+            "type": "number",
+            "format": "double",
+            "description": "Y coordinate in the target coordinate system."
+          }
+        }
+      },
+      "RoutingResponse": {
+        "type": "object",
+        "properties": {
+          "status_message": {
+            "type": "string"
+          },
+          "route_geometry": {
+            "type": "string",
+            "description": "Encoded polyline of the route geometry."
+          },
+          "status": {
+            "type": "integer"
+          },
+          "route_instructions": {
+            "type": "array",
+            "items": {
+              "type": "array",
+              "items": {},
+              "description": "Array of route instruction tuples."
+            }
+          },
+          "route_name": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Road names along the route."
+          },
+          "route_summary": {
+            "type": "object",
+            "properties": {
+              "start_point": {
+                "type": "string"
+              },
+              "end_point": {
+                "type": "string"
+              },
+              "total_time": {
+                "type": "integer",
+                "description": "Total travel time in seconds."
+              },
+              "total_distance": {
+                "type": "integer",
+                "description": "Total distance in metres."
+              }
+            }
+          },
+          "phyroute": {
+            "type": "object",
+            "description": "Physical route details."
+          },
+          "plan": {
+            "type": "object",
+            "description": "Public transport plan details (for pt routeType).",
+            "properties": {
+              "itineraries": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "duration": {
+                      "type": "integer"
+                    },
+                    "startTime": {
+                      "type": "integer"
+                    },
+                    "endTime": {
+                      "type": "integer"
+                    },
+                    "walkTime": {
+                      "type": "integer"
+                    },
+                    "transitTime": {
+                      "type": "integer"
+                    },
+                    "waitingTime": {
+                      "type": "integer"
+                    },
+                    "transfers": {
+                      "type": "integer"
+                    },
+                    "legs": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "mode": {
+                            "type": "string"
+                          },
+                          "route": {
+                            "type": "string"
+                          },
+                          "from": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "to": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string"
+                              },
+                              "lat": {
+                                "type": "number"
+                              },
+                              "lon": {
+                                "type": "number"
+                              }
+                            }
+                          },
+                          "duration": {
+                            "type": "integer"
+                          },
+                          "distance": {
+                            "type": "number"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ThemesResponse": {
+        "type": "object",
+        "properties": {
+          "Theme_Names": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "THEMENAME": {
+                  "type": "string"
+                },
+                "QUERYNAME": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ThemeDataResponse": {
+        "type": "object",
+        "properties": {
+          "SrchResults": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "FeatCount": {
+                  "type": "integer"
+                },
+                "Theme_Name": {
+                  "type": "string"
+                },
+                "NAME": {
+                  "type": "string"
+                },
+                "DESCRIPTION": {
+                  "type": "string"
+                },
+                "ADDRESSBLOCKHOUSENUMBER": {
+                  "type": "string"
+                },
+                "ADDRESSSTREETNAME": {
+                  "type": "string"
+                },
+                "ADDRESSPOSTALCODE": {
+                  "type": "string"
+                },
+                "LatLng": {
+                  "type": "string"
+                },
+                "XY": {
+                  "type": "string"
+                },
+                "ICON_NAME": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "description": "Error message."
+          },
+          "error": {
+            "type": "string",
+            "description": "Error description."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/onemap.gov.sg/one-map-singapore/meta.json
+++ b/apis/openapi/onemap.gov.sg/one-map-singapore/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "471675ff570b02c10f9aa7ce7bf27792",
+    "format": "openapi",
+    "vendor": "onemap.gov.sg",
+    "api_name": "one-map-singapore",
+    "friendly_id": "onemap.gov.sg/one-map-singapore"
+  }
+}

--- a/apis/openapi/pandascore.co/pandascore/2.0.0/openapi.json
+++ b/apis/openapi/pandascore.co/pandascore/2.0.0/openapi.json
@@ -1,0 +1,978 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "PandaScore API",
+    "description": "PandaScore provides historical and real-time statistics for 13+ major esports titles including League of Legends, Counter-Strike, Dota 2, Valorant, Overwatch, and more. Access data on leagues, matches, players, teams, tournaments, and series across all supported games.",
+    "version": "2.0.0",
+    "x-jentic-source-url": "https://developers.pandascore.co/"
+  },
+  "servers": [
+    {
+      "url": "https://api.pandascore.co",
+      "description": "PandaScore API server"
+    }
+  ],
+  "tags": [
+    { "name": "Incidents", "description": "Track additions, changes, and deletions across all resources" },
+    { "name": "Leagues", "description": "Esports leagues" },
+    { "name": "Matches", "description": "Match data including past, running, and upcoming" },
+    { "name": "Players", "description": "Player profiles and statistics" },
+    { "name": "Series", "description": "Series/seasons within leagues" },
+    { "name": "Teams", "description": "Team profiles and rosters" },
+    { "name": "Tournaments", "description": "Tournament data and brackets" },
+    { "name": "Videogames", "description": "Supported video game titles" }
+  ],
+  "paths": {
+    "/incidents": {
+      "get": {
+        "operationId": "listIncidents",
+        "summary": "List all changes, additions, and deletions",
+        "description": "Returns a combined list of all resource changes including creations, updates, and deletions.",
+        "tags": ["Incidents"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of incidents",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Incident" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "403": { "$ref": "#/components/responses/Forbidden" }
+        }
+      }
+    },
+    "/additions": {
+      "get": {
+        "operationId": "listAdditions",
+        "summary": "List additions",
+        "description": "Returns the latest resource additions (newly created objects).",
+        "tags": ["Incidents"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of additions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Incident" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/changes": {
+      "get": {
+        "operationId": "listChanges",
+        "summary": "List changes",
+        "description": "Returns the latest resource modifications.",
+        "tags": ["Incidents"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of changes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Incident" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/deletions": {
+      "get": {
+        "operationId": "listDeletions",
+        "summary": "List deletions",
+        "description": "Returns the latest resource deletions.",
+        "tags": ["Incidents"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of deletions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Incident" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues": {
+      "get": {
+        "operationId": "listLeagues",
+        "summary": "List leagues",
+        "description": "Returns a paginated list of esports leagues across all supported video games.",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of leagues",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/League" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}": {
+      "get": {
+        "operationId": "getLeague",
+        "summary": "Get a league",
+        "description": "Returns details for a specific league by ID or slug.",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "leagueIdOrSlug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "League details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/League" }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/matches": {
+      "get": {
+        "operationId": "getLeagueMatches",
+        "summary": "Get matches for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          {
+            "name": "leagueIdOrSlug",
+            "in": "path",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of matches",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": { "$ref": "#/components/schemas/Match" }
+                }
+              }
+            }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/matches/past": {
+      "get": {
+        "operationId": "getLeaguePastMatches",
+        "summary": "Get past matches for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "leagueIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of past matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/matches/running": {
+      "get": {
+        "operationId": "getLeagueRunningMatches",
+        "summary": "Get running matches for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "leagueIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of running matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/matches/upcoming": {
+      "get": {
+        "operationId": "getLeagueUpcomingMatches",
+        "summary": "Get upcoming matches for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "leagueIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of upcoming matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/series": {
+      "get": {
+        "operationId": "getLeagueSeries",
+        "summary": "List series for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "leagueIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of series",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Series" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/leagues/{leagueIdOrSlug}/tournaments": {
+      "get": {
+        "operationId": "getLeagueTournaments",
+        "summary": "Get tournaments for a league",
+        "tags": ["Leagues"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "leagueIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of tournaments",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Tournament" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/matches": {
+      "get": {
+        "operationId": "listMatches",
+        "summary": "List matches",
+        "description": "Returns a paginated list of matches across all games.",
+        "tags": ["Matches"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/matches/{matchIdOrSlug}": {
+      "get": {
+        "operationId": "getMatch",
+        "summary": "Get a match",
+        "tags": ["Matches"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "matchIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Match details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Match" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/matches/past": {
+      "get": {
+        "operationId": "listPastMatches",
+        "summary": "List past matches",
+        "tags": ["Matches"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of past matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/matches/running": {
+      "get": {
+        "operationId": "listRunningMatches",
+        "summary": "List running matches",
+        "tags": ["Matches"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of running matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/matches/upcoming": {
+      "get": {
+        "operationId": "listUpcomingMatches",
+        "summary": "List upcoming matches",
+        "tags": ["Matches"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of upcoming matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/players": {
+      "get": {
+        "operationId": "listPlayers",
+        "summary": "List players",
+        "description": "Returns a paginated list of esports players.",
+        "tags": ["Players"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of players",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Player" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/players/{playerIdOrSlug}": {
+      "get": {
+        "operationId": "getPlayer",
+        "summary": "Get a player",
+        "tags": ["Players"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "playerIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Player" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series": {
+      "get": {
+        "operationId": "listSeries",
+        "summary": "List series",
+        "tags": ["Series"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of series",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Series" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/series/{serieIdOrSlug}": {
+      "get": {
+        "operationId": "getSeries",
+        "summary": "Get a series",
+        "tags": ["Series"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "serieIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Series details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Series" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/series/{serieIdOrSlug}/matches": {
+      "get": {
+        "operationId": "getSeriesMatches",
+        "summary": "Get matches for a series",
+        "tags": ["Series"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "serieIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/series/{serieIdOrSlug}/tournaments": {
+      "get": {
+        "operationId": "getSeriesTournaments",
+        "summary": "Get tournaments for a series",
+        "tags": ["Series"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "serieIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of tournaments",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Tournament" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/teams": {
+      "get": {
+        "operationId": "listTeams",
+        "summary": "List teams",
+        "tags": ["Teams"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of teams",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Team" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/teams/{teamIdOrSlug}": {
+      "get": {
+        "operationId": "getTeam",
+        "summary": "Get a team",
+        "tags": ["Teams"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "teamIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Team details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Team" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/tournaments": {
+      "get": {
+        "operationId": "listTournaments",
+        "summary": "List tournaments",
+        "tags": ["Tournaments"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of tournaments",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Tournament" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/tournaments/{tournamentIdOrSlug}": {
+      "get": {
+        "operationId": "getTournament",
+        "summary": "Get a tournament",
+        "tags": ["Tournaments"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "tournamentIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Tournament details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Tournament" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/tournaments/{tournamentIdOrSlug}/matches": {
+      "get": {
+        "operationId": "getTournamentMatches",
+        "summary": "Get matches for a tournament",
+        "tags": ["Tournaments"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "tournamentIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of matches",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Match" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/tournaments/{tournamentIdOrSlug}/teams": {
+      "get": {
+        "operationId": "getTournamentTeams",
+        "summary": "Get teams for a tournament",
+        "tags": ["Tournaments"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "tournamentIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of teams",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Team" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/videogames": {
+      "get": {
+        "operationId": "listVideogames",
+        "summary": "List video games",
+        "description": "Returns a list of all supported esports video games.",
+        "tags": ["Videogames"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of video games",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Videogame" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/videogames/{videogameIdOrSlug}": {
+      "get": {
+        "operationId": "getVideogame",
+        "summary": "Get a video game",
+        "tags": ["Videogames"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "videogameIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } }
+        ],
+        "responses": {
+          "200": {
+            "description": "Video game details",
+            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Videogame" } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" },
+          "404": { "$ref": "#/components/responses/NotFound" }
+        }
+      }
+    },
+    "/videogames/{videogameIdOrSlug}/leagues": {
+      "get": {
+        "operationId": "getVideogameLeagues",
+        "summary": "Get leagues for a video game",
+        "tags": ["Videogames"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "videogameIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of leagues",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/League" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/videogames/{videogameIdOrSlug}/series": {
+      "get": {
+        "operationId": "getVideogameSeries",
+        "summary": "Get series for a video game",
+        "tags": ["Videogames"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "videogameIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of series",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Series" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    },
+    "/videogames/{videogameIdOrSlug}/tournaments": {
+      "get": {
+        "operationId": "getVideogameTournaments",
+        "summary": "Get tournaments for a video game",
+        "tags": ["Videogames"],
+        "security": [{ "bearerAuth": [] }],
+        "parameters": [
+          { "name": "videogameIdOrSlug", "in": "path", "required": true, "schema": { "type": "string" } },
+          { "$ref": "#/components/parameters/page" },
+          { "$ref": "#/components/parameters/perPage" }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of tournaments",
+            "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Tournament" } } } }
+          },
+          "401": { "$ref": "#/components/responses/Unauthorized" }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "PandaScore API access token. Obtain from the PandaScore developer dashboard."
+      }
+    },
+    "parameters": {
+      "page": {
+        "name": "page",
+        "in": "query",
+        "required": false,
+        "description": "Page number for pagination",
+        "schema": { "type": "integer", "minimum": 1, "default": 1 }
+      },
+      "perPage": {
+        "name": "per_page",
+        "in": "query",
+        "required": false,
+        "description": "Number of items per page (1-100)",
+        "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 50 }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Unauthorized - missing or invalid bearer token",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "Forbidden": {
+        "description": "Forbidden - insufficient permissions",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": { "$ref": "#/components/schemas/Error" }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "Incident": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "change_type": {
+            "type": "string",
+            "enum": ["creation", "deletion", "update"]
+          },
+          "type": {
+            "type": "string",
+            "enum": ["match", "league", "serie", "tournament", "team", "player"]
+          },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "object": {
+            "type": "object",
+            "description": "The full resource object (varies by type)"
+          }
+        }
+      },
+      "League": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "image_url": { "type": "string", "nullable": true },
+          "url": { "type": "string", "nullable": true },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "videogame": { "$ref": "#/components/schemas/Videogame" },
+          "series": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Series" }
+          }
+        },
+        "required": ["id", "name", "slug", "modified_at"]
+      },
+      "Match": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "status": {
+            "type": "string",
+            "enum": ["not_started", "running", "finished", "canceled", "postponed"]
+          },
+          "match_type": {
+            "type": "string",
+            "enum": ["best_of", "custom", "first_to", "ow_best_of"]
+          },
+          "number_of_games": { "type": "integer" },
+          "begin_at": { "type": "string", "format": "date-time", "nullable": true },
+          "end_at": { "type": "string", "format": "date-time", "nullable": true },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "winner": { "$ref": "#/components/schemas/Team" },
+          "opponents": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "opponent": { "$ref": "#/components/schemas/Team" },
+                "type": { "type": "string" }
+              }
+            }
+          },
+          "league": { "$ref": "#/components/schemas/League" },
+          "serie": { "$ref": "#/components/schemas/Series" },
+          "tournament": { "$ref": "#/components/schemas/Tournament" },
+          "videogame": { "$ref": "#/components/schemas/Videogame" },
+          "results": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "team_id": { "type": "integer" },
+                "score": { "type": "integer" }
+              }
+            }
+          }
+        },
+        "required": ["id", "name", "slug", "status", "modified_at"]
+      },
+      "Player": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "first_name": { "type": "string", "nullable": true },
+          "last_name": { "type": "string", "nullable": true },
+          "nationality": { "type": "string", "nullable": true },
+          "image_url": { "type": "string", "nullable": true },
+          "role": { "type": "string", "nullable": true },
+          "birthday": { "type": "string", "format": "date", "nullable": true },
+          "current_team": { "$ref": "#/components/schemas/Team" },
+          "current_videogame": { "$ref": "#/components/schemas/Videogame" },
+          "modified_at": { "type": "string", "format": "date-time" }
+        },
+        "required": ["id", "name", "slug"]
+      },
+      "Series": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string", "nullable": true },
+          "slug": { "type": "string" },
+          "full_name": { "type": "string" },
+          "season": { "type": "string", "nullable": true },
+          "year": { "type": "integer", "nullable": true },
+          "begin_at": { "type": "string", "format": "date-time", "nullable": true },
+          "end_at": { "type": "string", "format": "date-time", "nullable": true },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "league": { "$ref": "#/components/schemas/League" },
+          "videogame": { "$ref": "#/components/schemas/Videogame" }
+        },
+        "required": ["id", "slug", "full_name"]
+      },
+      "Team": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "acronym": { "type": "string", "nullable": true },
+          "image_url": { "type": "string", "nullable": true },
+          "location": { "type": "string", "nullable": true },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "players": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Player" }
+          },
+          "current_videogame": { "$ref": "#/components/schemas/Videogame" }
+        },
+        "required": ["id", "name", "slug"]
+      },
+      "Tournament": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" },
+          "begin_at": { "type": "string", "format": "date-time", "nullable": true },
+          "end_at": { "type": "string", "format": "date-time", "nullable": true },
+          "modified_at": { "type": "string", "format": "date-time" },
+          "tier": { "type": "string", "nullable": true },
+          "prizepool": { "type": "string", "nullable": true },
+          "league": { "$ref": "#/components/schemas/League" },
+          "serie": { "$ref": "#/components/schemas/Series" },
+          "videogame": { "$ref": "#/components/schemas/Videogame" },
+          "teams": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/Team" }
+          }
+        },
+        "required": ["id", "name", "slug"]
+      },
+      "Videogame": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "name": { "type": "string" },
+          "slug": { "type": "string" }
+        },
+        "required": ["id", "name", "slug"]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/pandascore.co/pandascore/meta.json
+++ b/apis/openapi/pandascore.co/pandascore/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "2133518bb94e04764b78f8c284a54e32",
+    "format": "openapi",
+    "vendor": "pandascore.co",
+    "api_name": "pandascore",
+    "friendly_id": "pandascore.co/pandascore"
+  }
+}

--- a/apis/openapi/pathofexile.com/path-of-exile/1.0.0/openapi.json
+++ b/apis/openapi/pathofexile.com/path-of-exile/1.0.0/openapi.json
@@ -1,0 +1,523 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Path of Exile API",
+    "description": "The official Path of Exile API provides access to game information including league data, ladder rankings, PvP matches, public stash tabs, and account profiles. Authentication uses OAuth 2.0 for account-specific endpoints.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Grinding Gear Games",
+      "url": "https://www.pathofexile.com"
+    },
+    "x-jentic-source-url": "https://www.pathofexile.com/developer/docs"
+  },
+  "servers": [
+    {
+      "url": "https://api.pathofexile.com",
+      "description": "Production API"
+    }
+  ],
+  "security": [
+    {
+      "oAuth2": []
+    }
+  ],
+  "tags": [
+    {"name": "Leagues", "description": "League information"},
+    {"name": "Ladders", "description": "League ladder rankings"},
+    {"name": "PvP", "description": "PvP match and season data"},
+    {"name": "Stash Tabs", "description": "Public stash tab data"},
+    {"name": "Accounts", "description": "Account and character information"},
+    {"name": "Characters", "description": "Character details and items"}
+  ],
+  "paths": {
+    "/league": {
+      "get": {
+        "tags": ["Leagues"],
+        "summary": "List leagues",
+        "description": "Retrieve a list of current and past leagues.",
+        "operationId": "listLeagues",
+        "security": [],
+        "parameters": [
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["main", "event", "season"]}, "description": "Filter by league type"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}, "description": "Game realm"},
+          {"name": "season", "in": "query", "schema": {"type": "string"}, "description": "Filter by season ID"},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 50}, "description": "Number of results"},
+          {"name": "offset", "in": "query", "schema": {"type": "integer", "default": 0}, "description": "Result offset"}
+        ],
+        "responses": {
+          "200": {
+            "description": "List of leagues",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"$ref": "#/components/schemas/League"}
+                }
+              }
+            }
+          },
+          "400": {"$ref": "#/components/responses/BadRequest"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/league/{id}": {
+      "get": {
+        "tags": ["Leagues"],
+        "summary": "Get a league",
+        "description": "Retrieve details for a specific league by ID.",
+        "operationId": "getLeague",
+        "security": [],
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}, "description": "League ID"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "League details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/League"}
+              }
+            }
+          },
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/league/{id}/ladder": {
+      "get": {
+        "tags": ["Ladders"],
+        "summary": "Get league ladder",
+        "description": "Retrieve the ladder (rankings) for a specific league.",
+        "operationId": "getLeagueLadder",
+        "security": [],
+        "parameters": [
+          {"name": "id", "in": "path", "required": true, "schema": {"type": "string"}, "description": "League ID"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 20, "maximum": 200}},
+          {"name": "offset", "in": "query", "schema": {"type": "integer", "default": 0}},
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["league", "labyrinth"]}, "description": "Ladder type"},
+          {"name": "sort", "in": "query", "schema": {"type": "string"}, "description": "Sort order"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Ladder rankings",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Ladder"}
+              }
+            }
+          },
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/pvp-match": {
+      "get": {
+        "tags": ["PvP"],
+        "summary": "List PvP matches",
+        "description": "Retrieve a list of PvP matches for a given season.",
+        "operationId": "listPvpMatches",
+        "security": [],
+        "parameters": [
+          {"name": "type", "in": "query", "schema": {"type": "string", "enum": ["season", "tournament"]}, "description": "Match type"},
+          {"name": "season", "in": "query", "schema": {"type": "string"}, "description": "PvP season ID"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "List of PvP matches",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"$ref": "#/components/schemas/PvpMatch"}
+                }
+              }
+            }
+          },
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/pvp-match/{matchId}": {
+      "get": {
+        "tags": ["PvP"],
+        "summary": "Get a PvP match",
+        "description": "Retrieve details for a specific PvP match.",
+        "operationId": "getPvpMatch",
+        "security": [],
+        "parameters": [
+          {"name": "matchId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "PvP match ID"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "PvP match details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PvpMatch"}
+              }
+            }
+          },
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/public-stash-tabs": {
+      "get": {
+        "tags": ["Stash Tabs"],
+        "summary": "Get public stash tabs",
+        "description": "Retrieve a chunk of public stash tab data. Use the id from the response to page through results.",
+        "operationId": "getPublicStashTabs",
+        "security": [],
+        "parameters": [
+          {"name": "id", "in": "query", "schema": {"type": "string"}, "description": "Pagination cursor from previous response"},
+          {"name": "realm", "in": "query", "schema": {"type": "string", "enum": ["pc", "xbox", "sony"]}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Public stash tab data",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/PublicStashTabsResponse"}
+              }
+            }
+          },
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/account/profile": {
+      "get": {
+        "tags": ["Accounts"],
+        "summary": "Get account profile",
+        "description": "Retrieve the profile of the authenticated account.",
+        "operationId": "getAccountProfile",
+        "responses": {
+          "200": {
+            "description": "Account profile",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/Account"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/account/stashes/{league}": {
+      "get": {
+        "tags": ["Accounts"],
+        "summary": "Get account stash tabs",
+        "description": "Retrieve stash tabs for the authenticated account in a specific league.",
+        "operationId": "getAccountStashes",
+        "parameters": [
+          {"name": "league", "in": "path", "required": true, "schema": {"type": "string"}, "description": "League ID"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Stash tab data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "stashes": {
+                      "type": "array",
+                      "items": {"$ref": "#/components/schemas/StashTab"}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/character": {
+      "get": {
+        "tags": ["Characters"],
+        "summary": "List characters",
+        "description": "Retrieve a list of characters for the authenticated account.",
+        "operationId": "listCharacters",
+        "responses": {
+          "200": {
+            "description": "List of characters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {"$ref": "#/components/schemas/Character"}
+                }
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/character/{name}": {
+      "get": {
+        "tags": ["Characters"],
+        "summary": "Get a character",
+        "description": "Retrieve detailed information for a specific character by name.",
+        "operationId": "getCharacter",
+        "parameters": [
+          {"name": "name", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Character name"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Character details",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/CharacterDetail"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "oAuth2": {
+        "type": "oauth2",
+        "description": "OAuth 2.0 authentication for account-specific endpoints.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://www.pathofexile.com/oauth/authorize",
+            "tokenUrl": "https://www.pathofexile.com/oauth/token",
+            "scopes": {
+              "account:profile": "View account profile",
+              "account:stashes": "View account stash tabs",
+              "account:characters": "View account characters",
+              "account:item_filter": "View and edit item filters",
+              "account:league_accounts": "View league accounts"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "League": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string", "description": "League identifier"},
+          "realm": {"type": "string"},
+          "description": {"type": "string"},
+          "url": {"type": "string", "format": "uri"},
+          "startAt": {"type": "string", "format": "date-time"},
+          "endAt": {"type": "string", "format": "date-time", "nullable": true},
+          "delveEvent": {"type": "boolean"},
+          "rules": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": {"type": "string"},
+                "name": {"type": "string"},
+                "description": {"type": "string"}
+              }
+            }
+          }
+        }
+      },
+      "Ladder": {
+        "type": "object",
+        "properties": {
+          "total": {"type": "integer", "description": "Total number of entries"},
+          "entries": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/LadderEntry"}
+          }
+        }
+      },
+      "LadderEntry": {
+        "type": "object",
+        "properties": {
+          "rank": {"type": "integer"},
+          "dead": {"type": "boolean"},
+          "online": {"type": "boolean"},
+          "character": {
+            "type": "object",
+            "properties": {
+              "id": {"type": "string"},
+              "name": {"type": "string"},
+              "level": {"type": "integer"},
+              "class": {"type": "string"},
+              "experience": {"type": "integer", "format": "int64"}
+            }
+          },
+          "account": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string"},
+              "realm": {"type": "string"}
+            }
+          }
+        }
+      },
+      "PvpMatch": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "realm": {"type": "string"},
+          "startAt": {"type": "string", "format": "date-time"},
+          "endAt": {"type": "string", "format": "date-time"},
+          "url": {"type": "string", "format": "uri"},
+          "description": {"type": "string"},
+          "glickoRatings": {"type": "boolean"},
+          "pvp": {"type": "boolean"},
+          "style": {"type": "string"},
+          "registerAt": {"type": "string", "format": "date-time"}
+        }
+      },
+      "PublicStashTabsResponse": {
+        "type": "object",
+        "properties": {
+          "next_change_id": {"type": "string", "description": "Cursor for next page"},
+          "stashes": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/StashTab"}
+          }
+        }
+      },
+      "StashTab": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "public": {"type": "boolean"},
+          "accountName": {"type": "string"},
+          "stash": {"type": "string", "description": "Stash tab name"},
+          "stashType": {"type": "string"},
+          "items": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/Item"}
+          }
+        }
+      },
+      "Item": {
+        "type": "object",
+        "properties": {
+          "id": {"type": "string"},
+          "name": {"type": "string"},
+          "typeLine": {"type": "string"},
+          "baseType": {"type": "string"},
+          "identified": {"type": "boolean"},
+          "ilvl": {"type": "integer", "description": "Item level"},
+          "note": {"type": "string", "description": "Price note"},
+          "icon": {"type": "string", "format": "uri"},
+          "league": {"type": "string"},
+          "w": {"type": "integer", "description": "Width in inventory"},
+          "h": {"type": "integer", "description": "Height in inventory"},
+          "frameType": {"type": "integer"},
+          "stackSize": {"type": "integer"},
+          "maxStackSize": {"type": "integer"},
+          "explicitMods": {"type": "array", "items": {"type": "string"}},
+          "implicitMods": {"type": "array", "items": {"type": "string"}},
+          "craftedMods": {"type": "array", "items": {"type": "string"}},
+          "sockets": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "group": {"type": "integer"},
+                "attr": {"type": "string"}
+              }
+            }
+          }
+        }
+      },
+      "Account": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "realm": {"type": "string"},
+          "uuid": {"type": "string"},
+          "guild": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "name": {"type": "string"}
+            }
+          }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "name": {"type": "string"},
+          "league": {"type": "string"},
+          "classId": {"type": "integer"},
+          "ascendancyClass": {"type": "integer"},
+          "class": {"type": "string"},
+          "level": {"type": "integer"},
+          "experience": {"type": "integer", "format": "int64"}
+        }
+      },
+      "CharacterDetail": {
+        "allOf": [
+          {"$ref": "#/components/schemas/Character"},
+          {
+            "type": "object",
+            "properties": {
+              "equipment": {"type": "array", "items": {"$ref": "#/components/schemas/Item"}},
+              "inventory": {"type": "array", "items": {"$ref": "#/components/schemas/Item"}},
+              "jewels": {"type": "array", "items": {"$ref": "#/components/schemas/Item"}},
+              "passives": {
+                "type": "object",
+                "properties": {
+                  "hashes": {"type": "array", "items": {"type": "integer"}},
+                  "hashes_ex": {"type": "array", "items": {"type": "integer"}}
+                }
+              }
+            }
+          }
+        ]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {"type": "integer"},
+              "message": {"type": "string"}
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Invalid request parameters",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "Unauthorized": {
+        "description": "Authentication required or token invalid",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      },
+      "RateLimited": {
+        "description": "Rate limit exceeded. Check X-Rate-Limit headers.",
+        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Error"}}}
+      }
+    }
+  }
+}

--- a/apis/openapi/pathofexile.com/path-of-exile/meta.json
+++ b/apis/openapi/pathofexile.com/path-of-exile/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "3f4bfaaa9d202bab51a706147fe2d8c6",
+    "format": "openapi",
+    "vendor": "pathofexile.com",
+    "api_name": "path-of-exile",
+    "friendly_id": "pathofexile.com/path-of-exile"
+  }
+}

--- a/apis/openapi/positionstack.com/positionstack/1.0.0/openapi.json
+++ b/apis/openapi/positionstack.com/positionstack/1.0.0/openapi.json
@@ -1,0 +1,953 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "positionstack API",
+    "description": "positionstack offers a powerful and free geocoding API for forward and reverse geocoding, supporting batch requests, multiple output formats, and optional data modules for timezone, sun, country, and bounding box information.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "positionstack",
+      "url": "https://positionstack.com"
+    },
+    "x-jentic-source-url": "https://positionstack.com/documentation"
+  },
+  "servers": [
+    {
+      "url": "https://api.positionstack.com/v1",
+      "description": "Production server (HTTPS - paid plans)"
+    },
+    {
+      "url": "http://api.positionstack.com/v1",
+      "description": "Production server (HTTP - free plan)"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Forward Geocoding",
+      "description": "Convert addresses to coordinates"
+    },
+    {
+      "name": "Reverse Geocoding",
+      "description": "Convert coordinates to addresses"
+    }
+  ],
+  "paths": {
+    "/forward": {
+      "get": {
+        "operationId": "forwardGeocode",
+        "summary": "Forward Geocoding",
+        "description": "Convert a free-text address, place name, or postal code to location data including latitude and longitude coordinates.",
+        "tags": ["Forward Geocoding"],
+        "parameters": [
+          {
+            "name": "access_key",
+            "in": "query",
+            "required": true,
+            "description": "Your API access key from the account dashboard.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Free-text address, place name, postal code, or location identifier to geocode.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "1600 Pennsylvania Ave NW, Washington DC"
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by one or more comma-separated 2 or 3-letter country codes (ISO 3166-1 Alpha-2 or Alpha-3).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "US,CA"
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "description": "Filter results by region, district, city, or state name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "in": "query",
+            "required": false,
+            "description": "2 or 3-letter language code for response localization. Defaults to English.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of results to return per query (1-80). Default is 10.",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 80,
+              "default": 10
+            }
+          },
+          {
+            "name": "output",
+            "in": "query",
+            "required": false,
+            "description": "Response output format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "geojson"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Specify response fields to reduce response size (e.g., results.latitude,results.longitude).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "country_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable the country data module in the response.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "sun_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable the sun/astrology data module in the response.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "timezone_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable the timezone data module in the response.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "bbox_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable the bounding box data module in the response.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "description": "JSONP callback function name for wrapping the response.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error (invalid/missing API key or inactive user).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access restricted (HTTPS or function not available on current plan).",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource or endpoint not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Usage or rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "batchForwardGeocode",
+        "summary": "Batch Forward Geocoding",
+        "description": "Process multiple forward geocoding queries in a single request. Requires Professional Plan or higher.",
+        "tags": ["Forward Geocoding"],
+        "parameters": [
+          {
+            "name": "access_key",
+            "in": "query",
+            "required": true,
+            "description": "Your API access key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access restricted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate or usage limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reverse": {
+      "get": {
+        "operationId": "reverseGeocode",
+        "summary": "Reverse Geocoding",
+        "description": "Convert coordinates (latitude and longitude) or an IP address to location data.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "access_key",
+            "in": "query",
+            "required": true,
+            "description": "Your API access key.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "Coordinates in 'latitude,longitude' format or an IP address.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "40.7638435,-73.9729691"
+          },
+          {
+            "name": "country",
+            "in": "query",
+            "required": false,
+            "description": "Filter by country code(s).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "region",
+            "in": "query",
+            "required": false,
+            "description": "Filter by region name.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "language",
+            "in": "query",
+            "required": false,
+            "description": "2 or 3-letter language code.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of results (1-80, default 10).",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 80,
+              "default": 10
+            }
+          },
+          {
+            "name": "output",
+            "in": "query",
+            "required": false,
+            "description": "Response format.",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "geojson"],
+              "default": "json"
+            }
+          },
+          {
+            "name": "fields",
+            "in": "query",
+            "required": false,
+            "description": "Specify response fields.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "country_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable country data module.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "sun_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable sun data module.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "timezone_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable timezone data module.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "bbox_module",
+            "in": "query",
+            "required": false,
+            "description": "Set to 1 to enable bounding box module.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1]
+            }
+          },
+          {
+            "name": "callback",
+            "in": "query",
+            "required": false,
+            "description": "JSONP callback function name.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful reverse geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access restricted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Resource not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate or usage limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "batchReverseGeocode",
+        "summary": "Batch Reverse Geocoding",
+        "description": "Process multiple reverse geocoding queries in a single request. Requires Professional Plan or higher.",
+        "tags": ["Reverse Geocoding"],
+        "parameters": [
+          {
+            "name": "access_key",
+            "in": "query",
+            "required": true,
+            "description": "Your API access key.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch reverse geocoding response.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Authentication error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Access restricted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate or usage limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "access_key",
+        "description": "API access key obtained from your positionstack account dashboard."
+      }
+    },
+    "schemas": {
+      "GeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "results": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/LocationResult"
+                }
+              }
+            }
+          }
+        }
+      },
+      "LocationResult": {
+        "type": "object",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude coordinate of the result."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude coordinate of the result."
+          },
+          "label": {
+            "type": "string",
+            "description": "Full formatted address label."
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the location or place."
+          },
+          "type": {
+            "type": "string",
+            "description": "Type of location (e.g., address, venue, locality)."
+          },
+          "number": {
+            "type": "string",
+            "description": "Street/house number."
+          },
+          "street": {
+            "type": "string",
+            "description": "Street name."
+          },
+          "postal_code": {
+            "type": "string",
+            "description": "Postal or ZIP code."
+          },
+          "confidence": {
+            "type": "number",
+            "format": "float",
+            "description": "Confidence score between 0 and 1."
+          },
+          "region": {
+            "type": "string",
+            "description": "Region or state name."
+          },
+          "region_code": {
+            "type": "string",
+            "description": "Region or state code."
+          },
+          "administrative_area": {
+            "type": "string",
+            "description": "Administrative area name."
+          },
+          "neighbourhood": {
+            "type": "string",
+            "description": "Neighbourhood name."
+          },
+          "country": {
+            "type": "string",
+            "description": "Country name."
+          },
+          "country_code": {
+            "type": "string",
+            "description": "ISO 3166-1 Alpha-2 country code."
+          },
+          "map_url": {
+            "type": "string",
+            "description": "URL to view the location on a map."
+          },
+          "distance": {
+            "type": "number",
+            "format": "float",
+            "description": "Distance from the queried coordinates (reverse geocoding only)."
+          },
+          "country_module": {
+            "$ref": "#/components/schemas/CountryModule"
+          },
+          "sun_module": {
+            "$ref": "#/components/schemas/SunModule"
+          },
+          "timezone_module": {
+            "$ref": "#/components/schemas/TimezoneModule"
+          },
+          "bbox_module": {
+            "$ref": "#/components/schemas/BboxModule"
+          }
+        }
+      },
+      "CountryModule": {
+        "type": "object",
+        "description": "Country data module (enabled with country_module=1).",
+        "properties": {
+          "latitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "common_name": {
+            "type": "string"
+          },
+          "official_name": {
+            "type": "string"
+          },
+          "capital": {
+            "type": "string"
+          },
+          "flag": {
+            "type": "string"
+          },
+          "area": {
+            "type": "number"
+          },
+          "landlocked": {
+            "type": "boolean"
+          },
+          "independent": {
+            "type": "boolean"
+          },
+          "global": {
+            "type": "object",
+            "properties": {
+              "alpha2": {
+                "type": "string"
+              },
+              "alpha3": {
+                "type": "string"
+              },
+              "numeric_code": {
+                "type": "string"
+              },
+              "region": {
+                "type": "string"
+              },
+              "subregion": {
+                "type": "string"
+              },
+              "region_code": {
+                "type": "string"
+              },
+              "subregion_code": {
+                "type": "string"
+              },
+              "world_region": {
+                "type": "string"
+              },
+              "continent_name": {
+                "type": "string"
+              },
+              "continent_code": {
+                "type": "string"
+              }
+            }
+          },
+          "dial": {
+            "type": "object",
+            "properties": {
+              "calling_code": {
+                "type": "string"
+              },
+              "national_prefix": {
+                "type": "string"
+              },
+              "international_prefix": {
+                "type": "string"
+              }
+            }
+          },
+          "currencies": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "symbol": {
+                  "type": "string"
+                },
+                "code": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "languages": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "SunModule": {
+        "type": "object",
+        "description": "Sun/astrology data module (enabled with sun_module=1).",
+        "properties": {
+          "rise": {
+            "type": "number",
+            "description": "Sunrise time as UNIX timestamp."
+          },
+          "set": {
+            "type": "number",
+            "description": "Sunset time as UNIX timestamp."
+          },
+          "transit": {
+            "type": "number",
+            "description": "Solar transit time as UNIX timestamp."
+          }
+        }
+      },
+      "TimezoneModule": {
+        "type": "object",
+        "description": "Timezone data module (enabled with timezone_module=1).",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Timezone name (e.g., America/New_York)."
+          },
+          "offset": {
+            "type": "integer",
+            "description": "UTC offset in seconds."
+          },
+          "offset_string": {
+            "type": "string",
+            "description": "UTC offset as a string (e.g., -05:00)."
+          }
+        }
+      },
+      "BboxModule": {
+        "type": "object",
+        "description": "Bounding box module (enabled with bbox_module=1).",
+        "properties": {
+          "min_longitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "min_latitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "max_longitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "max_latitude": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "BatchRequest": {
+        "type": "object",
+        "properties": {
+          "batch": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["query"],
+              "properties": {
+                "query": {
+                  "type": "string",
+                  "description": "Address or coordinates to geocode."
+                },
+                "country": {
+                  "type": "string",
+                  "description": "Country filter."
+                },
+                "region": {
+                  "type": "string",
+                  "description": "Region filter."
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code identifier.",
+                "enum": [
+                  "invalid_access_key",
+                  "missing_access_key",
+                  "inactive_user",
+                  "https_access_restricted",
+                  "function_access_restricted",
+                  "invalid_api_function",
+                  "404_not_found",
+                  "usage_limit_reached",
+                  "rate_limit_reached",
+                  "internal_error"
+                ]
+              },
+              "message": {
+                "type": "string",
+                "description": "Human-readable error message."
+              },
+              "context": {
+                "type": "object",
+                "description": "Additional error context with field-specific validation errors.",
+                "additionalProperties": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string"
+                      },
+                      "message": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/positionstack.com/positionstack/meta.json
+++ b/apis/openapi/positionstack.com/positionstack/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "c5de6b49ca617032e3618f0a78e703c9",
+    "format": "openapi",
+    "vendor": "positionstack.com",
+    "api_name": "positionstack",
+    "friendly_id": "positionstack.com/positionstack"
+  }
+}

--- a/apis/openapi/pubg.com/pubg/1.0.0/openapi.json
+++ b/apis/openapi/pubg.com/pubg/1.0.0/openapi.json
@@ -1,0 +1,727 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "PUBG API",
+    "description": "The official PUBG API provides programmatic access to in-game PUBG data including player stats, match data, season statistics, leaderboards, weapon mastery, survival mastery, and telemetry. Data is formatted using the JSON:API specification.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "PUBG Developer Portal",
+      "url": "https://developer.pubg.com"
+    },
+    "x-jentic-source-url": "https://developer.pubg.com/"
+  },
+  "servers": [
+    {
+      "url": "https://api.pubg.com",
+      "description": "Production"
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {"name": "Players", "description": "Player lookup and search"},
+    {"name": "Seasons", "description": "Season information"},
+    {"name": "Stats", "description": "Player season and lifetime statistics"},
+    {"name": "Matches", "description": "Match data and details"},
+    {"name": "Leaderboards", "description": "Ranked leaderboards"},
+    {"name": "Mastery", "description": "Weapon and survival mastery data"},
+    {"name": "Samples", "description": "Sample match data"},
+    {"name": "Status", "description": "API status"}
+  ],
+  "paths": {
+    "/shards/{platform}/players": {
+      "get": {
+        "tags": ["Players"],
+        "summary": "Get players",
+        "description": "Search for players by name or ID. Supports batch lookups of up to 10 players.",
+        "operationId": "getPlayers",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string", "enum": ["steam", "kakao", "xbox", "psn", "stadia", "tournament"]}, "description": "Platform shard"},
+          {"name": "filter[playerNames]", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated player names (up to 10)"},
+          {"name": "filter[playerIds]", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated player IDs (up to 10)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Player data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/PlayersResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}": {
+      "get": {
+        "tags": ["Players"],
+        "summary": "Get a single player",
+        "description": "Retrieve data for a specific player by their account ID.",
+        "operationId": "getPlayer",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Player account ID"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Player data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/PlayerResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/seasons": {
+      "get": {
+        "tags": ["Seasons"],
+        "summary": "Get seasons",
+        "description": "Retrieve the list of available seasons for a platform.",
+        "operationId": "getSeasons",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "List of seasons",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/SeasonsResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}/seasons/{seasonId}": {
+      "get": {
+        "tags": ["Stats"],
+        "summary": "Get player season stats",
+        "description": "Retrieve season statistics for a specific player.",
+        "operationId": "getPlayerSeasonStats",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "seasonId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Season ID or 'lifetime'"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Season statistics",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/PlayerSeasonStatsResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}/seasons/{seasonId}/ranked": {
+      "get": {
+        "tags": ["Stats"],
+        "summary": "Get player ranked stats",
+        "description": "Retrieve ranked season statistics for a specific player.",
+        "operationId": "getPlayerRankedStats",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "seasonId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked statistics",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/PlayerSeasonStatsResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}/seasons/lifetime": {
+      "get": {
+        "tags": ["Stats"],
+        "summary": "Get player lifetime stats",
+        "description": "Retrieve lifetime statistics for a specific player.",
+        "operationId": "getPlayerLifetimeStats",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Lifetime statistics",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/PlayerSeasonStatsResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/seasons/{seasonId}/gameMode/{gameMode}/players": {
+      "get": {
+        "tags": ["Stats"],
+        "summary": "Get batch season stats",
+        "description": "Retrieve season statistics for multiple players at once (batch up to 10).",
+        "operationId": "getBatchSeasonStats",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "seasonId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "gameMode", "in": "path", "required": true, "schema": {"type": "string", "enum": ["solo", "solo-fpp", "duo", "duo-fpp", "squad", "squad-fpp"]}},
+          {"name": "filter[playerIds]", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Comma-separated player IDs (up to 10)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Batch season statistics",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/BatchStatsResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/matches/{matchId}": {
+      "get": {
+        "tags": ["Matches"],
+        "summary": "Get a match",
+        "description": "Retrieve detailed data for a specific match. Match data is available for 14 days after creation.",
+        "operationId": "getMatch",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "matchId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Match ID"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Match data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/MatchResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/samples": {
+      "get": {
+        "tags": ["Samples"],
+        "summary": "Get match samples",
+        "description": "Retrieve a list of sample match IDs.",
+        "operationId": "getSamples",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "filter[createdAt-start]", "in": "query", "schema": {"type": "string", "format": "date-time"}, "description": "Start time filter (ISO 8601)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Sample match data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/SamplesResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}/weapon_mastery": {
+      "get": {
+        "tags": ["Mastery"],
+        "summary": "Get weapon mastery",
+        "description": "Retrieve weapon mastery data for a specific player.",
+        "operationId": "getWeaponMastery",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Weapon mastery data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/WeaponMasteryResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/players/{playerId}/survival_mastery": {
+      "get": {
+        "tags": ["Mastery"],
+        "summary": "Get survival mastery",
+        "description": "Retrieve survival mastery data for a specific player.",
+        "operationId": "getSurvivalMastery",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "playerId", "in": "path", "required": true, "schema": {"type": "string"}}
+        ],
+        "responses": {
+          "200": {
+            "description": "Survival mastery data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/SurvivalMasteryResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/shards/{platform}/leaderboards/{seasonId}/{gameMode}": {
+      "get": {
+        "tags": ["Leaderboards"],
+        "summary": "Get leaderboard",
+        "description": "Retrieve the leaderboard for a specific season and game mode.",
+        "operationId": "getLeaderboard",
+        "parameters": [
+          {"name": "platform", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "seasonId", "in": "path", "required": true, "schema": {"type": "string"}},
+          {"name": "gameMode", "in": "path", "required": true, "schema": {"type": "string", "enum": ["solo", "solo-fpp", "duo", "duo-fpp", "squad", "squad-fpp"]}},
+          {"name": "page[number]", "in": "query", "schema": {"type": "integer"}, "description": "Page number"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Leaderboard data",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {"$ref": "#/components/schemas/LeaderboardResponse"}
+              }
+            }
+          },
+          "401": {"$ref": "#/components/responses/Unauthorized"},
+          "404": {"$ref": "#/components/responses/NotFound"},
+          "429": {"$ref": "#/components/responses/RateLimited"}
+        }
+      }
+    },
+    "/status": {
+      "get": {
+        "tags": ["Status"],
+        "summary": "Get API status",
+        "description": "Check the status of the PUBG API.",
+        "operationId": "getStatus",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "API is up",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "type": {"type": "string", "example": "status"},
+                        "id": {"type": "string"},
+                        "attributes": {
+                          "type": "object",
+                          "properties": {
+                            "released": {"type": "boolean"},
+                            "version": {"type": "string"}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key passed as a Bearer token in the Authorization header."
+      }
+    },
+    "schemas": {
+      "JsonApiResource": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string"},
+          "id": {"type": "string"},
+          "attributes": {"type": "object"}
+        }
+      },
+      "Player": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string", "example": "player"},
+          "id": {"type": "string", "description": "Player account ID"},
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "name": {"type": "string", "description": "Player name"},
+              "stats": {"type": "object", "nullable": true},
+              "titleId": {"type": "string"},
+              "shardId": {"type": "string"},
+              "patchVersion": {"type": "string"},
+              "banType": {"type": "string"},
+              "clanId": {"type": "string"}
+            }
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "matches": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "type": {"type": "string"},
+                        "id": {"type": "string"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "PlayersResponse": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Player"}},
+          "links": {"type": "object", "properties": {"self": {"type": "string"}}},
+          "meta": {"type": "object"}
+        }
+      },
+      "PlayerResponse": {
+        "type": "object",
+        "properties": {
+          "data": {"$ref": "#/components/schemas/Player"},
+          "links": {"type": "object", "properties": {"self": {"type": "string"}}},
+          "meta": {"type": "object"}
+        }
+      },
+      "Season": {
+        "type": "object",
+        "properties": {
+          "type": {"type": "string", "example": "season"},
+          "id": {"type": "string"},
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "isCurrentSeason": {"type": "boolean"},
+              "isOffseason": {"type": "boolean"}
+            }
+          }
+        }
+      },
+      "SeasonsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Season"}}
+        }
+      },
+      "GameModeStats": {
+        "type": "object",
+        "properties": {
+          "assists": {"type": "integer"},
+          "boosts": {"type": "integer"},
+          "dBNOs": {"type": "integer"},
+          "dailyKills": {"type": "integer"},
+          "damageDealt": {"type": "number", "format": "double"},
+          "days": {"type": "integer"},
+          "headshotKills": {"type": "integer"},
+          "heals": {"type": "integer"},
+          "killPoints": {"type": "number", "format": "double"},
+          "kills": {"type": "integer"},
+          "longestKill": {"type": "number", "format": "double"},
+          "longestTimeSurvived": {"type": "number", "format": "double"},
+          "losses": {"type": "integer"},
+          "maxKillStreaks": {"type": "integer"},
+          "mostSurvivalTime": {"type": "number", "format": "double"},
+          "revives": {"type": "integer"},
+          "rideDistance": {"type": "number", "format": "double"},
+          "roadKills": {"type": "integer"},
+          "roundMostKills": {"type": "integer"},
+          "roundsPlayed": {"type": "integer"},
+          "suicides": {"type": "integer"},
+          "swimDistance": {"type": "number", "format": "double"},
+          "teamKills": {"type": "integer"},
+          "timeSurvived": {"type": "number", "format": "double"},
+          "top10s": {"type": "integer"},
+          "vehicleDestroys": {"type": "integer"},
+          "walkDistance": {"type": "number", "format": "double"},
+          "weaponsAcquired": {"type": "integer"},
+          "weeklyKills": {"type": "integer"},
+          "winPoints": {"type": "number", "format": "double"},
+          "wins": {"type": "integer"}
+        }
+      },
+      "PlayerSeasonStatsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "playerSeason"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "gameModeStats": {
+                    "type": "object",
+                    "properties": {
+                      "solo": {"$ref": "#/components/schemas/GameModeStats"},
+                      "solo-fpp": {"$ref": "#/components/schemas/GameModeStats"},
+                      "duo": {"$ref": "#/components/schemas/GameModeStats"},
+                      "duo-fpp": {"$ref": "#/components/schemas/GameModeStats"},
+                      "squad": {"$ref": "#/components/schemas/GameModeStats"},
+                      "squad-fpp": {"$ref": "#/components/schemas/GameModeStats"}
+                    }
+                  }
+                }
+              },
+              "relationships": {
+                "type": "object",
+                "properties": {
+                  "player": {"type": "object"},
+                  "season": {"type": "object"},
+                  "matchesSolo": {"type": "object"},
+                  "matchesDuo": {"type": "object"},
+                  "matchesSquad": {"type": "object"}
+                }
+              }
+            }
+          }
+        }
+      },
+      "BatchStatsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/JsonApiResource"}
+          }
+        }
+      },
+      "MatchResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "match"},
+              "id": {"type": "string"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "createdAt": {"type": "string", "format": "date-time"},
+                  "duration": {"type": "integer", "description": "Match duration in seconds"},
+                  "gameMode": {"type": "string"},
+                  "mapName": {"type": "string"},
+                  "isCustomMatch": {"type": "boolean"},
+                  "seasonState": {"type": "string"},
+                  "shardId": {"type": "string"},
+                  "titleId": {"type": "string"}
+                }
+              },
+              "relationships": {
+                "type": "object",
+                "properties": {
+                  "rosters": {"type": "object"},
+                  "assets": {"type": "object"}
+                }
+              }
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/JsonApiResource"}
+          }
+        }
+      },
+      "SamplesResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "sample"},
+              "id": {"type": "string"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "createdAt": {"type": "string", "format": "date-time"},
+                  "shardId": {"type": "string"},
+                  "titleId": {"type": "string"}
+                }
+              },
+              "relationships": {
+                "type": "object",
+                "properties": {
+                  "matches": {"type": "object"}
+                }
+              }
+            }
+          }
+        }
+      },
+      "WeaponMasteryResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "weaponMastery"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "weaponSummaries": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "object",
+                      "properties": {
+                        "xpTotal": {"type": "integer"},
+                        "levelCurrent": {"type": "integer"},
+                        "tierCurrent": {"type": "integer"},
+                        "statsTotal": {"type": "object"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "SurvivalMasteryResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "survivalMastery"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "xp": {"type": "integer"},
+                  "level": {"type": "integer"},
+                  "totalMatchesPlayed": {"type": "integer"}
+                }
+              }
+            }
+          }
+        }
+      },
+      "LeaderboardResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "object",
+            "properties": {
+              "type": {"type": "string", "example": "leaderboard"},
+              "id": {"type": "string"},
+              "attributes": {
+                "type": "object",
+                "properties": {
+                  "shardId": {"type": "string"},
+                  "gameMode": {"type": "string"}
+                }
+              },
+              "relationships": {"type": "object"}
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {"$ref": "#/components/schemas/JsonApiResource"}
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": {"type": "string"},
+                "detail": {"type": "string"},
+                "status": {"type": "string"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "API key is missing or invalid",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      },
+      "NotFound": {
+        "description": "The requested resource was not found",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      },
+      "RateLimited": {
+        "description": "Rate limit exceeded",
+        "content": {
+          "application/vnd.api+json": {
+            "schema": {"$ref": "#/components/schemas/Error"}
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/pubg.com/pubg/meta.json
+++ b/apis/openapi/pubg.com/pubg/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "59f4989a78f5b5d493164a092c1e7c9a",
+    "format": "openapi",
+    "vendor": "pubg.com",
+    "api_name": "pubg",
+    "friendly_id": "pubg.com/pubg"
+  }
+}

--- a/apis/openapi/quizapi.io/quizapi-io/1.0.0/openapi.json
+++ b/apis/openapi/quizapi.io/quizapi-io/1.0.0/openapi.json
@@ -1,0 +1,313 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "QuizAPI",
+    "description": "Access thousands of quiz questions across programming, science, and more. Browse by category, difficulty, and tags. Supports AI-powered question generation, embeddable widgets, leaderboards, and analytics.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "QuizAPI Support",
+      "url": "https://quizapi.io"
+    },
+    "x-jentic-source-url": "https://quizapi.io/"
+  },
+  "servers": [
+    {
+      "url": "https://quizapi.io",
+      "description": "Production"
+    }
+  ],
+  "security": [
+    {
+      "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {"name": "Discovery", "description": "Endpoints that require no authentication"},
+    {"name": "Quizzes", "description": "Browse and search published quizzes"},
+    {"name": "Questions", "description": "Retrieve questions for quizzes or browse across all quizzes"}
+  ],
+  "paths": {
+    "/api/v1/metadata": {
+      "get": {
+        "tags": ["Discovery"],
+        "summary": "Get API metadata",
+        "description": "Returns available categories, tags, difficulties, question types, and aggregate stats. No API key required.",
+        "operationId": "getMetadata",
+        "security": [],
+        "responses": {
+          "200": {
+            "description": "Metadata retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["success", "data"],
+                  "properties": {
+                    "success": {"type": "boolean", "enum": [true]},
+                    "data": {
+                      "type": "object",
+                      "required": ["difficulties", "questionTypes", "categories", "tags", "stats"],
+                      "properties": {
+                        "difficulties": {
+                          "type": "array",
+                          "items": {"$ref": "#/components/schemas/Difficulty"},
+                          "example": ["EASY", "MEDIUM", "HARD", "EXPERT"]
+                        },
+                        "questionTypes": {
+                          "type": "array",
+                          "items": {"$ref": "#/components/schemas/QuestionType"},
+                          "example": ["MULTIPLE_CHOICE", "TRUE_FALSE", "OPEN_ENDED"]
+                        },
+                        "categories": {
+                          "type": "array",
+                          "items": {"type": "string"},
+                          "example": ["Programming", "DevOps", "Science"]
+                        },
+                        "tags": {
+                          "type": "array",
+                          "items": {"type": "string"},
+                          "example": ["javascript", "python", "docker"]
+                        },
+                        "stats": {
+                          "type": "object",
+                          "required": ["totalQuizzes", "totalQuestions"],
+                          "properties": {
+                            "totalQuizzes": {"type": "integer", "example": 150},
+                            "totalQuestions": {"type": "integer", "example": 3200}
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {"$ref": "#/components/schemas/ErrorResponse"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/quizzes": {
+      "get": {
+        "tags": ["Quizzes"],
+        "summary": "List quizzes",
+        "description": "Returns a paginated list of published, approved quizzes. Supports filtering by category, difficulty, tags, and free-text topic search.",
+        "operationId": "listQuizzes",
+        "parameters": [
+          {"name": "category", "in": "query", "schema": {"type": "string"}, "description": "Filter by category (case-insensitive)", "example": "Programming"},
+          {"name": "difficulty", "in": "query", "schema": {"$ref": "#/components/schemas/Difficulty"}, "description": "Filter by difficulty level"},
+          {"name": "tags", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated list of tags", "example": "javascript,react"},
+          {"name": "topic", "in": "query", "schema": {"type": "string"}, "description": "Free-text search in title, description, and tags", "example": "react hooks"},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}, "description": "Number of results to return (1-50)"},
+          {"name": "offset", "in": "query", "schema": {"type": "integer", "minimum": 0, "default": 0}, "description": "Number of results to skip for pagination"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Quizzes retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["success", "data", "meta"],
+                  "properties": {
+                    "success": {"type": "boolean", "enum": [true]},
+                    "data": {
+                      "type": "array",
+                      "items": {"$ref": "#/components/schemas/QuizListItem"}
+                    },
+                    "meta": {
+                      "type": "object",
+                      "required": ["total", "limit", "offset"],
+                      "properties": {
+                        "total": {"type": "integer"},
+                        "limit": {"type": "integer"},
+                        "offset": {"type": "integer"}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "401": {
+            "description": "Missing or invalid API key",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          }
+        }
+      }
+    },
+    "/api/v1/questions": {
+      "get": {
+        "tags": ["Questions"],
+        "summary": "Get questions",
+        "description": "Two modes: (1) Pass quiz_id to get ordered questions for a specific quiz. (2) Omit quiz_id to browse questions across all published quizzes with pagination, filtering, and optional randomization.",
+        "operationId": "getQuestions",
+        "parameters": [
+          {"name": "quiz_id", "in": "query", "schema": {"type": "string"}, "description": "If provided, returns questions for this quiz. If omitted, enters browse mode."},
+          {"name": "include_answers", "in": "query", "schema": {"type": "string", "enum": ["true", "false"]}, "description": "Set to true to include answers (quiz_id mode only). In browse mode, answers are always included."},
+          {"name": "category", "in": "query", "schema": {"type": "string"}, "description": "Filter by quiz category. Comma-separated for multiple (browse mode only)."},
+          {"name": "difficulty", "in": "query", "schema": {"type": "string"}, "description": "Filter by difficulty. Comma-separated for multiple (browse mode only)."},
+          {"name": "type", "in": "query", "schema": {"type": "string"}, "description": "Filter by question type. Comma-separated (browse mode only)."},
+          {"name": "tags", "in": "query", "schema": {"type": "string"}, "description": "Comma-separated tags to match (browse mode only)."},
+          {"name": "limit", "in": "query", "schema": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10}, "description": "Max questions per page in browse mode (1-50)"},
+          {"name": "offset", "in": "query", "schema": {"type": "integer", "minimum": 0, "default": 0}, "description": "Number of questions to skip (browse mode only)"},
+          {"name": "random", "in": "query", "schema": {"type": "string", "enum": ["true", "false"]}, "description": "Set to true to shuffle results randomly (browse mode only)"}
+        ],
+        "responses": {
+          "200": {
+            "description": "Questions retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "required": ["success", "data", "meta"],
+                  "properties": {
+                    "success": {"type": "boolean", "enum": [true]},
+                    "data": {
+                      "type": "array",
+                      "items": {"$ref": "#/components/schemas/QuizQuestion"}
+                    },
+                    "meta": {"$ref": "#/components/schemas/PaginationMeta"}
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid parameters",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "401": {
+            "description": "Missing or invalid API key",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Pass your API key as a Bearer token: Authorization: Bearer qza_live_..."
+      }
+    },
+    "schemas": {
+      "Difficulty": {
+        "type": "string",
+        "enum": ["EASY", "MEDIUM", "HARD", "EXPERT"],
+        "description": "Difficulty level of a quiz or question"
+      },
+      "QuestionType": {
+        "type": "string",
+        "enum": ["MULTIPLE_CHOICE", "TRUE_FALSE", "OPEN_ENDED"],
+        "description": "The type of question"
+      },
+      "Answer": {
+        "type": "object",
+        "required": ["id", "text", "isCorrect"],
+        "properties": {
+          "id": {"type": "string", "example": "ans_abc123"},
+          "text": {"type": "string", "example": "42"},
+          "isCorrect": {"type": "boolean", "example": true}
+        }
+      },
+      "QuizListItem": {
+        "type": "object",
+        "required": ["id", "title", "description", "category", "difficulty", "tags", "questionCount", "plays"],
+        "properties": {
+          "id": {"type": "string", "example": "cm3abc123def456"},
+          "title": {"type": "string", "example": "JavaScript Fundamentals"},
+          "description": {"type": "string", "example": "Test your JS knowledge"},
+          "category": {"type": "string", "example": "Programming"},
+          "difficulty": {"$ref": "#/components/schemas/Difficulty"},
+          "tags": {"type": "array", "items": {"type": "string"}, "example": ["javascript", "web"]},
+          "questionCount": {"type": "integer", "example": 10},
+          "plays": {"type": "integer", "example": 1250}
+        }
+      },
+      "QuizQuestion": {
+        "type": "object",
+        "required": ["id", "quizId", "text", "type", "difficulty"],
+        "properties": {
+          "id": {"type": "string", "example": "cm3xyz789ghi012"},
+          "quizId": {"type": "string", "example": "cm3abc123def456"},
+          "text": {"type": "string", "example": "What is the typeof null in JavaScript?"},
+          "type": {"$ref": "#/components/schemas/QuestionType"},
+          "difficulty": {"$ref": "#/components/schemas/Difficulty"},
+          "explanation": {"type": "string", "nullable": true, "example": "typeof null returns 'object' due to a legacy bug in JavaScript."},
+          "category": {"type": "string", "nullable": true, "example": "Programming"},
+          "tags": {"type": "array", "items": {"type": "string"}, "example": ["javascript", "fundamentals"]},
+          "quizTitle": {"type": "string", "example": "JavaScript Essentials"},
+          "answers": {"type": "array", "items": {"$ref": "#/components/schemas/Answer"}}
+        }
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "required": ["total", "pageTotal", "page", "lastPage", "limit", "offset"],
+        "properties": {
+          "total": {"type": "integer", "description": "Total matching results across all pages", "example": 23},
+          "pageTotal": {"type": "integer", "description": "Number of results in this page", "example": 10},
+          "page": {"type": "integer", "description": "Current page number (1-based)", "example": 1},
+          "lastPage": {"type": "integer", "description": "Total number of pages", "example": 3},
+          "limit": {"type": "integer", "description": "Results per page", "example": 10},
+          "offset": {"type": "integer", "description": "Number of results skipped", "example": 0},
+          "links": {"$ref": "#/components/schemas/PaginationLinks"}
+        }
+      },
+      "PaginationLinks": {
+        "type": "object",
+        "properties": {
+          "first": {"type": "string", "example": "/api/v1/questions?offset=0&limit=10"},
+          "last": {"type": "string", "example": "/api/v1/questions?offset=20&limit=10"},
+          "next": {"type": "string", "nullable": true, "example": "/api/v1/questions?offset=10&limit=10"},
+          "prev": {"type": "string", "nullable": true}
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": ["success", "error"],
+        "properties": {
+          "success": {"type": "boolean", "enum": [false]},
+          "error": {"type": "string", "example": "Something went wrong."}
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/quizapi.io/quizapi-io/meta.json
+++ b/apis/openapi/quizapi.io/quizapi-io/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "6991a7c5f60e52c4595dd2b65f636836",
+    "format": "openapi",
+    "vendor": "quizapi.io",
+    "api_name": "quizapi-io",
+    "friendly_id": "quizapi.io/quizapi-io"
+  }
+}

--- a/apis/openapi/roadgoat.com/roadgoat-cities/1.0.0/openapi.json
+++ b/apis/openapi/roadgoat.com/roadgoat-cities/1.0.0/openapi.json
@@ -1,0 +1,504 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "RoadGoat Cities API",
+    "description": "The RoadGoat Cities API provides access to city and destination content including descriptions, photos, known-for tags, budget information, safety scores, and related destinations. It follows the JSON:API specification and provides rich data about cities worldwide for travel applications.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "RoadGoat",
+      "url": "https://www.roadgoat.com"
+    },
+    "x-jentic-source-url": "https://www.roadgoat.com/business/cities-api"
+  },
+  "servers": [
+    {
+      "url": "https://api.roadgoat.com/api/v2",
+      "description": "RoadGoat API v2 production server"
+    }
+  ],
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Destinations",
+      "description": "Search and retrieve city/destination information"
+    }
+  ],
+  "paths": {
+    "/destinations": {
+      "get": {
+        "operationId": "searchDestinations",
+        "summary": "Search Destinations",
+        "description": "Search for destinations (cities) by keyword. Returns a list of matching destinations with basic information.",
+        "tags": ["Destinations"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Search query string (city name, country, etc.).",
+            "schema": {
+              "type": "string"
+            },
+            "example": "Paris"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response in JSON:API format.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API credentials.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No destinations found.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/destinations/{id}": {
+      "get": {
+        "operationId": "getDestination",
+        "summary": "Get Destination by ID",
+        "description": "Retrieve detailed information about a specific destination by its unique ID. Includes descriptions, photos, known-for tags, budget info, safety scores, and related destinations.",
+        "tags": ["Destinations"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Unique destination identifier.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful destination detail response.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Destination not found.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/destinations/auto_complete": {
+      "get": {
+        "operationId": "autoCompleteDestinations",
+        "summary": "Auto-Complete Destinations",
+        "description": "Get auto-complete suggestions for destination names. Useful for type-ahead search interfaces.",
+        "tags": ["Destinations"],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "required": true,
+            "description": "Partial search query string for auto-completion.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "Par"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Auto-complete suggestions.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DestinationsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/vnd.api+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "HTTP Basic Authentication using your RoadGoat API key as the username and secret as the password."
+      }
+    },
+    "schemas": {
+      "DestinationsResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Destination"
+            }
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncludedResource"
+            }
+          }
+        }
+      },
+      "DestinationDetailResponse": {
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/Destination"
+          },
+          "included": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IncludedResource"
+            }
+          }
+        }
+      },
+      "Destination": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique destination identifier."
+          },
+          "type": {
+            "type": "string",
+            "description": "Resource type (always 'destinations').",
+            "enum": ["destinations"]
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "Destination name."
+              },
+              "slug": {
+                "type": "string",
+                "description": "URL-friendly slug."
+              },
+              "short_description": {
+                "type": "string",
+                "description": "Short description of the destination."
+              },
+              "description": {
+                "type": "string",
+                "description": "Full description of the destination."
+              },
+              "long_description": {
+                "type": "string",
+                "description": "Extended description."
+              },
+              "latitude": {
+                "type": "number",
+                "format": "double"
+              },
+              "longitude": {
+                "type": "number",
+                "format": "double"
+              },
+              "population": {
+                "type": "integer",
+                "description": "City population."
+              },
+              "budget": {
+                "type": "object",
+                "description": "Budget information.",
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  },
+                  "text": {
+                    "type": "string"
+                  },
+                  "currency": {
+                    "type": "string"
+                  }
+                }
+              },
+              "safety": {
+                "type": "object",
+                "description": "Safety score.",
+                "properties": {
+                  "value": {
+                    "type": "number"
+                  },
+                  "text": {
+                    "type": "string"
+                  }
+                }
+              },
+              "known_for": {
+                "type": "array",
+                "description": "Tags describing what the city is known for.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "score": {
+                      "type": "number"
+                    }
+                  }
+                }
+              },
+              "walk_score": {
+                "type": "integer",
+                "description": "Walk score for the destination."
+              },
+              "bike_score": {
+                "type": "integer",
+                "description": "Bike score for the destination."
+              },
+              "average_rating": {
+                "type": "number",
+                "format": "float",
+                "description": "Average user rating."
+              },
+              "reviews_count": {
+                "type": "integer",
+                "description": "Number of user reviews."
+              },
+              "wikipedia_url": {
+                "type": "string",
+                "description": "URL to the Wikipedia page."
+              },
+              "website": {
+                "type": "string",
+                "description": "Official destination website URL."
+              }
+            }
+          },
+          "relationships": {
+            "type": "object",
+            "properties": {
+              "photos": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              "nearby_destinations": {
+                "type": "object",
+                "properties": {
+                  "data": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "IncludedResource": {
+        "type": "object",
+        "description": "Sideloaded resource (photo, destination, etc.) per JSON:API spec.",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "description": "Resource type (e.g., 'photos', 'destinations')."
+          },
+          "attributes": {
+            "type": "object",
+            "properties": {
+              "image": {
+                "type": "object",
+                "description": "Image URLs at various sizes.",
+                "properties": {
+                  "full": {
+                    "type": "string"
+                  },
+                  "large": {
+                    "type": "string"
+                  },
+                  "medium": {
+                    "type": "string"
+                  },
+                  "small": {
+                    "type": "string"
+                  },
+                  "thumb": {
+                    "type": "string"
+                  }
+                }
+              },
+              "attribution": {
+                "type": "object",
+                "properties": {
+                  "source": {
+                    "type": "string"
+                  },
+                  "source_url": {
+                    "type": "string"
+                  },
+                  "photographer": {
+                    "type": "string"
+                  },
+                  "license": {
+                    "type": "string"
+                  },
+                  "license_url": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "status": {
+                  "type": "string",
+                  "description": "HTTP status code."
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Error title."
+                },
+                "detail": {
+                  "type": "string",
+                  "description": "Detailed error message."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/roadgoat.com/roadgoat-cities/meta.json
+++ b/apis/openapi/roadgoat.com/roadgoat-cities/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "b79b79311430bff1aa82f04bf28ef482",
+    "format": "openapi",
+    "vendor": "roadgoat.com",
+    "api_name": "roadgoat-cities",
+    "friendly_id": "roadgoat.com/roadgoat-cities"
+  }
+}

--- a/apis/openapi/smarty.com/us-zipcode/4.0.0/openapi.json
+++ b/apis/openapi/smarty.com/us-zipcode/4.0.0/openapi.json
@@ -1,0 +1,403 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Smarty US ZipCode API",
+    "description": "The Smarty US ZipCode API provides detailed information about US ZIP codes including city, state, latitude, longitude, and more. It validates ZIP codes and returns associated metadata including alternate city names, county information, and timezone data.",
+    "version": "4.0.0",
+    "contact": {
+      "name": "Smarty",
+      "url": "https://www.smarty.com"
+    },
+    "x-jentic-source-url": "https://www.smarty.com/docs/cloud/us-zipcode-api"
+  },
+  "servers": [
+    {
+      "url": "https://us-zipcode.api.smarty.com",
+      "description": "Smarty US ZipCode API production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "ZipCode Lookup",
+      "description": "ZIP code lookup and validation operations"
+    }
+  ],
+  "security": [
+    {
+      "authId": [],
+      "authToken": []
+    }
+  ],
+  "paths": {
+    "/lookup": {
+      "get": {
+        "tags": ["ZipCode Lookup"],
+        "summary": "Single ZIP code lookup",
+        "description": "Look up a single ZIP code or city/state combination to retrieve detailed information.",
+        "operationId": "zipcodeLookupGet",
+        "parameters": [
+          {
+            "name": "auth-id",
+            "in": "query",
+            "description": "Authentication ID (can also use Referer header for website keys)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "auth-token",
+            "in": "query",
+            "description": "Authentication token (raw or URL-encoded)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "zipcode",
+            "in": "query",
+            "description": "The 5-digit ZIP code to look up",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{5}$"
+            }
+          },
+          {
+            "name": "city",
+            "in": "query",
+            "description": "City name for city/state lookup",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "description": "State name or abbreviation for city/state lookup",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "input_id",
+            "in": "query",
+            "description": "A unique identifier for this request, passed through to the response",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful ZIP code lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZipCodeResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      },
+      "post": {
+        "tags": ["ZipCode Lookup"],
+        "summary": "Batch ZIP code lookup",
+        "description": "Look up multiple ZIP codes or city/state combinations in a single request. Maximum 100 lookups per request.",
+        "operationId": "zipcodeLookupPost",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "maxItems": 100,
+                "items": {
+                  "$ref": "#/components/schemas/ZipCodeLookupInput"
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful batch lookup",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ZipCodeResult"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "402": {
+            "$ref": "#/components/responses/PaymentRequired"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "authId": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "auth-id",
+        "description": "Smarty authentication ID"
+      },
+      "authToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "auth-token",
+        "description": "Smarty authentication token (secret key)"
+      }
+    },
+    "schemas": {
+      "ZipCodeLookupInput": {
+        "type": "object",
+        "properties": {
+          "zipcode": {
+            "type": "string",
+            "description": "5-digit ZIP code"
+          },
+          "city": {
+            "type": "string",
+            "description": "City name"
+          },
+          "state": {
+            "type": "string",
+            "description": "State name or 2-letter abbreviation"
+          },
+          "input_id": {
+            "type": "string",
+            "description": "Unique identifier passed through to the response"
+          }
+        }
+      },
+      "ZipCodeResult": {
+        "type": "object",
+        "properties": {
+          "input_index": {
+            "type": "integer",
+            "description": "Index of the input record"
+          },
+          "input_id": {
+            "type": "string",
+            "description": "Echoed input_id from request"
+          },
+          "city_states": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CityState"
+            }
+          },
+          "zipcodes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ZipCode"
+            }
+          },
+          "status": {
+            "type": "string",
+            "description": "Status of the lookup (blank for valid, or reason for invalid input)",
+            "enum": ["blank", "invalid_zipcode", "invalid_state", "invalid_city", "conflict"]
+          },
+          "reason": {
+            "type": "string",
+            "description": "Reason for invalid status"
+          }
+        }
+      },
+      "CityState": {
+        "type": "object",
+        "properties": {
+          "city": {
+            "type": "string",
+            "description": "City name"
+          },
+          "state_abbreviation": {
+            "type": "string",
+            "description": "2-letter state abbreviation"
+          },
+          "state": {
+            "type": "string",
+            "description": "Full state name"
+          },
+          "mailable_city": {
+            "type": "boolean",
+            "description": "Whether this city name is acceptable for mailing"
+          }
+        }
+      },
+      "ZipCode": {
+        "type": "object",
+        "properties": {
+          "zipcode": {
+            "type": "string",
+            "description": "5-digit ZIP code"
+          },
+          "zipcode_type": {
+            "type": "string",
+            "description": "Type of ZIP code",
+            "enum": ["S", "M", "P", "U"]
+          },
+          "default_city": {
+            "type": "string",
+            "description": "Default city name for this ZIP code"
+          },
+          "county_fips": {
+            "type": "string",
+            "description": "County FIPS code"
+          },
+          "county_name": {
+            "type": "string",
+            "description": "County name"
+          },
+          "state_abbreviation": {
+            "type": "string",
+            "description": "2-letter state abbreviation"
+          },
+          "state": {
+            "type": "string",
+            "description": "Full state name"
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude of the ZIP code centroid"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude of the ZIP code centroid"
+          },
+          "precision": {
+            "type": "string",
+            "description": "Precision of the coordinates",
+            "enum": ["None", "Zip5", "Zip7", "Zip9"]
+          },
+          "alternate_counties": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "county_fips": {
+                  "type": "string"
+                },
+                "county_name": {
+                  "type": "string"
+                },
+                "state_abbreviation": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "message": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "responses": {
+      "BadRequest": {
+        "description": "Bad request - malformed input",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "Unauthorized": {
+        "description": "Unauthorized - invalid or missing credentials",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "PaymentRequired": {
+        "description": "Payment required - subscription inactive or over limit",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UnprocessableEntity": {
+        "description": "Unprocessable entity - input could not be processed",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "TooManyRequests": {
+        "description": "Too many requests - rate limit exceeded",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/smarty.com/us-zipcode/meta.json
+++ b/apis/openapi/smarty.com/us-zipcode/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "dc095c421c1b216f412d05926ad9c8f7",
+    "format": "openapi",
+    "vendor": "smarty.com",
+    "api_name": "us-zipcode",
+    "friendly_id": "smarty.com/us-zipcode"
+  }
+}

--- a/apis/openapi/spotsense.io/spotsense/1.0.0/openapi.json
+++ b/apis/openapi/spotsense.io/spotsense/1.0.0/openapi.json
@@ -1,0 +1,1435 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "SpotSense API",
+    "description": "SpotSense provides a location-based engagement platform that enables developers to create geofences, beacons, and location-based rules to trigger actions when users enter or exit specific areas. The API supports managing geofences, beacon regions, rules, and retrieving location-based analytics.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "SpotSense",
+      "url": "https://spotsense.io"
+    },
+    "x-jentic-source-url": "https://spotsense.io/"
+  },
+  "servers": [
+    {
+      "url": "https://api.spotsense.io/v1",
+      "description": "SpotSense API v1 production server"
+    }
+  ],
+  "security": [
+    {
+      "apiKeyHeader": []
+    },
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geofences",
+      "description": "Create and manage geofences (geographic boundaries)"
+    },
+    {
+      "name": "Rules",
+      "description": "Create and manage location-triggered rules"
+    },
+    {
+      "name": "Beacons",
+      "description": "Manage Bluetooth beacon regions"
+    },
+    {
+      "name": "Apps",
+      "description": "Application management"
+    },
+    {
+      "name": "Analytics",
+      "description": "Location analytics and event data"
+    }
+  ],
+  "paths": {
+    "/apps/{appId}/geofences": {
+      "get": {
+        "operationId": "listGeofences",
+        "summary": "List Geofences",
+        "description": "Retrieve a list of all geofences for an application.",
+        "tags": ["Geofences"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "description": "Application ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "description": "Page number for pagination.",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of results per page.",
+            "schema": {
+              "type": "integer",
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of geofences.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Geofence"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createGeofence",
+        "summary": "Create Geofence",
+        "description": "Create a new geofence for an application. Supports circular and polygon geofences.",
+        "tags": ["Geofences"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "description": "Application ID.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeofenceCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Geofence created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Geofence"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid geofence data.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}/geofences/{geofenceId}": {
+      "get": {
+        "operationId": "getGeofence",
+        "summary": "Get Geofence",
+        "description": "Retrieve details of a specific geofence.",
+        "tags": ["Geofences"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "geofenceId",
+            "in": "path",
+            "required": true,
+            "description": "Geofence ID.",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Geofence details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Geofence"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Geofence not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateGeofence",
+        "summary": "Update Geofence",
+        "description": "Update an existing geofence.",
+        "tags": ["Geofences"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "geofenceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GeofenceCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Geofence updated successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Geofence"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Geofence not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteGeofence",
+        "summary": "Delete Geofence",
+        "description": "Delete a geofence.",
+        "tags": ["Geofences"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "geofenceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Geofence deleted successfully."
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Geofence not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}/rules": {
+      "get": {
+        "operationId": "listRules",
+        "summary": "List Rules",
+        "description": "Retrieve all location-triggered rules for an application.",
+        "tags": ["Rules"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of rules.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Rule"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createRule",
+        "summary": "Create Rule",
+        "description": "Create a new location-triggered rule that fires when users enter or exit a geofence or beacon region.",
+        "tags": ["Rules"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuleCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Rule created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}/rules/{ruleId}": {
+      "get": {
+        "operationId": "getRule",
+        "summary": "Get Rule",
+        "description": "Retrieve details of a specific rule.",
+        "tags": ["Rules"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Rule details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rule not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updateRule",
+        "summary": "Update Rule",
+        "description": "Update an existing rule.",
+        "tags": ["Rules"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuleCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Rule updated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Rule"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rule not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteRule",
+        "summary": "Delete Rule",
+        "description": "Delete a rule.",
+        "tags": ["Rules"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "ruleId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Rule deleted successfully."
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Rule not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}/beacons": {
+      "get": {
+        "operationId": "listBeacons",
+        "summary": "List Beacons",
+        "description": "Retrieve a list of all beacon regions for an application.",
+        "tags": ["Beacons"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of beacon regions.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Beacon"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createBeacon",
+        "summary": "Create Beacon",
+        "description": "Register a new beacon region.",
+        "tags": ["Beacons"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BeaconCreate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Beacon created successfully.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Beacon"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}/analytics/events": {
+      "get": {
+        "operationId": "getAnalyticsEvents",
+        "summary": "Get Analytics Events",
+        "description": "Retrieve location-based analytics events such as geofence entries, exits, and dwell times.",
+        "tags": ["Analytics"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "startDate",
+            "in": "query",
+            "required": false,
+            "description": "Start date filter (ISO 8601 format).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "endDate",
+            "in": "query",
+            "required": false,
+            "description": "End date filter (ISO 8601 format).",
+            "schema": {
+              "type": "string",
+              "format": "date-time"
+            }
+          },
+          {
+            "name": "geofenceId",
+            "in": "query",
+            "required": false,
+            "description": "Filter events by geofence ID.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "eventType",
+            "in": "query",
+            "required": false,
+            "description": "Filter by event type.",
+            "schema": {
+              "type": "string",
+              "enum": ["enter", "exit", "dwell"]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 25
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of analytics events.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AnalyticsEvent"
+                      }
+                    },
+                    "meta": {
+                      "$ref": "#/components/schemas/PaginationMeta"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps": {
+      "get": {
+        "operationId": "listApps",
+        "summary": "List Apps",
+        "description": "Retrieve a list of all applications associated with your account.",
+        "tags": ["Apps"],
+        "responses": {
+          "200": {
+            "description": "List of applications.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/App"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/apps/{appId}": {
+      "get": {
+        "operationId": "getApp",
+        "summary": "Get App",
+        "description": "Retrieve details of a specific application.",
+        "tags": ["Apps"],
+        "parameters": [
+          {
+            "name": "appId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Application details.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/App"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "App not found.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKeyHeader": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "SpotSense API key obtained from your dashboard."
+      },
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "Bearer token for authenticated requests."
+      }
+    },
+    "schemas": {
+      "Geofence": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "description": "Unique geofence identifier."
+          },
+          "name": {
+            "type": "string",
+            "description": "Geofence name."
+          },
+          "description": {
+            "type": "string",
+            "description": "Geofence description."
+          },
+          "type": {
+            "type": "string",
+            "description": "Geofence type.",
+            "enum": ["circle", "polygon"]
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Center latitude (for circular geofences)."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Center longitude (for circular geofences)."
+          },
+          "radius": {
+            "type": "number",
+            "description": "Radius in meters (for circular geofences)."
+          },
+          "coordinates": {
+            "type": "array",
+            "description": "Polygon coordinates (for polygon geofences).",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Custom key-value metadata.",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the geofence is active."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "GeofenceCreate": {
+        "type": "object",
+        "required": ["name", "type"],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Geofence name."
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": ["circle", "polygon"]
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Center latitude (required for circle type)."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Center longitude (required for circle type)."
+          },
+          "radius": {
+            "type": "number",
+            "description": "Radius in meters (required for circle type)."
+          },
+          "coordinates": {
+            "type": "array",
+            "description": "Polygon coordinates (required for polygon type).",
+            "items": {
+              "type": "array",
+              "items": {
+                "type": "number"
+              }
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "Rule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "trigger": {
+            "type": "string",
+            "description": "Trigger event type.",
+            "enum": ["enter", "exit", "dwell"]
+          },
+          "geofence_id": {
+            "type": "string",
+            "description": "Associated geofence ID."
+          },
+          "beacon_id": {
+            "type": "string",
+            "description": "Associated beacon ID."
+          },
+          "action": {
+            "type": "object",
+            "description": "Action to perform when triggered.",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["webhook", "notification", "custom"]
+              },
+              "url": {
+                "type": "string",
+                "description": "Webhook URL (for webhook actions)."
+              },
+              "payload": {
+                "type": "object",
+                "description": "Custom payload data.",
+                "additionalProperties": true
+              }
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "RuleCreate": {
+        "type": "object",
+        "required": ["name", "trigger"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "trigger": {
+            "type": "string",
+            "enum": ["enter", "exit", "dwell"]
+          },
+          "geofence_id": {
+            "type": "string"
+          },
+          "beacon_id": {
+            "type": "string"
+          },
+          "action": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string",
+                "enum": ["webhook", "notification", "custom"]
+              },
+              "url": {
+                "type": "string"
+              },
+              "payload": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            }
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "Beacon": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Beacon UUID."
+          },
+          "major": {
+            "type": "integer",
+            "description": "Beacon major value."
+          },
+          "minor": {
+            "type": "integer",
+            "description": "Beacon minor value."
+          },
+          "description": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "BeaconCreate": {
+        "type": "object",
+        "required": ["name", "uuid"],
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "uuid": {
+            "type": "string"
+          },
+          "major": {
+            "type": "integer"
+          },
+          "minor": {
+            "type": "integer"
+          },
+          "description": {
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "AnalyticsEvent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "event_type": {
+            "type": "string",
+            "enum": ["enter", "exit", "dwell"]
+          },
+          "geofence_id": {
+            "type": "string"
+          },
+          "geofence_name": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double"
+          },
+          "dwell_time": {
+            "type": "integer",
+            "description": "Dwell time in seconds (for dwell events)."
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "App": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "api_key": {
+            "type": "string",
+            "description": "Application API key."
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "PaginationMeta": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "total_pages": {
+            "type": "integer"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string",
+                "description": "Error code."
+              },
+              "message": {
+                "type": "string",
+                "description": "Error message."
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/spotsense.io/spotsense/meta.json
+++ b/apis/openapi/spotsense.io/spotsense/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "572c643cf8f65d07bf9765b41501db1a",
+    "format": "openapi",
+    "vendor": "spotsense.io",
+    "api_name": "spotsense",
+    "friendly_id": "spotsense.io/spotsense"
+  }
+}

--- a/apis/openapi/superheroapi.com/superheroes/1.0.0/openapi.json
+++ b/apis/openapi/superheroapi.com/superheroes/1.0.0/openapi.json
@@ -1,0 +1,686 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "SuperHero API",
+    "description": "The SuperHero API provides quantified data on superheroes and villains from various comic book universes. Access detailed information including power stats, biography, appearance, work, connections, and images for over 700 characters.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "SuperHero API",
+      "url": "https://superheroapi.com"
+    },
+    "x-jentic-source-url": "https://superheroapi.com"
+  },
+  "servers": [
+    {
+      "url": "https://superheroapi.com/api/{access-token}",
+      "description": "SuperHero API Server",
+      "variables": {
+        "access-token": {
+          "default": "YOUR_ACCESS_TOKEN",
+          "description": "Access token obtained by signing in with a GitHub account"
+        }
+      }
+    }
+  ],
+  "security": [
+    {
+      "accessToken": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Characters",
+      "description": "Retrieve superhero and villain character data"
+    },
+    {
+      "name": "Search",
+      "description": "Search for characters by name"
+    }
+  ],
+  "paths": {
+    "/{id}": {
+      "get": {
+        "operationId": "getCharacterById",
+        "summary": "Get complete character data",
+        "description": "Retrieves all available data for a character by their unique ID, including power stats, biography, appearance, work, connections, and image.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with complete character data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Character"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/powerstats": {
+      "get": {
+        "operationId": "getCharacterPowerstats",
+        "summary": "Get character power stats",
+        "description": "Retrieves the power statistics for a character including intelligence, strength, speed, durability, power, and combat ratings.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with power stats",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PowerstatsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/biography": {
+      "get": {
+        "operationId": "getCharacterBiography",
+        "summary": "Get character biography",
+        "description": "Retrieves biographical information for a character including full name, alter egos, aliases, place of birth, first appearance, publisher, and alignment.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with biography",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BiographyResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/appearance": {
+      "get": {
+        "operationId": "getCharacterAppearance",
+        "summary": "Get character appearance",
+        "description": "Retrieves physical appearance details for a character including gender, race, height, weight, eye color, and hair color.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with appearance data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppearanceResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/work": {
+      "get": {
+        "operationId": "getCharacterWork",
+        "summary": "Get character work information",
+        "description": "Retrieves occupation and base of operations for a character.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with work data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/connections": {
+      "get": {
+        "operationId": "getCharacterConnections",
+        "summary": "Get character connections",
+        "description": "Retrieves group affiliations and relatives for a character.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with connections data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConnectionsResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/{id}/image": {
+      "get": {
+        "operationId": "getCharacterImage",
+        "summary": "Get character image",
+        "description": "Retrieves the image URL for a character.",
+        "tags": ["Characters"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "The unique identifier of the character",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with image URL",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImageResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Character not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/search/{name}": {
+      "get": {
+        "operationId": "searchCharacters",
+        "summary": "Search characters by name",
+        "description": "Searches for characters matching the given name. Returns an array of matching characters with their full profiles.",
+        "tags": ["Search"],
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "required": true,
+            "description": "The name or partial name to search for",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with matching characters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "No characters found matching the search",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "accessToken": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "access-token",
+        "description": "Access token obtained by authenticating with a GitHub account at superheroapi.com"
+      }
+    },
+    "schemas": {
+      "Powerstats": {
+        "type": "object",
+        "properties": {
+          "intelligence": {
+            "type": "string",
+            "description": "Intelligence rating"
+          },
+          "strength": {
+            "type": "string",
+            "description": "Strength rating"
+          },
+          "speed": {
+            "type": "string",
+            "description": "Speed rating"
+          },
+          "durability": {
+            "type": "string",
+            "description": "Durability rating"
+          },
+          "power": {
+            "type": "string",
+            "description": "Power rating"
+          },
+          "combat": {
+            "type": "string",
+            "description": "Combat rating"
+          }
+        }
+      },
+      "Biography": {
+        "type": "object",
+        "properties": {
+          "full-name": {
+            "type": "string",
+            "description": "Full name of the character"
+          },
+          "alter-egos": {
+            "type": "string",
+            "description": "Alter egos of the character"
+          },
+          "aliases": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Known aliases"
+          },
+          "place-of-birth": {
+            "type": "string",
+            "description": "Place of birth"
+          },
+          "first-appearance": {
+            "type": "string",
+            "description": "First comic book appearance"
+          },
+          "publisher": {
+            "type": "string",
+            "description": "Comic book publisher"
+          },
+          "alignment": {
+            "type": "string",
+            "description": "Character alignment (good, bad, neutral)"
+          }
+        }
+      },
+      "Appearance": {
+        "type": "object",
+        "properties": {
+          "gender": {
+            "type": "string",
+            "description": "Gender of the character"
+          },
+          "race": {
+            "type": "string",
+            "description": "Race/species of the character"
+          },
+          "height": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Height in different units"
+          },
+          "weight": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "Weight in different units"
+          },
+          "eye-color": {
+            "type": "string",
+            "description": "Eye color"
+          },
+          "hair-color": {
+            "type": "string",
+            "description": "Hair color"
+          }
+        }
+      },
+      "Work": {
+        "type": "object",
+        "properties": {
+          "occupation": {
+            "type": "string",
+            "description": "Character occupation"
+          },
+          "base": {
+            "type": "string",
+            "description": "Base of operations"
+          }
+        }
+      },
+      "Connections": {
+        "type": "object",
+        "properties": {
+          "group-affiliation": {
+            "type": "string",
+            "description": "Groups the character belongs to"
+          },
+          "relatives": {
+            "type": "string",
+            "description": "Known relatives"
+          }
+        }
+      },
+      "Image": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the character image"
+          }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string",
+            "description": "Response status (success or error)"
+          },
+          "id": {
+            "type": "string",
+            "description": "Character unique identifier"
+          },
+          "name": {
+            "type": "string",
+            "description": "Character name"
+          },
+          "powerstats": {
+            "$ref": "#/components/schemas/Powerstats"
+          },
+          "biography": {
+            "$ref": "#/components/schemas/Biography"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/Appearance"
+          },
+          "work": {
+            "$ref": "#/components/schemas/Work"
+          },
+          "connections": {
+            "$ref": "#/components/schemas/Connections"
+          },
+          "image": {
+            "$ref": "#/components/schemas/Image"
+          }
+        }
+      },
+      "PowerstatsResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "powerstats": {
+            "$ref": "#/components/schemas/Powerstats"
+          }
+        }
+      },
+      "BiographyResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "biography": {
+            "$ref": "#/components/schemas/Biography"
+          }
+        }
+      },
+      "AppearanceResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "appearance": {
+            "$ref": "#/components/schemas/Appearance"
+          }
+        }
+      },
+      "WorkResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "work": {
+            "$ref": "#/components/schemas/Work"
+          }
+        }
+      },
+      "ConnectionsResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "connections": {
+            "$ref": "#/components/schemas/Connections"
+          }
+        }
+      },
+      "ImageResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "image": {
+            "$ref": "#/components/schemas/Image"
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string"
+          },
+          "results-for": {
+            "type": "string",
+            "description": "The search term used"
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Character"
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "string",
+            "example": "error"
+          },
+          "error": {
+            "type": "string",
+            "description": "Error message describing what went wrong"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/superheroapi.com/superheroes/meta.json
+++ b/apis/openapi/superheroapi.com/superheroes/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "281b0c5333d49d78262380e6db8d4f90",
+    "format": "openapi",
+    "vendor": "superheroapi.com",
+    "api_name": "superheroes",
+    "friendly_id": "superheroapi.com/superheroes"
+  }
+}

--- a/apis/openapi/tebex.io/tebex/1.0.0/openapi.json
+++ b/apis/openapi/tebex.io/tebex/1.0.0/openapi.json
@@ -1,0 +1,1810 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Tebex Plugin API",
+    "description": "The Tebex Plugin API enables game server plugins to interact with a Tebex webstore. It provides endpoints for managing command queues, payments, packages, checkout, gift cards, coupons, bans, sales, community goals, and player data. This API is used to implement command execution on game servers for purchased items.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Tebex Support",
+      "email": "support@tebex.io",
+      "url": "https://docs.tebex.io"
+    },
+    "x-jentic-source-url": "https://docs.tebex.io/plugin/"
+  },
+  "servers": [
+    {
+      "url": "https://plugin.tebex.io",
+      "description": "Tebex Plugin API Server"
+    }
+  ],
+  "security": [
+    {
+      "TebexSecret": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Information",
+      "description": "General account and server information"
+    },
+    {
+      "name": "Command Queue",
+      "description": "Manage command queues for due players"
+    },
+    {
+      "name": "Packages",
+      "description": "Manage webstore packages"
+    },
+    {
+      "name": "Payments",
+      "description": "Manage and retrieve payment information"
+    },
+    {
+      "name": "Checkout",
+      "description": "Create checkout URLs for purchases"
+    },
+    {
+      "name": "Gift Cards",
+      "description": "Manage gift cards"
+    },
+    {
+      "name": "Coupons",
+      "description": "Manage discount coupons"
+    },
+    {
+      "name": "Bans",
+      "description": "Manage player bans"
+    },
+    {
+      "name": "Sales",
+      "description": "Retrieve active sales"
+    },
+    {
+      "name": "Community Goals",
+      "description": "Manage community goals"
+    },
+    {
+      "name": "Player Lookup",
+      "description": "Look up player information and purchases"
+    }
+  ],
+  "paths": {
+    "/information": {
+      "get": {
+        "operationId": "getInformation",
+        "summary": "Get server information",
+        "description": "Returns general information about the authenticated account and server.",
+        "tags": ["Information"],
+        "responses": {
+          "200": {
+            "description": "Successful response with account and server information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "account": {
+                      "$ref": "#/components/schemas/Account"
+                    },
+                    "server": {
+                      "$ref": "#/components/schemas/Server"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Invalid or missing secret key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/queue": {
+      "get": {
+        "operationId": "getDuePlayers",
+        "summary": "Get due players",
+        "description": "Retrieves a list of players who have commands due to be executed.",
+        "tags": ["Command Queue"],
+        "responses": {
+          "200": {
+            "description": "List of due players",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "execute_offline": {
+                          "type": "boolean"
+                        },
+                        "next_check": {
+                          "type": "integer",
+                          "description": "Seconds until next check"
+                        },
+                        "more": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "players": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/QueuePlayer"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteCommands",
+        "summary": "Delete commands",
+        "description": "Deletes commands that have been executed from the command queue.",
+        "tags": ["Command Queue"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["ids"],
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "description": "Array of command IDs to delete"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Commands deleted successfully"
+          }
+        }
+      }
+    },
+    "/queue/offline-commands": {
+      "get": {
+        "operationId": "getOfflineCommands",
+        "summary": "Get offline commands",
+        "description": "Retrieves commands that can be executed for offline players.",
+        "tags": ["Command Queue"],
+        "responses": {
+          "200": {
+            "description": "List of offline commands",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "type": "object",
+                      "properties": {
+                        "limited": {
+                          "type": "boolean"
+                        }
+                      }
+                    },
+                    "commands": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Command"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/queue/online-commands/{playerId}": {
+      "get": {
+        "operationId": "getOnlineCommands",
+        "summary": "Get online commands for a player",
+        "description": "Retrieves commands that should be executed for a specific online player.",
+        "tags": ["Command Queue"],
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "description": "The internal plugin player ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of online commands for the player",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "commands": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/OnlineCommand"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/listing": {
+      "get": {
+        "operationId": "getListing",
+        "summary": "Get listing (deprecated)",
+        "description": "Retrieves the store listing. This endpoint is deprecated; use the Headless API for displaying categories or products in game.",
+        "tags": ["Packages"],
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Store listing data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/packages": {
+      "get": {
+        "operationId": "getPackages",
+        "summary": "Get all packages (deprecated)",
+        "description": "Retrieves all packages on the webstore. This endpoint is deprecated; use the Headless API for displaying categories or products in game.",
+        "tags": ["Packages"],
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "List of packages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Package"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/package/{packageId}": {
+      "get": {
+        "operationId": "getPackage",
+        "summary": "Get a package (deprecated)",
+        "description": "Retrieves a specific package by ID. This endpoint is deprecated; use the Headless API.",
+        "tags": ["Packages"],
+        "deprecated": true,
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Package details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Package"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updatePackage",
+        "summary": "Update a package",
+        "description": "Updates the settings for a package on your webstore.",
+        "tags": ["Packages"],
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "disabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable the package"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Package title"
+                  },
+                  "price": {
+                    "type": "integer",
+                    "description": "Package price"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Package updated successfully"
+          }
+        }
+      }
+    },
+    "/payments": {
+      "get": {
+        "operationId": "getPayments",
+        "summary": "Get all payments",
+        "description": "Retrieves a list of payments. Supports pagination and limiting.",
+        "tags": ["Payments"],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of payments to return (max 100)",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "paged",
+            "in": "query",
+            "description": "Set to 1 to enable pagination (25 items per page)",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of payments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Payment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createPayment",
+        "summary": "Create a payment",
+        "description": "Creates a manual payment.",
+        "tags": ["Payments"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["ign", "price", "packages"],
+                "properties": {
+                  "ign": {
+                    "type": "string",
+                    "description": "Player in-game name"
+                  },
+                  "price": {
+                    "type": "number",
+                    "description": "Payment price"
+                  },
+                  "note": {
+                    "type": "string",
+                    "description": "Optional note for the payment"
+                  },
+                  "packages": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "id": {
+                          "type": "integer"
+                        },
+                        "options": {
+                          "type": "object"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Payment created successfully"
+          }
+        }
+      }
+    },
+    "/payments/{transaction}": {
+      "get": {
+        "operationId": "getPayment",
+        "summary": "Get a payment",
+        "description": "Retrieves a specific payment by transaction ID.",
+        "tags": ["Payments"],
+        "parameters": [
+          {
+            "name": "transaction",
+            "in": "path",
+            "required": true,
+            "description": "Transaction ID",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Payment"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "updatePayment",
+        "summary": "Update a payment",
+        "description": "Updates a payment status (complete, chargeback, or refund).",
+        "tags": ["Payments"],
+        "parameters": [
+          {
+            "name": "transaction",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "username": {
+                    "type": "string"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": ["complete", "chargeback", "refund"]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Payment updated successfully"
+          }
+        }
+      }
+    },
+    "/payments/{transaction}/note": {
+      "post": {
+        "operationId": "createPaymentNote",
+        "summary": "Create a payment note",
+        "description": "Adds a note to a specific payment.",
+        "tags": ["Payments"],
+        "parameters": [
+          {
+            "name": "transaction",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["note"],
+                "properties": {
+                  "note": {
+                    "type": "string",
+                    "description": "Note content"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Note created successfully"
+          }
+        }
+      }
+    },
+    "/payments/fields/{packageId}": {
+      "get": {
+        "operationId": "getPaymentFields",
+        "summary": "Get payment fields for a package",
+        "description": "Retrieves the required payment fields for a specific package.",
+        "tags": ["Payments"],
+        "parameters": [
+          {
+            "name": "packageId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Payment fields",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PaymentField"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/checkout": {
+      "post": {
+        "operationId": "createCheckout",
+        "summary": "Create checkout URL",
+        "description": "Creates a URL which will redirect the player to the webstore and add the package to their basket.",
+        "tags": ["Checkout"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["package_id", "username"],
+                "properties": {
+                  "package_id": {
+                    "type": "string",
+                    "description": "The package to add to the basket"
+                  },
+                  "username": {
+                    "type": "string",
+                    "description": "The player's account name"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Checkout URL created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "format": "uri",
+                      "description": "Checkout redirect URL"
+                    },
+                    "expires": {
+                      "type": "string",
+                      "description": "Expiration timestamp"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gift-cards": {
+      "get": {
+        "operationId": "getGiftCards",
+        "summary": "Get all gift cards",
+        "description": "Retrieves all gift cards on the account.",
+        "tags": ["Gift Cards"],
+        "responses": {
+          "200": {
+            "description": "List of gift cards",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/GiftCard"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createGiftCard",
+        "summary": "Create a gift card",
+        "description": "Creates a new gift card with an initial balance.",
+        "tags": ["Gift Cards"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["amount"],
+                "properties": {
+                  "amount": {
+                    "type": "number",
+                    "description": "Initial card value"
+                  },
+                  "note": {
+                    "type": "string",
+                    "description": "Optional note"
+                  },
+                  "expires_at": {
+                    "type": "string",
+                    "description": "Expiration date (yyyy-mm-dd hh:mm:ss)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Gift card created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GiftCard"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gift-cards/{id}": {
+      "get": {
+        "operationId": "getGiftCard",
+        "summary": "Get a gift card",
+        "description": "Retrieves a specific gift card by ID.",
+        "tags": ["Gift Cards"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gift card details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GiftCard"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "topUpGiftCard",
+        "summary": "Top up a gift card",
+        "description": "Adds funds to an existing gift card.",
+        "tags": ["Gift Cards"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["amount"],
+                "properties": {
+                  "amount": {
+                    "type": "string",
+                    "description": "Amount of credit to add"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Gift card topped up",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GiftCard"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "voidGiftCard",
+        "summary": "Void a gift card",
+        "description": "Voids/disables a gift card.",
+        "tags": ["Gift Cards"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Gift card voided successfully"
+          }
+        }
+      }
+    },
+    "/gift-cards/lookup/{code}": {
+      "get": {
+        "operationId": "lookupGiftCard",
+        "summary": "Look up a gift card by code",
+        "description": "Retrieves a gift card by its code.",
+        "tags": ["Gift Cards"],
+        "parameters": [
+          {
+            "name": "code",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Gift card details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/GiftCard"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coupons": {
+      "get": {
+        "operationId": "getCoupons",
+        "summary": "Get all coupons",
+        "description": "Retrieves a paginated list of all coupons on the account.",
+        "tags": ["Coupons"],
+        "responses": {
+          "200": {
+            "description": "Paginated list of coupons",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Coupon"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createCoupon",
+        "summary": "Create a coupon",
+        "description": "Creates a new coupon with specified discount settings.",
+        "tags": ["Coupons"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateCouponRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Coupon created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Coupon"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/coupons/{id}": {
+      "get": {
+        "operationId": "getCoupon",
+        "summary": "Get a coupon",
+        "description": "Retrieves a specific coupon by ID.",
+        "tags": ["Coupons"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Coupon details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "$ref": "#/components/schemas/Coupon"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "operationId": "deleteCoupon",
+        "summary": "Delete a coupon",
+        "description": "Deletes a coupon by ID.",
+        "tags": ["Coupons"],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Coupon deleted successfully"
+          }
+        }
+      }
+    },
+    "/bans": {
+      "get": {
+        "operationId": "getBans",
+        "summary": "Get all bans",
+        "description": "Retrieves all bans on the account.",
+        "tags": ["Bans"],
+        "responses": {
+          "200": {
+            "description": "List of bans",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Ban"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createBan",
+        "summary": "Create a ban",
+        "description": "Bans a player from the webstore.",
+        "tags": ["Bans"],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": ["reason", "user"],
+                "properties": {
+                  "reason": {
+                    "type": "string",
+                    "description": "The reason for the ban"
+                  },
+                  "ip": {
+                    "type": "string",
+                    "description": "The IP address to also ban"
+                  },
+                  "user": {
+                    "type": "string",
+                    "description": "The username or UUID of the player to ban"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Ban created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Ban"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/sales": {
+      "get": {
+        "operationId": "getSales",
+        "summary": "Get all active sales",
+        "description": "Retrieves all currently active sales on the account.",
+        "tags": ["Sales"],
+        "responses": {
+          "200": {
+            "description": "List of active sales",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Sale"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/community_goals": {
+      "get": {
+        "operationId": "getCommunityGoals",
+        "summary": "Get all community goals",
+        "description": "Retrieves all community goals created on the account.",
+        "tags": ["Community Goals"],
+        "responses": {
+          "200": {
+            "description": "List of community goals",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CommunityGoal"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/community_goals/{communityGoalId}": {
+      "get": {
+        "operationId": "getCommunityGoal",
+        "summary": "Get a community goal",
+        "description": "Retrieves a specific community goal by ID.",
+        "tags": ["Community Goals"],
+        "parameters": [
+          {
+            "name": "communityGoalId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Community goal details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityGoal"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/user/{user}": {
+      "get": {
+        "operationId": "lookupPlayer",
+        "summary": "Look up a player",
+        "description": "Retrieves player information including payment history and ban count. Requires Ultimate or higher plan tier.",
+        "tags": ["Player Lookup"],
+        "parameters": [
+          {
+            "name": "user",
+            "in": "path",
+            "required": true,
+            "description": "Player UUID or username",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Player details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlayerLookup"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/player/{playerId}/packages": {
+      "get": {
+        "operationId": "getPlayerPackages",
+        "summary": "Get player's active packages",
+        "description": "Lists active packages for a customer. Can filter by specific package ID.",
+        "tags": ["Player Lookup"],
+        "parameters": [
+          {
+            "name": "playerId",
+            "in": "path",
+            "required": true,
+            "description": "ID of the player",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "package",
+            "in": "query",
+            "description": "Filter to a specific package ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of player's purchased packages",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "txn_id": {
+                        "type": "string"
+                      },
+                      "date": {
+                        "type": "string",
+                        "format": "date-time"
+                      },
+                      "quantity": {
+                        "type": "integer"
+                      },
+                      "package": {
+                        "type": "object",
+                        "properties": {
+                          "id": {
+                            "type": "integer"
+                          },
+                          "name": {
+                            "type": "string"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "TebexSecret": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-Tebex-Secret",
+        "description": "Secret key for server authentication. Found in your Tebex server settings."
+      }
+    },
+    "schemas": {
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Account identifier"
+          },
+          "domain": {
+            "type": "string",
+            "description": "Store domain URL"
+          },
+          "name": {
+            "type": "string",
+            "description": "Store name"
+          },
+          "currency": {
+            "type": "object",
+            "properties": {
+              "iso_4217": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              }
+            }
+          },
+          "online_mode": {
+            "type": "boolean"
+          },
+          "game_type": {
+            "type": "string",
+            "description": "Associated game platform"
+          },
+          "log_events": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Server": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "QueuePlayer": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Internal plugin player ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Player name"
+          },
+          "uuid": {
+            "type": "string",
+            "description": "Player UUID (Steam64, XUID, etc.)"
+          }
+        }
+      },
+      "Command": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "command": {
+            "type": "string",
+            "description": "Command string with {name} placeholder"
+          },
+          "payment": {
+            "type": "integer"
+          },
+          "package": {
+            "type": "integer"
+          },
+          "conditions": {
+            "type": "object",
+            "properties": {
+              "delay": {
+                "type": "integer",
+                "description": "Delay in seconds"
+              }
+            }
+          },
+          "player": {
+            "$ref": "#/components/schemas/QueuePlayer"
+          }
+        }
+      },
+      "OnlineCommand": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "command": {
+            "type": "string"
+          },
+          "payment": {
+            "type": "integer"
+          },
+          "package": {
+            "type": "integer"
+          },
+          "conditions": {
+            "type": "object",
+            "properties": {
+              "delay": {
+                "type": "integer"
+              },
+              "slots": {
+                "type": "integer"
+              }
+            }
+          }
+        }
+      },
+      "Package": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number"
+          },
+          "disabled": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Payment": {
+        "type": "object",
+        "properties": {
+          "txn_id": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer",
+            "description": "Unix timestamp"
+          },
+          "price": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "PaymentField": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "GiftCard": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "code": {
+            "type": "string"
+          },
+          "balance": {
+            "type": "object",
+            "properties": {
+              "starting": {
+                "type": "string"
+              },
+              "remaining": {
+                "type": "string"
+              },
+              "currency": {
+                "type": "string"
+              }
+            }
+          },
+          "note": {
+            "type": "string"
+          },
+          "void": {
+            "type": "boolean"
+          }
+        }
+      },
+      "Coupon": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "code": {
+            "type": "string"
+          },
+          "effective": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "categories": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "discount": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "percentage": {
+                "type": "integer"
+              },
+              "value": {
+                "type": "number"
+              }
+            }
+          },
+          "expire_never": {
+            "type": "boolean"
+          },
+          "expire_limit": {
+            "type": "integer"
+          },
+          "expire_date": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string"
+          },
+          "basket_type": {
+            "type": "string"
+          },
+          "minimum": {
+            "type": "number"
+          },
+          "username": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateCouponRequest": {
+        "type": "object",
+        "required": ["code", "effective_on", "discount_type", "discount_amount"],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "effective_on": {
+            "type": "string",
+            "enum": ["package", "category", "cart"]
+          },
+          "packages": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "categories": {
+            "type": "array",
+            "items": {
+              "type": "integer"
+            }
+          },
+          "discount_type": {
+            "type": "string",
+            "enum": ["percentage", "value"]
+          },
+          "discount_amount": {
+            "type": "integer"
+          },
+          "discount_percentage": {
+            "type": "integer"
+          },
+          "redeem_unlimited": {
+            "type": "boolean"
+          },
+          "expire_never": {
+            "type": "boolean"
+          },
+          "expire_limit": {
+            "type": "integer"
+          },
+          "expire_date": {
+            "type": "string",
+            "description": "Format: yyyy-mm-dd"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Format: yyyy-mm-dd"
+          },
+          "basket_type": {
+            "type": "string",
+            "enum": ["single", "subscription", "both"]
+          },
+          "minimum": {
+            "type": "number"
+          },
+          "discount_application_method": {
+            "type": "integer",
+            "enum": [0, 1, 2]
+          },
+          "username": {
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          }
+        }
+      },
+      "Ban": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "time": {
+            "type": "string"
+          },
+          "ip": {
+            "type": "string"
+          },
+          "payment_email": {
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "user": {
+            "type": "object",
+            "properties": {
+              "ign": {
+                "type": "string"
+              },
+              "uuid": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "Sale": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "effective": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "packages": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              },
+              "categories": {
+                "type": "array",
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
+          },
+          "discount": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "percentage": {
+                "type": "integer"
+              },
+              "value": {
+                "type": "number"
+              }
+            }
+          },
+          "start": {
+            "type": "integer",
+            "description": "Unix timestamp"
+          },
+          "expire": {
+            "type": "integer",
+            "description": "Unix timestamp"
+          },
+          "order": {
+            "type": "integer"
+          }
+        }
+      },
+      "CommunityGoal": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "account": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string"
+          },
+          "target": {
+            "type": "string"
+          },
+          "current": {
+            "type": "string"
+          },
+          "repeatable": {
+            "type": "integer"
+          },
+          "last_achieved": {
+            "type": "string",
+            "nullable": true
+          },
+          "times_achieved": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "sale": {
+            "type": "integer"
+          }
+        }
+      },
+      "PlayerLookup": {
+        "type": "object",
+        "properties": {
+          "player": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer"
+              },
+              "username": {
+                "type": "string"
+              },
+              "meta": {
+                "type": "object"
+              },
+              "plugin_username_id": {
+                "type": "integer"
+              }
+            }
+          },
+          "banCount": {
+            "type": "integer"
+          },
+          "chargebackRate": {
+            "type": "integer"
+          },
+          "payments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Payment"
+            }
+          },
+          "purchaseTotals": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number"
+            }
+          }
+        }
+      },
+      "Pagination": {
+        "type": "object",
+        "properties": {
+          "current_page": {
+            "type": "integer"
+          },
+          "last_page": {
+            "type": "integer"
+          },
+          "per_page": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "integer"
+          },
+          "error_message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/tebex.io/tebex/meta.json
+++ b/apis/openapi/tebex.io/tebex/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "7f63b6635cc73a816dff3732f033cf8e",
+    "format": "openapi",
+    "vendor": "tebex.io",
+    "api_name": "tebex",
+    "friendly_id": "tebex.io/tebex"
+  }
+}

--- a/apis/openapi/tools.keycdn.com/keycdn-ip-location-finder/1.0.0/openapi.json
+++ b/apis/openapi/tools.keycdn.com/keycdn-ip-location-finder/1.0.0/openapi.json
@@ -1,0 +1,226 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "KeyCDN IP Location Finder API",
+    "description": "KeyCDN's IP Location Finder API (geoip) provides geolocation data for any IP address or hostname. It returns details including country, region, city, postal code, ISP, ASN, coordinates, timezone and more. A custom User-Agent header containing 'keycdn-tools:https://yourdomain.com' is required for authentication.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "KeyCDN",
+      "url": "https://www.keycdn.com"
+    },
+    "x-jentic-source-url": "https://tools.keycdn.com/geo"
+  },
+  "servers": [
+    {
+      "url": "https://tools.keycdn.com",
+      "description": "KeyCDN Tools server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geolocation",
+      "description": "IP geolocation lookup"
+    }
+  ],
+  "paths": {
+    "/geo.json": {
+      "get": {
+        "operationId": "getGeoLocation",
+        "summary": "IP geolocation lookup",
+        "description": "Returns geolocation data for the specified IP address or hostname. Requires a User-Agent header in the format 'keycdn-tools:https://yourdomain.com'.",
+        "tags": ["Geolocation"],
+        "parameters": [
+          {
+            "name": "host",
+            "in": "query",
+            "required": true,
+            "description": "IP address or hostname to look up.",
+            "schema": {
+              "type": "string"
+            },
+            "example": "8.8.8.8"
+          },
+          {
+            "name": "User-Agent",
+            "in": "header",
+            "required": true,
+            "description": "Must be in the format 'keycdn-tools:https://yourdomain.com' where yourdomain.com is your website.",
+            "schema": {
+              "type": "string",
+              "pattern": "^keycdn-tools:https?://.+"
+            },
+            "example": "keycdn-tools:https://example.com"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geolocation lookup.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeoResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request. Invalid IP address or hostname.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden. Missing or invalid User-Agent header.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests. Rate limit exceeded.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "GeoResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "description": "Status of the request.",
+            "example": "success"
+          },
+          "description": {
+            "type": "string",
+            "description": "Human-readable status description.",
+            "example": "Data successfully received."
+          },
+          "data": {
+            "type": "object",
+            "properties": {
+              "geo": {
+                "$ref": "#/components/schemas/GeoData"
+              }
+            }
+          }
+        }
+      },
+      "GeoData": {
+        "type": "object",
+        "properties": {
+          "host": {
+            "type": "string",
+            "description": "The queried host or IP address."
+          },
+          "ip": {
+            "type": "string",
+            "description": "Resolved IP address."
+          },
+          "asn": {
+            "type": "integer",
+            "description": "Autonomous System Number."
+          },
+          "isp": {
+            "type": "string",
+            "description": "Internet Service Provider name."
+          },
+          "country_name": {
+            "type": "string",
+            "description": "Full country name.",
+            "nullable": true
+          },
+          "country_code": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code.",
+            "nullable": true
+          },
+          "region_name": {
+            "type": "string",
+            "description": "Region or state name.",
+            "nullable": true
+          },
+          "region_code": {
+            "type": "string",
+            "description": "Region code.",
+            "nullable": true
+          },
+          "city": {
+            "type": "string",
+            "description": "City name.",
+            "nullable": true
+          },
+          "postal_code": {
+            "type": "string",
+            "description": "Postal or zip code.",
+            "nullable": true
+          },
+          "continent_name": {
+            "type": "string",
+            "description": "Continent name.",
+            "nullable": true
+          },
+          "continent_code": {
+            "type": "string",
+            "description": "Two-letter continent code.",
+            "nullable": true
+          },
+          "latitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude coordinate."
+          },
+          "longitude": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude coordinate."
+          },
+          "metro_code": {
+            "type": "integer",
+            "description": "Metro area code (US only).",
+            "nullable": true
+          },
+          "timezone": {
+            "type": "string",
+            "description": "IANA timezone identifier.",
+            "nullable": true
+          },
+          "datetime": {
+            "type": "string",
+            "description": "Current date and time in the timezone.",
+            "nullable": true
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "error"
+          },
+          "description": {
+            "type": "string",
+            "description": "Error description."
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/tools.keycdn.com/keycdn-ip-location-finder/meta.json
+++ b/apis/openapi/tools.keycdn.com/keycdn-ip-location-finder/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "80f16b8451360ca9549a363c7a94ce8f",
+    "format": "openapi",
+    "vendor": "tools.keycdn.com",
+    "api_name": "keycdn-ip-location-finder",
+    "friendly_id": "tools.keycdn.com/keycdn-ip-location-finder"
+  }
+}

--- a/apis/openapi/uebermaps.com/uebermaps/2.0.0/openapi.json
+++ b/apis/openapi/uebermaps.com/uebermaps/2.0.0/openapi.json
@@ -1,0 +1,1274 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Uebermaps API",
+    "description": "Uebermaps lets you create maps with spots and share them with friends. Discover, collect, and share the best spots. Note: This service was shut down in July 2023.",
+    "version": "2.0.0",
+    "contact": {
+      "email": "contact@uebermaps.com"
+    },
+    "x-jentic-source-url": "https://uebermaps.com/api/v2"
+  },
+  "servers": [
+    {
+      "url": "https://uebermaps.com/api/v2",
+      "description": "Uebermaps API v2 (discontinued)"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Maps",
+      "description": "Operations related to maps"
+    },
+    {
+      "name": "Spots",
+      "description": "Operations related to spots on maps"
+    },
+    {
+      "name": "Users",
+      "description": "Operations related to user accounts"
+    },
+    {
+      "name": "Comments",
+      "description": "Operations related to comments on spots"
+    },
+    {
+      "name": "Subscriptions",
+      "description": "Operations related to map subscriptions"
+    },
+    {
+      "name": "Attachments",
+      "description": "Operations related to spot attachments"
+    }
+  ],
+  "security": [
+    {
+      "authToken": []
+    }
+  ],
+  "paths": {
+    "/maps": {
+      "get": {
+        "tags": ["Maps"],
+        "summary": "List maps",
+        "description": "Retrieve a list of publicly available maps.",
+        "operationId": "listMaps",
+        "security": [],
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "Page number for pagination",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "per_page",
+            "in": "query",
+            "description": "Number of results per page",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Map"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Maps"],
+        "summary": "Create a map",
+        "description": "Create a new map.",
+        "operationId": "createMap",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MapInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Map created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Map"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/maps/search": {
+      "get": {
+        "tags": ["Maps"],
+        "summary": "Search maps",
+        "description": "Search for maps by query string.",
+        "operationId": "searchMaps",
+        "security": [],
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Search results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Map"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/maps/nearest": {
+      "get": {
+        "tags": ["Maps"],
+        "summary": "List nearest maps",
+        "description": "Retrieve maps nearest to a given location.",
+        "operationId": "listNearestMaps",
+        "security": [],
+        "parameters": [
+          {
+            "name": "lat",
+            "in": "query",
+            "description": "Latitude",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lon",
+            "in": "query",
+            "description": "Longitude",
+            "required": true,
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Nearest maps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Map"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/maps/{id}": {
+      "get": {
+        "tags": ["Maps"],
+        "summary": "Get a map",
+        "description": "Retrieve a single map by its ID.",
+        "operationId": "getMap",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Map"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Maps"],
+        "summary": "Update a map",
+        "description": "Update an existing map.",
+        "operationId": "updateMap",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MapInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Map updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Map"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Maps"],
+        "summary": "Delete a map",
+        "description": "Delete a map by its ID.",
+        "operationId": "deleteMap",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Map deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/maps/{map_id}/spots": {
+      "get": {
+        "tags": ["Spots"],
+        "summary": "List spots on a map",
+        "description": "Retrieve all spots associated with a map.",
+        "operationId": "listMapSpots",
+        "security": [],
+        "parameters": [
+          {
+            "name": "map_id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "description": "Sort order",
+            "schema": {
+              "type": "string",
+              "enum": ["created_at_asc", "created_at_desc", "updated_at_asc", "updated_at_desc"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of spots",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Spot"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "post": {
+        "tags": ["Spots"],
+        "summary": "Create a spot",
+        "description": "Add a new spot to a map.",
+        "operationId": "createSpot",
+        "parameters": [
+          {
+            "name": "map_id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SpotInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Spot created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Spot"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "422": {
+            "$ref": "#/components/responses/UnprocessableEntity"
+          }
+        }
+      }
+    },
+    "/spots/{id}": {
+      "get": {
+        "tags": ["Spots"],
+        "summary": "Get a spot",
+        "description": "Retrieve a single spot by its ID.",
+        "operationId": "getSpot",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Spot"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Spots"],
+        "summary": "Update a spot",
+        "description": "Update an existing spot.",
+        "operationId": "updateSpot",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SpotInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Spot updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Spot"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Spots"],
+        "summary": "Delete a spot",
+        "description": "Delete a spot by its ID.",
+        "operationId": "deleteSpot",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Spot deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/spots/{spot_id}/comments": {
+      "get": {
+        "tags": ["Comments"],
+        "summary": "List comments on a spot",
+        "description": "Retrieve all comments for a spot.",
+        "operationId": "listSpotComments",
+        "security": [],
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Comment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Comments"],
+        "summary": "Create a comment",
+        "description": "Add a comment to a spot.",
+        "operationId": "createComment",
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CommentInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Comment created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Comment"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/spots/{spot_id}/comments/{id}": {
+      "delete": {
+        "tags": ["Comments"],
+        "summary": "Delete a comment",
+        "description": "Delete a comment from a spot.",
+        "operationId": "deleteComment",
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Comment ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Comment deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/spots/{spot_id}/attachments": {
+      "get": {
+        "tags": ["Attachments"],
+        "summary": "List attachments on a spot",
+        "description": "Retrieve all attachments for a spot.",
+        "operationId": "listSpotAttachments",
+        "security": [],
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of attachments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Attachment"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["Attachments"],
+        "summary": "Upload an attachment",
+        "description": "Upload an attachment to a spot.",
+        "operationId": "createAttachment",
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "image": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Image file to upload"
+                  }
+                },
+                "required": ["image"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Attachment created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attachment"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/spots/{spot_id}/attachments/{id}": {
+      "delete": {
+        "tags": ["Attachments"],
+        "summary": "Delete an attachment",
+        "description": "Delete an attachment from a spot.",
+        "operationId": "deleteAttachment",
+        "parameters": [
+          {
+            "name": "spot_id",
+            "in": "path",
+            "required": true,
+            "description": "Spot ID",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "Attachment ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Attachment deleted"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/maps/{map_id}/subscriptions": {
+      "post": {
+        "tags": ["Subscriptions"],
+        "summary": "Subscribe to a map",
+        "description": "Subscribe to receive updates for a map.",
+        "operationId": "subscribeToMap",
+        "parameters": [
+          {
+            "name": "map_id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscribed successfully"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      },
+      "delete": {
+        "tags": ["Subscriptions"],
+        "summary": "Unsubscribe from a map",
+        "description": "Unsubscribe from a map.",
+        "operationId": "unsubscribeFromMap",
+        "parameters": [
+          {
+            "name": "map_id",
+            "in": "path",
+            "required": true,
+            "description": "Map ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Unsubscribed successfully"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/users/{id}": {
+      "get": {
+        "tags": ["Users"],
+        "summary": "Get a user",
+        "description": "Retrieve a user profile by ID.",
+        "operationId": "getUser",
+        "security": [],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "User ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      },
+      "patch": {
+        "tags": ["Users"],
+        "summary": "Update current user",
+        "description": "Update the authenticated user's profile.",
+        "operationId": "updateUser",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "description": "User ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UserInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "User updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    },
+    "/users/{user_id}/maps": {
+      "get": {
+        "tags": ["Users", "Maps"],
+        "summary": "List user's maps",
+        "description": "Retrieve all maps belonging to a user.",
+        "operationId": "listUserMaps",
+        "security": [],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "description": "User ID",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List of user's maps",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Map"
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        }
+      }
+    },
+    "/authentication": {
+      "post": {
+        "tags": ["Users"],
+        "summary": "Authenticate user",
+        "description": "Authenticate and receive an auth token.",
+        "operationId": "authenticateUser",
+        "security": [],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "user": {
+                    "type": "object",
+                    "properties": {
+                      "email": {
+                        "type": "string",
+                        "format": "email"
+                      },
+                      "password": {
+                        "type": "string"
+                      }
+                    },
+                    "required": ["email", "password"]
+                  }
+                },
+                "required": ["user"]
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Authentication successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "auth_token": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "authToken": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "Authorization",
+        "description": "Auth token obtained via /authentication endpoint"
+      }
+    },
+    "schemas": {
+      "Map": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "visibility": {
+            "type": "string",
+            "enum": ["public", "private"]
+          },
+          "owner_id": {
+            "type": "integer"
+          },
+          "spots_count": {
+            "type": "integer"
+          },
+          "subscriptions_count": {
+            "type": "integer"
+          },
+          "map_settings": {
+            "type": "object",
+            "properties": {
+              "center_lat": {
+                "type": "number",
+                "format": "double"
+              },
+              "center_lng": {
+                "type": "number",
+                "format": "double"
+              },
+              "zoom_level": {
+                "type": "integer"
+              }
+            }
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "MapInput": {
+        "type": "object",
+        "properties": {
+          "map": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "visibility": {
+                "type": "string",
+                "enum": ["public", "private"]
+              }
+            },
+            "required": ["title"]
+          }
+        },
+        "required": ["map"]
+      },
+      "Spot": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "lat": {
+            "type": "number",
+            "format": "double"
+          },
+          "lon": {
+            "type": "number",
+            "format": "double"
+          },
+          "map_id": {
+            "type": "integer"
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "SpotInput": {
+        "type": "object",
+        "properties": {
+          "spot": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              },
+              "lat": {
+                "type": "number",
+                "format": "double"
+              },
+              "lon": {
+                "type": "number",
+                "format": "double"
+              }
+            },
+            "required": ["title", "lat", "lon"]
+          }
+        },
+        "required": ["spot"]
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "body": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "spot_id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "CommentInput": {
+        "type": "object",
+        "properties": {
+          "comment": {
+            "type": "object",
+            "properties": {
+              "body": {
+                "type": "string"
+              }
+            },
+            "required": ["body"]
+          }
+        },
+        "required": ["comment"]
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "image_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "spot_id": {
+            "type": "integer"
+          },
+          "user_id": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "screen_name": {
+            "type": "string"
+          },
+          "avatar_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "header_picture": {
+            "type": "string",
+            "format": "uri"
+          },
+          "about": {
+            "type": "string"
+          }
+        }
+      },
+      "UserInput": {
+        "type": "object",
+        "properties": {
+          "user": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "about": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "required": ["user"]
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "error_description": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "Unauthorized": {
+        "description": "Authentication required or invalid token",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "NotFound": {
+        "description": "Resource not found",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UnprocessableEntity": {
+        "description": "Validation error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/uebermaps.com/uebermaps/meta.json
+++ b/apis/openapi/uebermaps.com/uebermaps/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "79db3724e3e892abf0812b2f47a4f8cf",
+    "format": "openapi",
+    "vendor": "uebermaps.com",
+    "api_name": "uebermaps",
+    "friendly_id": "uebermaps.com/uebermaps"
+  }
+}

--- a/apis/openapi/usa.gov/usa-gov/2.0.0/openapi.json
+++ b/apis/openapi/usa.gov/usa-gov/2.0.0/openapi.json
@@ -1,0 +1,345 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "USA.gov Search Results API",
+    "description": "The USA.gov Search Results API (powered by Search.gov) provides programmatic access to search results from USA.gov and other federal government websites. It enables searching across federal web content with features like keyword highlighting, best bets, and spelling corrections.",
+    "version": "2.0.0",
+    "contact": {
+      "name": "USA.gov",
+      "url": "https://www.usa.gov"
+    },
+    "license": {
+      "name": "Public Domain",
+      "url": "https://www.usa.gov/policies"
+    },
+    "x-jentic-source-url": "https://www.usa.gov/developer"
+  },
+  "servers": [
+    {
+      "url": "https://api.gsa.gov/technology/searchgov/v2",
+      "description": "Search.gov API production server"
+    }
+  ],
+  "tags": [
+    { "name": "search", "description": "Search results operations" }
+  ],
+  "paths": {
+    "/results/i14y": {
+      "get": {
+        "summary": "Search web results",
+        "description": "Retrieve search results from indexed federal government web content. Returns web results, best bets, spelling corrections, and related search suggestions.",
+        "operationId": "searchResults",
+        "tags": ["search"],
+        "parameters": [
+          {
+            "name": "affiliate",
+            "in": "query",
+            "required": true,
+            "description": "Site handle identifying the search configuration (unique identifier for the site).",
+            "schema": { "type": "string" },
+            "example": "usagov"
+          },
+          {
+            "name": "access_key",
+            "in": "query",
+            "required": true,
+            "description": "Unique API access key for the site. Generated during search site setup.",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "description": "The search query string.",
+            "schema": { "type": "string" },
+            "example": "social security"
+          },
+          {
+            "name": "enable_highlighting",
+            "in": "query",
+            "description": "Whether to include HTML highlighting tags around matching terms in results.",
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of results to return per page.",
+            "schema": { "type": "integer", "default": 20, "maximum": 50 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Offset for pagination. Starts at 0.",
+            "schema": { "type": "integer", "default": 0, "maximum": 999 }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "description": "Sort order for results.",
+            "schema": {
+              "type": "string",
+              "enum": ["relevance", "date"],
+              "default": "relevance"
+            }
+          },
+          {
+            "name": "sitelimit",
+            "in": "query",
+            "description": "Restrict results to a specific domain or subfolder (e.g., 'www.usa.gov/benefits').",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "api_key",
+            "in": "query",
+            "description": "Optional API.Data.gov API key for higher rate limits (1,000 requests/hour default without key).",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful search response.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/SearchResultsResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - missing or invalid required parameters.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid access_key or affiliate.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded. Default limit is 1,000 requests per hour.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/Error" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "SearchResultsResponse": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "The search query that was executed."
+          },
+          "web": {
+            "$ref": "#/components/schemas/WebResults"
+          },
+          "text_best_bets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TextBestBet" },
+            "description": "Editorially curated best bet results."
+          },
+          "graphic_best_bets": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/GraphicBestBet" },
+            "description": "Graphical best bet results with images."
+          },
+          "health_topics": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/HealthTopic" },
+            "description": "Related health topics from MedlinePlus."
+          },
+          "job_openings": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/JobOpening" },
+            "description": "Related federal job openings."
+          },
+          "federal_register_documents": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/FederalRegisterDocument" },
+            "description": "Related Federal Register documents."
+          },
+          "recent_tweets": {
+            "type": "array",
+            "items": { "type": "object" },
+            "description": "Recent relevant social media posts."
+          },
+          "recent_video_news": {
+            "type": "array",
+            "items": { "type": "object" },
+            "description": "Recent relevant video news."
+          },
+          "route_to": {
+            "type": "string",
+            "description": "URL to redirect to for configured query routing.",
+            "nullable": true
+          }
+        }
+      },
+      "WebResults": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of matching web results."
+          },
+          "next_offset": {
+            "type": "integer",
+            "description": "Offset value for the next page of results.",
+            "nullable": true
+          },
+          "spelling_correction": {
+            "type": "string",
+            "description": "Suggested spelling correction for the query.",
+            "nullable": true
+          },
+          "results": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/WebResult" }
+          }
+        }
+      },
+      "WebResult": {
+        "type": "object",
+        "properties": {
+          "title": {
+            "type": "string",
+            "description": "Title of the web page. May include HTML highlighting tags."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the web page."
+          },
+          "snippet": {
+            "type": "string",
+            "description": "Text snippet from the page. May include HTML highlighting tags."
+          },
+          "publication_date": {
+            "type": "string",
+            "format": "date",
+            "description": "Publication date of the content.",
+            "nullable": true
+          },
+          "thumbnail_url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of a thumbnail image for the result.",
+            "nullable": true
+          }
+        }
+      },
+      "TextBestBet": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Unique identifier for the best bet."
+          },
+          "title": {
+            "type": "string",
+            "description": "Title of the best bet."
+          },
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL of the best bet."
+          },
+          "description": {
+            "type": "string",
+            "description": "Description of the best bet."
+          }
+        }
+      },
+      "GraphicBestBet": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "title_url": { "type": "string", "format": "uri" },
+          "image_url": { "type": "string", "format": "uri" },
+          "image_alt_text": { "type": "string" },
+          "links": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "title": { "type": "string" },
+                "url": { "type": "string", "format": "uri" }
+              }
+            }
+          }
+        }
+      },
+      "HealthTopic": {
+        "type": "object",
+        "properties": {
+          "title": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "snippet": { "type": "string" }
+        }
+      },
+      "JobOpening": {
+        "type": "object",
+        "properties": {
+          "position_title": { "type": "string" },
+          "organization_name": { "type": "string" },
+          "rate_interval_code": { "type": "string" },
+          "minimum": { "type": "number" },
+          "maximum": { "type": "number" },
+          "start_date": { "type": "string", "format": "date" },
+          "end_date": { "type": "string", "format": "date" },
+          "locations": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "url": { "type": "string", "format": "uri" }
+        }
+      },
+      "FederalRegisterDocument": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "title": { "type": "string" },
+          "url": { "type": "string", "format": "uri" },
+          "agency_names": {
+            "type": "array",
+            "items": { "type": "string" }
+          },
+          "document_type": { "type": "string" },
+          "document_number": { "type": "string" },
+          "publication_date": { "type": "string", "format": "date" },
+          "comments_close_on": { "type": "string", "format": "date", "nullable": true },
+          "start_page": { "type": "integer" },
+          "end_page": { "type": "integer" },
+          "page_length": { "type": "integer" }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "error": { "type": "string" },
+          "message": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/usa.gov/usa-gov/meta.json
+++ b/apis/openapi/usa.gov/usa-gov/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "6f25370a63d72e1cb0e93b53e6e5e3ec",
+    "format": "openapi",
+    "vendor": "usa.gov",
+    "api_name": "usa-gov",
+    "friendly_id": "usa.gov/usa-gov"
+  }
+}

--- a/apis/openapi/wirefreethought.com/geodb-cities/1.0.0/openapi.json
+++ b/apis/openapi/wirefreethought.com/geodb-cities/1.0.0/openapi.json
@@ -1,0 +1,779 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "GeoDB Cities API",
+    "description": "GeoDB Cities is a comprehensive API for getting global city, region, and country data. It provides geolocation data including city populations, coordinates, currency info, and locale data. Data is sourced from WikiData.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "WireFreethought",
+      "url": "http://geodb-cities-api.wirefreethought.com/"
+    },
+    "x-jentic-source-url": "http://geodb-cities-api.wirefreethought.com/"
+  },
+  "servers": [
+    {
+      "url": "https://wft-geo-db.p.rapidapi.com/v1",
+      "description": "RapidAPI Production Server"
+    },
+    {
+      "url": "https://geodb-free-service.wirefreethought.com/v1",
+      "description": "Free Tier Server"
+    }
+  ],
+  "security": [
+    {
+      "RapidAPIKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geo",
+      "description": "Geographic data endpoints for cities, countries, and regions"
+    },
+    {
+      "name": "Locale",
+      "description": "Locale-related data including currencies and locales"
+    }
+  ],
+  "paths": {
+    "/geo/cities": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Find cities",
+        "description": "Find cities using various filter criteria. Results are paginated.",
+        "operationId": "findCities",
+        "parameters": [
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "description": "Filter by city name prefix",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "namePrefixDefaultLangResults",
+            "in": "query",
+            "description": "When true, include results in default language if no match for requested language",
+            "schema": { "type": "boolean", "default": true }
+          },
+          {
+            "name": "countryIds",
+            "in": "query",
+            "description": "Filter by comma-separated ISO country codes",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "excludedCountryIds",
+            "in": "query",
+            "description": "Exclude cities from these comma-separated country codes",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "minPopulation",
+            "in": "query",
+            "description": "Filter by minimum population",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "maxPopulation",
+            "in": "query",
+            "description": "Filter by maximum population",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "description": "Filter by location in format +/-DD.DDDD+/-DDD.DDDD",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "distanceUnit",
+            "in": "query",
+            "description": "Unit of distance (MI or KM)",
+            "schema": { "type": "string", "enum": ["MI", "KM"], "default": "MI" }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "description": "Maximum distance from location in distance units",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "description": "Sort field and direction (e.g., -population, +name)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Filter by city types (comma-separated): CITY, ADM2",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "languageCode",
+            "in": "query",
+            "description": "Language code for localized results",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results per page",
+            "schema": { "type": "integer", "default": 10, "maximum": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Pagination offset",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "hateoasMode",
+            "in": "query",
+            "description": "Include HATEOAS links in response",
+            "schema": { "type": "boolean", "default": true }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of cities",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CitiesResponse" }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - invalid or missing API key"
+          },
+          "403": {
+            "description": "Forbidden - subscription required"
+          },
+          "429": {
+            "description": "Rate limit exceeded"
+          }
+        }
+      }
+    },
+    "/geo/cities/{cityId}": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Get city details",
+        "description": "Get details for a specific city by its ID.",
+        "operationId": "getCityDetails",
+        "parameters": [
+          {
+            "name": "cityId",
+            "in": "path",
+            "required": true,
+            "description": "The city ID (GeoDB native or WikiData QID)",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "languageCode",
+            "in": "query",
+            "description": "Language code for localized results",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with city details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CityDetailResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "City not found"
+          }
+        }
+      }
+    },
+    "/geo/cities/{cityId}/nearbyCities": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Find nearby cities",
+        "description": "Find cities near the given city.",
+        "operationId": "findNearbyCities",
+        "parameters": [
+          {
+            "name": "cityId",
+            "in": "path",
+            "required": true,
+            "description": "The city ID",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "description": "Maximum radius in distance units",
+            "schema": { "type": "integer", "default": 100 }
+          },
+          {
+            "name": "distanceUnit",
+            "in": "query",
+            "description": "Unit of distance",
+            "schema": { "type": "string", "enum": ["MI", "KM"], "default": "MI" }
+          },
+          {
+            "name": "minPopulation",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "languageCode",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CitiesResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "City not found"
+          }
+        }
+      }
+    },
+    "/geo/cities/{cityId}/distance": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Get city distance",
+        "description": "Get the distance between two cities.",
+        "operationId": "getCityDistance",
+        "parameters": [
+          {
+            "name": "cityId",
+            "in": "path",
+            "required": true,
+            "description": "The origin city ID",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "toCityId",
+            "in": "query",
+            "required": true,
+            "description": "The target city ID",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "distanceUnit",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["MI", "KM"], "default": "MI" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with distance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": { "type": "number", "description": "Distance value" }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geo/countries": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Find countries",
+        "description": "Find countries using various filter criteria.",
+        "operationId": "findCountries",
+        "parameters": [
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "description": "Filter by country name prefix",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "currencyCode",
+            "in": "query",
+            "description": "Filter by currency code",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of countries",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CountriesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geo/countries/{countryId}": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Get country details",
+        "description": "Get details for a specific country.",
+        "operationId": "getCountryDetails",
+        "parameters": [
+          {
+            "name": "countryId",
+            "in": "path",
+            "required": true,
+            "description": "ISO country code",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with country details",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CountryDetailResponse" }
+              }
+            }
+          },
+          "404": {
+            "description": "Country not found"
+          }
+        }
+      }
+    },
+    "/geo/countries/{countryId}/regions": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Find country regions",
+        "description": "Get all regions/states within a country.",
+        "operationId": "findCountryRegions",
+        "parameters": [
+          {
+            "name": "countryId",
+            "in": "path",
+            "required": true,
+            "description": "ISO country code",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of regions",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/RegionsResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/geo/adminDivisions": {
+      "get": {
+        "tags": ["Geo"],
+        "summary": "Find administrative divisions",
+        "description": "Find administrative divisions (regions, states, provinces) using various filter criteria.",
+        "operationId": "findAdminDivisions",
+        "parameters": [
+          {
+            "name": "namePrefix",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "countryIds",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "minPopulation",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "location",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "radius",
+            "in": "query",
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "distanceUnit",
+            "in": "query",
+            "schema": { "type": "string", "enum": ["MI", "KM"] }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          },
+          {
+            "name": "sort",
+            "in": "query",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "languageCode",
+            "in": "query",
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with admin divisions",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/AdminDivisionsResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/locale/currencies": {
+      "get": {
+        "tags": ["Locale"],
+        "summary": "Find currencies",
+        "description": "Get a list of currencies with their associated country codes.",
+        "operationId": "findCurrencies",
+        "parameters": [
+          {
+            "name": "countryId",
+            "in": "query",
+            "description": "Filter by country code",
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of currencies",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/CurrenciesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/locale/locales": {
+      "get": {
+        "tags": ["Locale"],
+        "summary": "Find locales",
+        "description": "Get a list of known locales.",
+        "operationId": "findLocales",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of locales",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/LocalesResponse" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/locale/timezones": {
+      "get": {
+        "tags": ["Locale"],
+        "summary": "Find timezones",
+        "description": "Get a list of known timezones.",
+        "operationId": "findTimezones",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": { "type": "integer", "default": 10 }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": { "type": "integer", "default": 0 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response with list of timezones",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TimezonesResponse" }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "RapidAPIKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-RapidAPI-Key",
+        "description": "RapidAPI key for authentication"
+      }
+    },
+    "schemas": {
+      "Link": {
+        "type": "object",
+        "properties": {
+          "rel": { "type": "string", "description": "Link relation type" },
+          "href": { "type": "string", "description": "Link URL" }
+        }
+      },
+      "Metadata": {
+        "type": "object",
+        "properties": {
+          "currentOffset": { "type": "integer", "description": "Current pagination offset" },
+          "totalCount": { "type": "integer", "description": "Total number of results" }
+        }
+      },
+      "CitySummary": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "description": "GeoDB native ID" },
+          "wikiDataId": { "type": "string", "description": "WikiData QID" },
+          "type": { "type": "string", "description": "Place type (CITY, ADM2)", "enum": ["CITY", "ADM2"] },
+          "city": { "type": "string", "description": "City name" },
+          "country": { "type": "string", "description": "Country name" },
+          "countryCode": { "type": "string", "description": "ISO country code" },
+          "region": { "type": "string", "description": "Region/state name" },
+          "regionCode": { "type": "string", "description": "Region code" },
+          "latitude": { "type": "number", "format": "double", "description": "Latitude coordinate" },
+          "longitude": { "type": "number", "format": "double", "description": "Longitude coordinate" },
+          "population": { "type": "integer", "description": "City population" }
+        }
+      },
+      "CitiesResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/CitySummary" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "CityDetailResponse": {
+        "type": "object",
+        "properties": {
+          "data": { "$ref": "#/components/schemas/CitySummary" }
+        }
+      },
+      "CountrySummary": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "description": "ISO country code" },
+          "name": { "type": "string", "description": "Country name" },
+          "currencyCodes": { "type": "array", "items": { "type": "string" }, "description": "Currency codes used" },
+          "wikiDataId": { "type": "string", "description": "WikiData QID" }
+        }
+      },
+      "CountriesResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/CountrySummary" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "CountryDetailResponse": {
+        "type": "object",
+        "properties": {
+          "data": { "$ref": "#/components/schemas/CountrySummary" }
+        }
+      },
+      "RegionSummary": {
+        "type": "object",
+        "properties": {
+          "isoCode": { "type": "string" },
+          "name": { "type": "string" },
+          "countryCode": { "type": "string" },
+          "wikiDataId": { "type": "string" },
+          "fipsCode": { "type": "string" }
+        }
+      },
+      "RegionsResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/RegionSummary" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "AdminDivisionSummary": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer" },
+          "wikiDataId": { "type": "string" },
+          "name": { "type": "string" },
+          "country": { "type": "string" },
+          "countryCode": { "type": "string" },
+          "region": { "type": "string" },
+          "regionCode": { "type": "string" },
+          "regionWdId": { "type": "string" },
+          "latitude": { "type": "number", "format": "double" },
+          "longitude": { "type": "number", "format": "double" },
+          "population": { "type": "integer" }
+        }
+      },
+      "AdminDivisionsResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/AdminDivisionSummary" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "Currency": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "description": "Currency code" },
+          "countryCodes": { "type": "array", "items": { "type": "string" }, "description": "Country codes using this currency" },
+          "symbol": { "type": "string", "description": "Currency symbol" }
+        }
+      },
+      "CurrenciesResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Currency" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "Locale": {
+        "type": "object",
+        "properties": {
+          "code": { "type": "string", "description": "Locale code" },
+          "name": { "type": "string", "description": "Locale display name" }
+        }
+      },
+      "LocalesResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": { "type": "array", "items": { "$ref": "#/components/schemas/Locale" } },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "TimezonesResponse": {
+        "type": "object",
+        "properties": {
+          "links": { "type": "array", "items": { "$ref": "#/components/schemas/Link" } },
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "id": { "type": "string" },
+                "name": { "type": "string" },
+                "rawUtcOffsetHours": { "type": "integer" }
+              }
+            }
+          },
+          "metadata": { "$ref": "#/components/schemas/Metadata" }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "code": { "type": "string" },
+                "message": { "type": "string" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/wirefreethought.com/geodb-cities/meta.json
+++ b/apis/openapi/wirefreethought.com/geodb-cities/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "8ea699a7771c296ccd19a3338f84f15e",
+    "format": "openapi",
+    "vendor": "wirefreethought.com",
+    "api_name": "geodb-cities",
+    "friendly_id": "wirefreethought.com/geodb-cities"
+  }
+}

--- a/apis/openapi/yandex.com/yandex-maps-geocoder/1.x/openapi.json
+++ b/apis/openapi/yandex.com/yandex-maps-geocoder/1.x/openapi.json
@@ -1,0 +1,389 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Yandex Maps Geocoder API",
+    "description": "The Yandex Maps Geocoder API converts addresses to geographic coordinates (forward geocoding) and geographic coordinates to addresses (reverse geocoding). It supports structured and unstructured address queries and covers Russia, CIS countries, Turkey, and other regions.",
+    "version": "1.x",
+    "contact": {
+      "name": "Yandex",
+      "url": "https://yandex.com/dev/maps/geocoder"
+    },
+    "x-jentic-source-url": "https://yandex.com/dev/maps/geocoder"
+  },
+  "servers": [
+    {
+      "url": "https://geocode-maps.yandex.ru",
+      "description": "Yandex Geocoder API production server"
+    }
+  ],
+  "tags": [
+    {
+      "name": "Geocoding",
+      "description": "Forward and reverse geocoding operations"
+    }
+  ],
+  "security": [
+    {
+      "apiKey": []
+    }
+  ],
+  "paths": {
+    "/1.x/": {
+      "get": {
+        "tags": ["Geocoding"],
+        "summary": "Geocode an address or coordinates",
+        "description": "Performs forward geocoding (address to coordinates) or reverse geocoding (coordinates to address). For forward geocoding, provide an address string in the geocode parameter. For reverse geocoding, provide coordinates in 'longitude,latitude' format.",
+        "operationId": "geocode",
+        "parameters": [
+          {
+            "name": "apikey",
+            "in": "query",
+            "required": true,
+            "description": "API key for authentication, obtained from the Yandex Developer Dashboard",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "geocode",
+            "in": "query",
+            "required": true,
+            "description": "Address string for forward geocoding, or coordinates in 'longitude,latitude' format for reverse geocoding (e.g., '37.617698,55.755864' for Moscow)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Response format",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml"],
+              "default": "xml"
+            }
+          },
+          {
+            "name": "lang",
+            "in": "query",
+            "description": "Response language. Format: language_region (e.g., 'en_US', 'ru_RU', 'uk_UA', 'be_BY', 'tr_TR')",
+            "schema": {
+              "type": "string",
+              "default": "ru_RU"
+            }
+          },
+          {
+            "name": "results",
+            "in": "query",
+            "description": "Maximum number of results to return (1-100)",
+            "schema": {
+              "type": "integer",
+              "default": 10,
+              "minimum": 1,
+              "maximum": 100
+            }
+          },
+          {
+            "name": "skip",
+            "in": "query",
+            "description": "Number of results to skip (for pagination)",
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
+          },
+          {
+            "name": "ll",
+            "in": "query",
+            "description": "Center of the search area in 'longitude,latitude' format. Used to bias results toward a specific area.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "spn",
+            "in": "query",
+            "description": "Span of the search area in 'longitudeSpan,latitudeSpan' format (degrees). Used with ll parameter.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bbox",
+            "in": "query",
+            "description": "Bounding box to limit search area in 'x1,y1~x2,y2' format (lower-left~upper-right corners)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rspn",
+            "in": "query",
+            "description": "Restrict results to the area specified by ll+spn or bbox. 0=bias, 1=strict restriction.",
+            "schema": {
+              "type": "integer",
+              "enum": [0, 1],
+              "default": 0
+            }
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "description": "Filter results by geographic object type",
+            "schema": {
+              "type": "string",
+              "enum": ["house", "street", "metro", "district", "locality", "area", "province", "country", "hydro", "railway", "route", "vegetation", "airport", "other"]
+            }
+          },
+          {
+            "name": "sco",
+            "in": "query",
+            "description": "Coordinate order in geocode parameter. 'longlat' = longitude first (default), 'latlong' = latitude first.",
+            "schema": {
+              "type": "string",
+              "enum": ["longlat", "latlong"],
+              "default": "longlat"
+            }
+          },
+          {
+            "name": "uri",
+            "in": "query",
+            "description": "Yandex Maps URI of the object for precise lookup (alternative to geocode parameter)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful geocoding response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GeocodeResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "type": "string",
+                  "description": "XML formatted response (YMaps XML schema)"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request - invalid parameters",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden - invalid or missing API key",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Too many requests - rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "apikey",
+        "description": "API key from the Yandex Developer Dashboard (developer.tech.yandex.ru)"
+      }
+    },
+    "schemas": {
+      "GeocodeResponse": {
+        "type": "object",
+        "properties": {
+          "response": {
+            "type": "object",
+            "properties": {
+              "GeoObjectCollection": {
+                "type": "object",
+                "properties": {
+                  "metaDataProperty": {
+                    "type": "object",
+                    "properties": {
+                      "GeocoderResponseMetaData": {
+                        "type": "object",
+                        "properties": {
+                          "request": {
+                            "type": "string",
+                            "description": "The original geocode request"
+                          },
+                          "results": {
+                            "type": "string",
+                            "description": "Maximum number of results requested"
+                          },
+                          "found": {
+                            "type": "string",
+                            "description": "Total number of results found"
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "featureMember": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/FeatureMember"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "FeatureMember": {
+        "type": "object",
+        "properties": {
+          "GeoObject": {
+            "type": "object",
+            "properties": {
+              "metaDataProperty": {
+                "type": "object",
+                "properties": {
+                  "GeocoderMetaData": {
+                    "type": "object",
+                    "properties": {
+                      "precision": {
+                        "type": "string",
+                        "description": "Geocoding precision level",
+                        "enum": ["exact", "number", "near", "range", "street", "other"]
+                      },
+                      "text": {
+                        "type": "string",
+                        "description": "Full formatted address"
+                      },
+                      "kind": {
+                        "type": "string",
+                        "description": "Type of geographic object"
+                      },
+                      "Address": {
+                        "$ref": "#/components/schemas/Address"
+                      },
+                      "AddressDetails": {
+                        "type": "object",
+                        "description": "Detailed structured address (xAL format)"
+                      }
+                    }
+                  }
+                }
+              },
+              "name": {
+                "type": "string",
+                "description": "Short name of the object"
+              },
+              "description": {
+                "type": "string",
+                "description": "Description (typically parent administrative area)"
+              },
+              "boundedBy": {
+                "type": "object",
+                "properties": {
+                  "Envelope": {
+                    "type": "object",
+                    "properties": {
+                      "lowerCorner": {
+                        "type": "string",
+                        "description": "Lower-left corner coordinates 'longitude latitude'"
+                      },
+                      "upperCorner": {
+                        "type": "string",
+                        "description": "Upper-right corner coordinates 'longitude latitude'"
+                      }
+                    }
+                  }
+                }
+              },
+              "uri": {
+                "type": "string",
+                "description": "Yandex Maps URI for this object"
+              },
+              "Point": {
+                "type": "object",
+                "properties": {
+                  "pos": {
+                    "type": "string",
+                    "description": "Coordinates in 'longitude latitude' format"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "Address": {
+        "type": "object",
+        "properties": {
+          "country_code": {
+            "type": "string",
+            "description": "ISO 3166-1 alpha-2 country code"
+          },
+          "formatted": {
+            "type": "string",
+            "description": "Formatted address string"
+          },
+          "postal_code": {
+            "type": "string",
+            "description": "Postal code"
+          },
+          "Components": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "kind": {
+                  "type": "string",
+                  "description": "Component type (country, province, area, locality, street, house)"
+                },
+                "name": {
+                  "type": "string",
+                  "description": "Component value"
+                }
+              }
+            }
+          }
+        }
+      },
+      "Error": {
+        "type": "object",
+        "properties": {
+          "statusCode": {
+            "type": "integer"
+          },
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/yandex.com/yandex-maps-geocoder/meta.json
+++ b/apis/openapi/yandex.com/yandex-maps-geocoder/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "b687a38aaaca8cad7f57e7c3f783e36a",
+    "format": "openapi",
+    "vendor": "yandex.com",
+    "api_name": "yandex-maps-geocoder",
+    "friendly_id": "yandex.com/yandex-maps-geocoder"
+  }
+}

--- a/apis/openapi/zipcodeapi.com/zipcodeapi/1.0.0/openapi.json
+++ b/apis/openapi/zipcodeapi.com/zipcodeapi/1.0.0/openapi.json
@@ -1,0 +1,883 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "ZipCodeAPI",
+    "description": "ZipCodeAPI provides US ZIP code distance calculations, radius searches, ZIP-to-location lookups, city-to-ZIP lookups, and Canadian postal code operations. The API key is embedded in the URL path for all requests.",
+    "version": "1.0.0",
+    "contact": {
+      "name": "ZipCodeAPI",
+      "url": "https://www.zipcodeapi.com"
+    },
+    "x-jentic-source-url": "https://www.zipcodeapi.com"
+  },
+  "servers": [
+    {
+      "url": "https://www.zipcodeapi.com/rest/{api_key}",
+      "description": "ZipCodeAPI US endpoints",
+      "variables": {
+        "api_key": {
+          "default": "YOUR_API_KEY",
+          "description": "Your ZipCodeAPI API key"
+        }
+      }
+    }
+  ],
+  "tags": [
+    {
+      "name": "Distance",
+      "description": "Distance calculations between ZIP codes"
+    },
+    {
+      "name": "Radius",
+      "description": "Find ZIP codes within a radius"
+    },
+    {
+      "name": "Location",
+      "description": "ZIP code to location information"
+    },
+    {
+      "name": "City",
+      "description": "City/state to ZIP code lookups"
+    },
+    {
+      "name": "SQL",
+      "description": "SQL WHERE clause generation for radius queries"
+    }
+  ],
+  "paths": {
+    "/distance.{format}/{zip_code1}/{zip_code2}/{units}": {
+      "get": {
+        "tags": ["Distance"],
+        "summary": "Distance between two ZIP codes",
+        "description": "Calculate the distance between two US ZIP codes.",
+        "operationId": "getDistance",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "description": "Response format",
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_code1",
+            "in": "path",
+            "required": true,
+            "description": "First 5-digit US ZIP code",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{5}$"
+            }
+          },
+          {
+            "name": "zip_code2",
+            "in": "path",
+            "required": true,
+            "description": "Second 5-digit US ZIP code",
+            "schema": {
+              "type": "string",
+              "pattern": "^[0-9]{5}$"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "description": "Distance units",
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Distance result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DistanceResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/multi-distance.{format}/{zip_code}/{other_zip_codes}/{units}": {
+      "get": {
+        "tags": ["Distance"],
+        "summary": "Distances from one ZIP code to multiple others",
+        "description": "Calculate distances from a base ZIP code to up to 100 other ZIP codes. Each ZIP code counts as a separate request.",
+        "operationId": "getMultiDistance",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_code",
+            "in": "path",
+            "required": true,
+            "description": "Base 5-digit US ZIP code",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "other_zip_codes",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of ZIP codes (max 100)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Multiple distance results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiDistanceResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/radius.{format}/{zip_code}/{distance}/{units}": {
+      "get": {
+        "tags": ["Radius"],
+        "summary": "ZIP codes within a radius",
+        "description": "Find all ZIP codes within a given radius of a ZIP code. Capped at 500 miles unless minimal option is used.",
+        "operationId": "getZipCodesInRadius",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_code",
+            "in": "path",
+            "required": true,
+            "description": "Center 5-digit US ZIP code",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "distance",
+            "in": "path",
+            "required": true,
+            "description": "Radius distance",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          },
+          {
+            "name": "minimal",
+            "in": "query",
+            "description": "Return only ZIP codes (no additional data)",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP codes within radius",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RadiusResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/multi-radius.{format}/{distance}/{units}": {
+      "post": {
+        "tags": ["Radius"],
+        "summary": "ZIP codes within radius for multiple centers",
+        "description": "Find ZIP codes within a radius for multiple center ZIP codes (max 100).",
+        "operationId": "getMultiRadius",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "distance",
+            "in": "path",
+            "required": true,
+            "description": "Radius distance",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "zip_codes": {
+                    "type": "string",
+                    "description": "One ZIP code per line (max 100)"
+                  },
+                  "addrs": {
+                    "type": "string",
+                    "description": "Addresses (alternative to zip_codes)"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Multi-radius results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/RadiusResponse"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/match-close.{format}/{zip_codes}/{distance}/{units}": {
+      "get": {
+        "tags": ["Distance"],
+        "summary": "Find close ZIP code pairs",
+        "description": "Find pairs of ZIP codes from a list that are within a specified distance of each other.",
+        "operationId": "matchClose",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_codes",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of ZIP codes (max 100)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "distance",
+            "in": "path",
+            "required": true,
+            "description": "Maximum distance threshold",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Matched close pairs",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MatchCloseResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/info.{format}/{zip_code}/{units}": {
+      "get": {
+        "tags": ["Location"],
+        "summary": "ZIP code to location info",
+        "description": "Get city, state, latitude, longitude, timezone, and alternative city names for a ZIP code.",
+        "operationId": "getZipCodeInfo",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_code",
+            "in": "path",
+            "required": true,
+            "description": "5-digit US ZIP code",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "description": "Coordinate units",
+            "schema": {
+              "type": "string",
+              "enum": ["degrees", "radians"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP code location information",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ZipCodeInfo"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/multi-info.{format}/{zip_codes}/{units}": {
+      "get": {
+        "tags": ["Location"],
+        "summary": "Multiple ZIP codes to location info",
+        "description": "Get location information for up to 100 ZIP codes at once.",
+        "operationId": "getMultiZipCodeInfo",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "zip_codes",
+            "in": "path",
+            "required": true,
+            "description": "Comma-separated list of ZIP codes (max 100)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["degrees", "radians"]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Multiple ZIP code location results",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "$ref": "#/components/schemas/ZipCodeInfo"
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/city-zips.{format}/{city}/{state}": {
+      "get": {
+        "tags": ["City"],
+        "summary": "City/state to ZIP codes",
+        "description": "Get all ZIP codes for a given US city and state.",
+        "operationId": "getCityZipCodes",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "city",
+            "in": "path",
+            "required": true,
+            "description": "US city name",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "path",
+            "required": true,
+            "description": "Two-letter US state code",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ZIP codes for the city",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CityZipsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/state-zips.{format}/{state}": {
+      "get": {
+        "tags": ["City"],
+        "summary": "State to all ZIP codes",
+        "description": "Get all ZIP codes for a US state. Charged as multiple requests (every 10 ZIP codes = 1 request).",
+        "operationId": "getStateZipCodes",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "state",
+            "in": "path",
+            "required": true,
+            "description": "Two-letter US state code",
+            "schema": {
+              "type": "string",
+              "pattern": "^[A-Z]{2}$"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "All ZIP codes for the state",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CityZipsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    },
+    "/radius-sql.{format}/{lat}/{long}/{lat_long_units}/{distance}/{units}/{lat_field_name}/{long_field_name}/{precision}": {
+      "get": {
+        "tags": ["SQL"],
+        "summary": "Generate SQL WHERE clause for radius search",
+        "description": "Generate a SQL WHERE clause for finding records within a radius of given coordinates.",
+        "operationId": "getRadiusSql",
+        "parameters": [
+          {
+            "name": "format",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": ["json", "xml", "csv"]
+            }
+          },
+          {
+            "name": "lat",
+            "in": "path",
+            "required": true,
+            "description": "Center latitude",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "long",
+            "in": "path",
+            "required": true,
+            "description": "Center longitude",
+            "schema": {
+              "type": "number",
+              "format": "double"
+            }
+          },
+          {
+            "name": "lat_long_units",
+            "in": "path",
+            "required": true,
+            "description": "Coordinate units",
+            "schema": {
+              "type": "string",
+              "enum": ["degrees", "radians"]
+            }
+          },
+          {
+            "name": "distance",
+            "in": "path",
+            "required": true,
+            "description": "Radius distance",
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "name": "units",
+            "in": "path",
+            "required": true,
+            "description": "Distance units",
+            "schema": {
+              "type": "string",
+              "enum": ["km", "mile"]
+            }
+          },
+          {
+            "name": "lat_field_name",
+            "in": "path",
+            "required": true,
+            "description": "Name of the latitude field in your database",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "long_field_name",
+            "in": "path",
+            "required": true,
+            "description": "Name of the longitude field in your database",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "precision",
+            "in": "path",
+            "required": true,
+            "description": "Precision level (1-16, higher = more accurate but slower)",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 16
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SQL WHERE clause",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RadiusSqlResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ApiError"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "path",
+        "name": "api_key",
+        "description": "API key embedded in the URL path. Obtain from zipcodeapi.com. Use JavaScript client keys (js-*) for browser requests."
+      }
+    },
+    "schemas": {
+      "DistanceResponse": {
+        "type": "object",
+        "properties": {
+          "distance": {
+            "type": "number",
+            "format": "double",
+            "description": "Distance between the two ZIP codes"
+          }
+        }
+      },
+      "MultiDistanceResponse": {
+        "type": "object",
+        "properties": {
+          "distances": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "number",
+              "format": "double"
+            },
+            "description": "Map of ZIP code to distance"
+          }
+        }
+      },
+      "RadiusResponse": {
+        "type": "object",
+        "properties": {
+          "zip_codes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "zip_code": {
+                  "type": "string"
+                },
+                "distance": {
+                  "type": "number",
+                  "format": "double"
+                },
+                "city": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "MatchCloseResponse": {
+        "type": "object",
+        "properties": {
+          "zip_codes": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "zip_code1": {
+                  "type": "string"
+                },
+                "zip_code2": {
+                  "type": "string"
+                },
+                "distance": {
+                  "type": "number",
+                  "format": "double"
+                }
+              }
+            }
+          }
+        }
+      },
+      "ZipCodeInfo": {
+        "type": "object",
+        "properties": {
+          "zip_code": {
+            "type": "string",
+            "description": "5-digit ZIP code"
+          },
+          "lat": {
+            "type": "number",
+            "format": "double",
+            "description": "Latitude"
+          },
+          "lng": {
+            "type": "number",
+            "format": "double",
+            "description": "Longitude"
+          },
+          "city": {
+            "type": "string",
+            "description": "City name"
+          },
+          "state": {
+            "type": "string",
+            "description": "Two-letter state code"
+          },
+          "timezone": {
+            "type": "object",
+            "properties": {
+              "timezone_identifier": {
+                "type": "string"
+              },
+              "timezone_abbr": {
+                "type": "string"
+              },
+              "utc_offset_sec": {
+                "type": "integer"
+              },
+              "is_dst": {
+                "type": "string",
+                "enum": ["T", "F"]
+              }
+            }
+          },
+          "acceptable_city_names": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "city": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "CityZipsResponse": {
+        "type": "object",
+        "properties": {
+          "zip_codes": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "RadiusSqlResponse": {
+        "type": "object",
+        "properties": {
+          "sql_fragment": {
+            "type": "string",
+            "description": "SQL WHERE clause for use in database queries"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error_code": {
+            "type": "integer"
+          },
+          "error_msg": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "responses": {
+      "ApiError": {
+        "description": "API error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/apis/openapi/zipcodeapi.com/zipcodeapi/meta.json
+++ b/apis/openapi/zipcodeapi.com/zipcodeapi/meta.json
@@ -1,0 +1,10 @@
+{
+  "oak_meta": "1.0.0",
+  "api_info": {
+    "id": "d3dfe88301b19349ce1614d146d23923",
+    "format": "openapi",
+    "vendor": "zipcodeapi.com",
+    "api_name": "zipcodeapi",
+    "friendly_id": "zipcodeapi.com/zipcodeapi"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **50 OpenAPI specs** converted from the [public-apis](https://github.com/public-apis/public-apis) directory
- **Batch 005** covering: Games & Comics, Geocoding, Government

## APIs included

**Games & Comics (19):** Guild Wars 2, Halo, Hearthstone, Humor, Hypixel, IGDB, Lichess, Mario Kart Tour, Marvel, mod.io, Mojang, PandaScore, Path of Exile, PUBG, quizapi.io, Riot Games, SuperHeroes, Tebex, Wargaming.net

**Geocoding (26):** IPstack, ipapi.com, Apiip, CountryStateCity, Geocod.io, GeoDB Cities, HERE Maps, Hirak IP to Country, IP Geolocation (Abstract), ipgeolocation.io, IPInfoDB, Kakao Maps, keycdn IP Location, LocationIQ, Longdo Map, MapQuest, One Map Singapore, positionstack, RoadGoat Cities, SpotSense, Uebermaps, US ZipCode, Utah AGRC, Yandex Maps Geocoder, ZipCodeAPI, ipstack

**Government (5):** Code.gov, Gun Policy, National Park Service US, UK Companies House, USA.gov

## Notable specs
- **Lichess**: 170 endpoints from official OpenAPI spec
- **Hypixel**: 34 endpoints from embedded ReDoc spec
- **National Park Service**: 29 endpoints from official Swagger spec
- **UK Companies House**: 27 endpoints
- **Riot Games**: 24 endpoints across LoL/TFT/Valorant
- **Guild Wars 2**: 23 paths from live API
- **Longdo Map**: 17 endpoints for Thailand mapping

## Source
All APIs sourced from https://github.com/public-apis/public-apis