### PR TITLE
Spectral-lint clean 50 OpenAPI specs (batch 004)

### DIFF
--- a/apis/openapi/arena.fi/smartdialog-api/1.0.0/openapi.json
+++ b/apis/openapi/arena.fi/smartdialog-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "SmartDialog API",
     "description": "SmartDialog platform API for managing dialog and conversation flows",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://openapi.arena.fi/"
+    "x-jentic-source-url": "https://openapi.arena.fi/",
+    "contact": {}
   },
   "servers": [
     {
@@ -30,7 +31,9 @@
   "paths": {
     "/dialogs": {
       "get": {
-        "tags": ["Dialogs"],
+        "tags": [
+          "Dialogs"
+        ],
         "summary": "List dialogs",
         "description": "Retrieve all dialogs",
         "operationId": "listDialogs",
@@ -77,7 +80,9 @@
         }
       },
       "post": {
-        "tags": ["Dialogs"],
+        "tags": [
+          "Dialogs"
+        ],
         "summary": "Create dialog",
         "description": "Create a new dialog",
         "operationId": "createDialog",
@@ -87,7 +92,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -132,7 +139,9 @@
     },
     "/dialogs/{id}": {
       "get": {
-        "tags": ["Dialogs"],
+        "tags": [
+          "Dialogs"
+        ],
         "summary": "Get dialog",
         "description": "Retrieve a specific dialog by ID",
         "operationId": "getDialog",
@@ -172,7 +181,9 @@
     },
     "/conversations": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "List conversations",
         "description": "Retrieve all conversations",
         "operationId": "listConversations",
@@ -189,7 +200,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["active", "completed", "abandoned"]
+              "enum": [
+                "active",
+                "completed",
+                "abandoned"
+              ]
             }
           }
         ],
@@ -215,7 +230,9 @@
         }
       },
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Create conversation",
         "description": "Start a new conversation",
         "operationId": "createConversation",
@@ -225,7 +242,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["dialog_id"],
+                "required": [
+                  "dialog_id"
+                ],
                 "properties": {
                   "dialog_id": {
                     "type": "string"
@@ -303,7 +322,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "completed", "abandoned"]
+            "enum": [
+              "active",
+              "completed",
+              "abandoned"
+            ]
           },
           "context": {
             "type": "object"

--- a/apis/openapi/arespass.net/arespass.net/1.0/openapi.json
+++ b/apis/openapi/arespass.net/arespass.net/1.0/openapi.json
@@ -19,7 +19,8 @@
     "x-providerName": "arespass.net",
     "x-logo": {
       "url": "https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"
-    }
+    },
+    "contact": {}
   },
   "paths": {
     "/about": {
@@ -66,7 +67,12 @@
             "description": "**Unexpected server error.**                \n"
           }
         },
-        "summary": "Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n"
+        "summary": "Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n",
+        "tags": [
+          "about"
+        ],
+        "description": "Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n",
+        "operationId": "get-about"
       }
     },
     "/ec": {
@@ -140,7 +146,12 @@
             "description": "**Unexpected server error.**\n"
           }
         },
-        "summary": "The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n"
+        "summary": "The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n",
+        "tags": [
+          "ec"
+        ],
+        "description": "The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n",
+        "operationId": "get-ec"
       }
     }
   },
@@ -450,5 +461,13 @@
         "type": "object"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "about"
+    },
+    {
+      "name": "ec"
+    }
+  ]
 }

--- a/apis/openapi/arespass.net/arespass/1.0/openapi.json
+++ b/apis/openapi/arespass.net/arespass/1.0/openapi.json
@@ -1,1 +1,474 @@
-{"openapi":"3.0.0","servers":[{"url":"http://arespass.net/v1.0"}],"info":{"description":"Analyzes a password and calculates its entropy.","title":"Arespass","version":"1.0","x-origin":[{"format":"openapi","url":"https://arespass.net/assets/arespassv1.0-openapi.yaml","version":"3.0"}],"x-providerName":"arespass.net","x-logo":{"url":"https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"},"x-jentic-source-url":"https://api.apis.guru/v2/specs/arespass.net/1.0/openapi.yaml"},"paths":{"/about":{"get":{"parameters":[{"description":"**The format of the returned metadata.**\n\nAllowed values are *json*, *xml* and *yaml*.\n\nThe default value is *xml*.\n","in":"query","name":"outputFormat","required":false,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/about"}},"application/x-yaml":{"schema":{"$ref":"#/components/schemas/about"}},"application/xml":{"schema":{"$ref":"#/components/schemas/about"}}},"description":"**The metadata about this API&#58; version number, release date and available languages.**\n"},"400":{"description":"**At least one error was found in the request parameters.**\n"},"405":{"description":"**HTTP method POST is not allowed.**\n"},"500":{"description":"**Unexpected server error.**                \n"}},"summary":"Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n"}},"/ec":{"get":{"parameters":[{"description":"**The password to be analyzed.**\n\nMinimum length is 4 characters; maximum length is 128 characters.\n\nBeware that certain characters like '&#35;', '&#61;' or '&#63;' must be properly encoded.\n\nFor more information about this issue, please refer to RFC 3986 (\"*Uniform Resource Identifier (URI): Generic Syntax*\"), sections 2.1, 2.2 and 2.4.\n","in":"query","name":"password","required":true,"schema":{"type":"string"}},{"description":"**The format of the returned analysis.**\n\nAllowed values are *json*, *xml* and *yaml*.\n\nThe default value is *xml*.\n","in":"query","name":"outputFormat","required":false,"schema":{"type":"string"}},{"description":"**The penalty applied to each character that is part of a word, number sequence, alphabet sequence, etc.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n\nThe character used as decimal separator is always '&#46;'. Hence, a parameter value like *0,33* would be illegal.\n\nThe default value is *0.25*.\n","in":"query","name":"penalty","required":false,"schema":{"type":"number"}},{"description":"**An identifier for this request.**\n\nThe request identifier is a string that must match the regular expression */(?i)^[a-z0-9]{8,16}$/*.\n\nThis identifier is echoed in the returned response. Its value has no effect on the password analysis.\n\nIf this parameter is unset, a randomly generated identifier will be automatically assigned to this request.\n","in":"query","name":"reqId","required":false,"schema":{"type":"string"}}],"responses":{"200":{"content":{"application/json":{"schema":{"$ref":"#/components/schemas/ec"}},"application/x-yaml":{"schema":{"$ref":"#/components/schemas/ec"}},"application/xml":{"schema":{"$ref":"#/components/schemas/ec"}}},"description":"The password analysis, including the calculated entropy."},"400":{"description":"**At least one error was found in the request parameters.**\n"},"405":{"description":"**HTTP method POST is not allowed.**\n"},"500":{"description":"**Unexpected server error.**\n"}},"summary":"The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n"}}},"components":{"schemas":{"about":{"description":"**This API version number**.\n","properties":{"apiReleaseDateIso8601":{"description":"**The release date of this API, ISO 8601 format.**\n","type":"string"},"apiVersion":{"properties":{"majorNumber":{"description":"This API version major number.","type":"integer","xml":{"attribute":true}},"minorNumber":{"description":"This API version minor number.","type":"integer","xml":{"attribute":true}}},"type":"object"},"availableLanguagesIso639_1":{"description":"**The list of available languages.**\n\nEach language is identified by its ISO 639-1, two-letter code.\n\nThe list elements are comma-separated and sorted in ascending order.\n","type":"string"}},"type":"object"},"ec":{"properties":{"alphabetSequence":{"description":"**The penalty applied to each character that has been found to be part of an alphabet sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The penalty applied to this character if it is part of an alphabet sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"apiVersion":{"description":"**This API version number.**\n","type":"string"},"detectedKeyboard":{"description":"**The detected keyboard, QWERTY or Dvorak.**\n","type":"string"},"efficiency":{"description":"**The ratio entropy / idealEntropy.**\n\nIt is a float number in the range [0, 1].\n","type":"number"},"entropy":{"description":"**The entropy calculated for the input password.**\n\nIt is measured in bits.\n","type":"number"},"entropyDistribution":{"description":"**The distribution of the calculated entropy among the password characters.**\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"percentage":{"description":"The amount of entropy contributed by this character, expressed as percentage of the total.","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"idealEntropy":{"description":"**The Shannon entropy.**\n\nThe Shannon entropy is the entropy calculated if no penalizations - words, number sequence, alphabet sequence, etc - were found in the password.\n\nIt is measured in bits.\n","type":"number"},"keyboardSequence":{"description":"**The penalty applied to each character that has been found to be part of a keyboard sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The penalty applied to this character if it is part of a keyboard sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"l33tPassword":{"description":"The analyzed password after the l33t substitution.","type":"string"},"nonUniformEntropyDistributionPenalty":{"description":"**The penalty applied to the whole password because of irregular entropy distribution.**\n\nThis penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","type":"number"},"numberSequence":{"description":"**The penalty applied to each character that has been found to be part of a number sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The penalty applied to this character if it is part of a number sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"password":{"description":"The analyzed password.","type":"string"},"passwordLength":{"description":"The number of characters the password has.","type":"integer"},"penalty":{"description":"**The penalty applied to each character that has been found to be part of a word, number sequence, alphabet sequence, etc.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n\nIts value is equal to the value of the input parameter *penalty*.\n","type":"number"},"repeatedChars":{"description":"**The penalty applied to each character that are repeated**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.          \n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The penalty applied to this character if it is repeated.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"requestId":{"description":"**The identifier of the request that corresponds to this response.**\n","type":"string"},"requestTimestamp":{"description":"**The timestamp for this response.**\n\nMilliseconds from the epoch of 1970-01-01T00:00:00Z.\n","type":"number"},"summary":{"items":{"description":"**A human-readable summary of the password analysis.**\n\nThis human readable summary is not intended to be parsed.\n","type":"string"},"type":"array"},"total":{"description":"**The total penalty applied to each character.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The total penalty applied to each character.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.                \n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"},"words":{"description":"**The penalty applied to each character that has been found to be part of a word.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n","items":{"properties":{"char":{"description":"The n-th character.","type":"string","xml":{"attribute":true}},"l33tchar":{"description":"The n-th character after the l33t transformation.","type":"string","xml":{"attribute":true}},"penalty":{"description":"The penalty applied to this character if it is part of a word.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.                \n","type":"number","xml":{"attribute":true}}},"type":"object"},"type":"array"}},"type":"object"}}}}
+{
+  "openapi": "3.0.0",
+  "servers": [
+    {
+      "url": "http://arespass.net/v1.0"
+    }
+  ],
+  "info": {
+    "description": "Analyzes a password and calculates its entropy.",
+    "title": "Arespass",
+    "version": "1.0",
+    "x-origin": [
+      {
+        "format": "openapi",
+        "url": "https://arespass.net/assets/arespassv1.0-openapi.yaml",
+        "version": "3.0"
+      }
+    ],
+    "x-providerName": "arespass.net",
+    "x-logo": {
+      "url": "https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"
+    },
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/arespass.net/1.0/openapi.yaml",
+    "contact": {}
+  },
+  "paths": {
+    "/about": {
+      "get": {
+        "parameters": [
+          {
+            "description": "**The format of the returned metadata.**\n\nAllowed values are *json*, *xml* and *yaml*.\n\nThe default value is *xml*.\n",
+            "in": "query",
+            "name": "outputFormat",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/about"
+                }
+              },
+              "application/x-yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/about"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/about"
+                }
+              }
+            },
+            "description": "**The metadata about this API&#58; version number, release date and available languages.**\n"
+          },
+          "400": {
+            "description": "**At least one error was found in the request parameters.**\n"
+          },
+          "405": {
+            "description": "**HTTP method POST is not allowed.**\n"
+          },
+          "500": {
+            "description": "**Unexpected server error.**                \n"
+          }
+        },
+        "summary": "Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n",
+        "tags": [
+          "about"
+        ],
+        "description": "Metadata about this API&#58; version number, release date and available languages.\n\nMetadata requests are NOT billed.\n",
+        "operationId": "get-about"
+      }
+    },
+    "/ec": {
+      "get": {
+        "parameters": [
+          {
+            "description": "**The password to be analyzed.**\n\nMinimum length is 4 characters; maximum length is 128 characters.\n\nBeware that certain characters like '&#35;', '&#61;' or '&#63;' must be properly encoded.\n\nFor more information about this issue, please refer to RFC 3986 (\"*Uniform Resource Identifier (URI): Generic Syntax*\"), sections 2.1, 2.2 and 2.4.\n",
+            "in": "query",
+            "name": "password",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "**The format of the returned analysis.**\n\nAllowed values are *json*, *xml* and *yaml*.\n\nThe default value is *xml*.\n",
+            "in": "query",
+            "name": "outputFormat",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "**The penalty applied to each character that is part of a word, number sequence, alphabet sequence, etc.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n\nThe character used as decimal separator is always '&#46;'. Hence, a parameter value like *0,33* would be illegal.\n\nThe default value is *0.25*.\n",
+            "in": "query",
+            "name": "penalty",
+            "required": false,
+            "schema": {
+              "type": "number"
+            }
+          },
+          {
+            "description": "**An identifier for this request.**\n\nThe request identifier is a string that must match the regular expression */(?i)^[a-z0-9]{8,16}$/*.\n\nThis identifier is echoed in the returned response. Its value has no effect on the password analysis.\n\nIf this parameter is unset, a randomly generated identifier will be automatically assigned to this request.\n",
+            "in": "query",
+            "name": "reqId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ec"
+                }
+              },
+              "application/x-yaml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ec"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ec"
+                }
+              }
+            },
+            "description": "The password analysis, including the calculated entropy."
+          },
+          "400": {
+            "description": "**At least one error was found in the request parameters.**\n"
+          },
+          "405": {
+            "description": "**HTTP method POST is not allowed.**\n"
+          },
+          "500": {
+            "description": "**Unexpected server error.**\n"
+          }
+        },
+        "summary": "The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n",
+        "tags": [
+          "ec"
+        ],
+        "description": "The entropy calculator - alias ec -, analyzes a password and calculates its entropy.\n\nEntropy calculator requests are billed.\n",
+        "operationId": "get-ec"
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "about": {
+        "description": "**This API version number**.\n",
+        "properties": {
+          "apiReleaseDateIso8601": {
+            "description": "**The release date of this API, ISO 8601 format.**\n",
+            "type": "string"
+          },
+          "apiVersion": {
+            "properties": {
+              "majorNumber": {
+                "description": "This API version major number.",
+                "type": "integer",
+                "xml": {
+                  "attribute": true
+                }
+              },
+              "minorNumber": {
+                "description": "This API version minor number.",
+                "type": "integer",
+                "xml": {
+                  "attribute": true
+                }
+              }
+            },
+            "type": "object"
+          },
+          "availableLanguagesIso639_1": {
+            "description": "**The list of available languages.**\n\nEach language is identified by its ISO 639-1, two-letter code.\n\nThe list elements are comma-separated and sorted in ascending order.\n",
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ec": {
+        "properties": {
+          "alphabetSequence": {
+            "description": "**The penalty applied to each character that has been found to be part of an alphabet sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The penalty applied to this character if it is part of an alphabet sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "apiVersion": {
+            "description": "**This API version number.**\n",
+            "type": "string"
+          },
+          "detectedKeyboard": {
+            "description": "**The detected keyboard, QWERTY or Dvorak.**\n",
+            "type": "string"
+          },
+          "efficiency": {
+            "description": "**The ratio entropy / idealEntropy.**\n\nIt is a float number in the range [0, 1].\n",
+            "type": "number"
+          },
+          "entropy": {
+            "description": "**The entropy calculated for the input password.**\n\nIt is measured in bits.\n",
+            "type": "number"
+          },
+          "entropyDistribution": {
+            "description": "**The distribution of the calculated entropy among the password characters.**\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "percentage": {
+                  "description": "The amount of entropy contributed by this character, expressed as percentage of the total.",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "idealEntropy": {
+            "description": "**The Shannon entropy.**\n\nThe Shannon entropy is the entropy calculated if no penalizations - words, number sequence, alphabet sequence, etc - were found in the password.\n\nIt is measured in bits.\n",
+            "type": "number"
+          },
+          "keyboardSequence": {
+            "description": "**The penalty applied to each character that has been found to be part of a keyboard sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The penalty applied to this character if it is part of a keyboard sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "l33tPassword": {
+            "description": "The analyzed password after the l33t substitution.",
+            "type": "string"
+          },
+          "nonUniformEntropyDistributionPenalty": {
+            "description": "**The penalty applied to the whole password because of irregular entropy distribution.**\n\nThis penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "type": "number"
+          },
+          "numberSequence": {
+            "description": "**The penalty applied to each character that has been found to be part of a number sequence.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The penalty applied to this character if it is part of a number sequence.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "password": {
+            "description": "The analyzed password.",
+            "type": "string"
+          },
+          "passwordLength": {
+            "description": "The number of characters the password has.",
+            "type": "integer"
+          },
+          "penalty": {
+            "description": "**The penalty applied to each character that has been found to be part of a word, number sequence, alphabet sequence, etc.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n\nIts value is equal to the value of the input parameter *penalty*.\n",
+            "type": "number"
+          },
+          "repeatedChars": {
+            "description": "**The penalty applied to each character that are repeated**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.          \n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The penalty applied to this character if it is repeated.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "requestId": {
+            "description": "**The identifier of the request that corresponds to this response.**\n",
+            "type": "string"
+          },
+          "requestTimestamp": {
+            "description": "**The timestamp for this response.**\n\nMilliseconds from the epoch of 1970-01-01T00:00:00Z.\n",
+            "type": "number"
+          },
+          "summary": {
+            "items": {
+              "description": "**A human-readable summary of the password analysis.**\n\nThis human readable summary is not intended to be parsed.\n",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "total": {
+            "description": "**The total penalty applied to each character.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The total penalty applied to each character.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.                \n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "words": {
+            "description": "**The penalty applied to each character that has been found to be part of a word.**\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.\n",
+            "items": {
+              "properties": {
+                "char": {
+                  "description": "The n-th character.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "l33tchar": {
+                  "description": "The n-th character after the l33t transformation.",
+                  "type": "string",
+                  "xml": {
+                    "attribute": true
+                  }
+                },
+                "penalty": {
+                  "description": "The penalty applied to this character if it is part of a word.\n\nThe penalty is a float number in the range [0, 1]. Full penalty, 0; no penalty, 1.                \n",
+                  "type": "number",
+                  "xml": {
+                    "attribute": true
+                  }
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          }
+        },
+        "type": "object"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "about"
+    },
+    {
+      "name": "ec"
+    }
+  ]
+}

--- a/apis/openapi/arrangr.com/arrangr-api/1.0.0/openapi.json
+++ b/apis/openapi/arrangr.com/arrangr-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Arrangr API",
     "version": "1.0.0",
     "description": "Arrangr is a meeting scheduling platform. The API provides webhook management for meeting events including 1:1 meetings, event RSVPs, and poll responses.",
-    "x-jentic-source-url": "https://arrangr.com/pdfs/ArrangrAPIDocumentation.pdf"
+    "x-jentic-source-url": "https://arrangr.com/pdfs/ArrangrAPIDocumentation.pdf",
+    "contact": {}
   },
   "servers": [
     {
@@ -179,6 +180,11 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/artworker.io/artworker-api/2.0.0/openapi.json
+++ b/apis/openapi/artworker.io/artworker-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Artworker API",
     "version": "2.0.0",
     "description": "Artworker provides artwork management, proofing, and file processing APIs for print and packaging workflows.",
-    "x-jentic-source-url": "https://docs.artworker.io"
+    "x-jentic-source-url": "https://docs.artworker.io",
+    "contact": {}
   },
   "servers": [
     {
@@ -130,7 +131,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get job item details"
       }
     },
     "/v2/job-item/{id}/complete": {
@@ -182,7 +184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Mark a job item as complete"
       }
     },
     "/v2/job-item/{id}/archive": {
@@ -234,7 +237,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Archive a job item"
       }
     },
     "/v2/job-item/{id}/request-artwork": {
@@ -365,7 +369,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Import files to job item"
       }
     },
     "/v2/job-item/{id}/files/customUid/{customUid}": {
@@ -425,7 +430,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Archive file by custom UID"
       }
     },
     "/v1/webhook_endpoint": {
@@ -486,7 +492,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create webhook endpoint"
       },
       "get": {
         "operationId": "listWebhookEndpoints",
@@ -538,7 +545,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all webhook endpoints"
       }
     },
     "/v1/webhook_endpoint/{id}": {
@@ -597,7 +605,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get webhook endpoint"
       },
       "post": {
         "operationId": "updateWebhookEndpoint",
@@ -657,7 +666,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update webhook endpoint"
       },
       "delete": {
         "operationId": "deleteWebhookEndpoint",
@@ -707,7 +717,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete webhook endpoint"
       }
     },
     "/v1/taskapi/workflows": {
@@ -768,7 +779,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a workflow with tasks"
       }
     },
     "/v1/taskapi/workflows/{workflowId}": {
@@ -827,7 +839,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get workflow status"
       }
     },
     "/v1/taskapi/workflows/{workflowId}/task/{taskName}": {
@@ -894,7 +907,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get specific task details"
       }
     },
     "/v1/taskapi/workflows/{workflowId}/task/{taskName}/files": {
@@ -964,7 +978,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List files from a task"
       }
     },
     "/v1/taskapi/workflows/{workflowId}/task/{taskName}/files/{fileNum}": {
@@ -1032,7 +1047,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific file"
       }
     },
     "/v1/taskapi/workflows/{workflowId}/task/{taskName}/files/{fileNum}/pages": {
@@ -1110,7 +1126,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List pages for a file"
       }
     },
     "/v1/taskapi/workflows/{workflowId}/task/{taskName}/files/{fileNum}/pages/{pageNum}": {
@@ -1186,7 +1203,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific page"
       }
     }
   },
@@ -1342,6 +1360,17 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Jobs"
+    },
+    {
+      "name": "Task API"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/arubanetworks.com/arubanetworks/1.0.0/openapi.json
+++ b/apis/openapi/arubanetworks.com/arubanetworks/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "HPE Aruba Networking Central API",
     "description": "REST API for managing HPE Aruba Networking Central cloud platform. Supports device management, monitoring, configuration, guest access, and analytics for wireless and wired networks.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developer.arubanetworks.com/central/docs/rest-api-getting-started"
+    "x-jentic-source-url": "https://developer.arubanetworks.com/central/docs/rest-api-getting-started",
+    "contact": {}
   },
   "servers": [
     {
@@ -31,7 +32,9 @@
         "summary": "User authentication",
         "description": "Login using user credentials to get valid session and CSRF token from HPE Aruba Networking Central",
         "operationId": "login",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -39,7 +42,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["username", "password"],
+                "required": [
+                  "username",
+                  "password"
+                ],
                 "properties": {
                   "username": {
                     "type": "string",
@@ -97,7 +103,9 @@
         "summary": "Generate authorization code",
         "description": "Generate authorization code for OAuth 2.0 flow",
         "operationId": "authorizeCode",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [],
         "parameters": [
           {
@@ -125,7 +133,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["client_id", "response_type"],
+                "required": [
+                  "client_id",
+                  "response_type"
+                ],
                 "properties": {
                   "client_id": {
                     "type": "string",
@@ -133,12 +144,17 @@
                   },
                   "response_type": {
                     "type": "string",
-                    "enum": ["code"],
+                    "enum": [
+                      "code"
+                    ],
                     "description": "OAuth response type"
                   },
                   "scope": {
                     "type": "string",
-                    "enum": ["read", "all"],
+                    "enum": [
+                      "read",
+                      "all"
+                    ],
                     "description": "Access scope"
                   }
                 }
@@ -171,7 +187,9 @@
         "summary": "Get or refresh access token",
         "description": "Obtain access token using authorization code or refresh token",
         "operationId": "getToken",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -181,7 +199,12 @@
                 "oneOf": [
                   {
                     "type": "object",
-                    "required": ["client_id", "client_secret", "grant_type", "code"],
+                    "required": [
+                      "client_id",
+                      "client_secret",
+                      "grant_type",
+                      "code"
+                    ],
                     "properties": {
                       "client_id": {
                         "type": "string"
@@ -191,7 +214,9 @@
                       },
                       "grant_type": {
                         "type": "string",
-                        "enum": ["authorization_code"]
+                        "enum": [
+                          "authorization_code"
+                        ]
                       },
                       "code": {
                         "type": "string",
@@ -201,7 +226,12 @@
                   },
                   {
                     "type": "object",
-                    "required": ["client_id", "client_secret", "grant_type", "refresh_token"],
+                    "required": [
+                      "client_id",
+                      "client_secret",
+                      "grant_type",
+                      "refresh_token"
+                    ],
                     "properties": {
                       "client_id": {
                         "type": "string"
@@ -211,7 +241,9 @@
                       },
                       "grant_type": {
                         "type": "string",
-                        "enum": ["refresh_token"]
+                        "enum": [
+                          "refresh_token"
+                        ]
                       },
                       "refresh_token": {
                         "type": "string",
@@ -257,7 +289,9 @@
         "summary": "List all networks",
         "description": "Retrieve list of all networks in Aruba Central",
         "operationId": "listNetworks",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "responses": {
           "200": {
             "description": "List of networks",
@@ -288,7 +322,9 @@
         "summary": "List access points",
         "description": "Retrieve wireless access point information",
         "operationId": "listAccessPoints",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -342,7 +378,9 @@
         "summary": "List connected clients",
         "description": "Retrieve connected wireless and wired device details",
         "operationId": "listClients",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "parameters": [
           {
             "name": "limit",
@@ -389,7 +427,9 @@
         "summary": "List switches",
         "description": "Retrieve managed network switches",
         "operationId": "listSwitches",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "responses": {
           "200": {
             "description": "List of switches",
@@ -420,7 +460,9 @@
         "summary": "List gateways",
         "description": "Access gateway device information",
         "operationId": "listGateways",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "responses": {
           "200": {
             "description": "List of gateways",
@@ -451,7 +493,9 @@
         "summary": "List labels",
         "description": "Retrieve organizational groupings",
         "operationId": "listLabels",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "responses": {
           "200": {
             "description": "List of labels",
@@ -482,7 +526,9 @@
         "summary": "List sites",
         "description": "Retrieve site/location data",
         "operationId": "listSites",
-        "tags": ["Monitoring"],
+        "tags": [
+          "Monitoring"
+        ],
         "responses": {
           "200": {
             "description": "List of sites",
@@ -513,7 +559,9 @@
         "summary": "List groups",
         "description": "Retrieve device groupings",
         "operationId": "listGroups",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "responses": {
           "200": {
             "description": "List of groups",
@@ -542,7 +590,9 @@
         "summary": "Create group",
         "description": "Create a new device group",
         "operationId": "createGroup",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -575,7 +625,9 @@
         "summary": "List templates",
         "description": "Retrieve configuration templates",
         "operationId": "listTemplates",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "responses": {
           "200": {
             "description": "List of templates",
@@ -604,7 +656,9 @@
         "summary": "Create template",
         "description": "Create a new configuration template",
         "operationId": "createTemplate",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -637,7 +691,9 @@
         "summary": "List WLANs",
         "description": "Retrieve wireless network configurations",
         "operationId": "listWLANs",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "responses": {
           "200": {
             "description": "List of WLANs",
@@ -666,7 +722,9 @@
         "summary": "Create WLAN",
         "description": "Create a new wireless network",
         "operationId": "createWLAN",
-        "tags": ["Configuration"],
+        "tags": [
+          "Configuration"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -699,7 +757,9 @@
         "summary": "List devices",
         "description": "Retrieve device inventory",
         "operationId": "listDevices",
-        "tags": ["Device Management"],
+        "tags": [
+          "Device Management"
+        ],
         "responses": {
           "200": {
             "description": "List of devices",
@@ -728,7 +788,9 @@
         "summary": "Add device",
         "description": "Add device to inventory",
         "operationId": "addDevice",
-        "tags": ["Device Management"],
+        "tags": [
+          "Device Management"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -761,14 +823,19 @@
         "summary": "Upgrade firmware",
         "description": "Update device firmware versions",
         "operationId": "upgradeFirmware",
-        "tags": ["Device Management"],
+        "tags": [
+          "Device Management"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["device_id", "firmware_version"],
+                "required": [
+                  "device_id",
+                  "firmware_version"
+                ],
                 "properties": {
                   "device_id": {
                     "type": "string"
@@ -811,7 +878,9 @@
         "summary": "List guest portals",
         "description": "Retrieve guest access portal configurations",
         "operationId": "listPortals",
-        "tags": ["Guest Management"],
+        "tags": [
+          "Guest Management"
+        ],
         "responses": {
           "200": {
             "description": "List of portals",
@@ -840,7 +909,9 @@
         "summary": "Create guest portal",
         "description": "Create a new guest access portal",
         "operationId": "createPortal",
-        "tags": ["Guest Management"],
+        "tags": [
+          "Guest Management"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -873,7 +944,9 @@
         "summary": "List visitors",
         "description": "Retrieve guest user accounts",
         "operationId": "listVisitors",
-        "tags": ["Guest Management"],
+        "tags": [
+          "Guest Management"
+        ],
         "responses": {
           "200": {
             "description": "List of visitors",
@@ -902,7 +975,9 @@
         "summary": "Create visitor",
         "description": "Create a new guest user account",
         "operationId": "createVisitor",
-        "tags": ["Guest Management"],
+        "tags": [
+          "Guest Management"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -935,7 +1010,9 @@
         "summary": "List guest sessions",
         "description": "Track guest connectivity sessions",
         "operationId": "listSessions",
-        "tags": ["Guest Management"],
+        "tags": [
+          "Guest Management"
+        ],
         "responses": {
           "200": {
             "description": "List of sessions",
@@ -966,7 +1043,9 @@
         "summary": "Get audit logs",
         "description": "Retrieve system activity records",
         "operationId": "getAuditLogs",
-        "tags": ["Audit"],
+        "tags": [
+          "Audit"
+        ],
         "parameters": [
           {
             "name": "start_time",
@@ -1098,7 +1177,10 @@
           },
           "connection_type": {
             "type": "string",
-            "enum": ["wireless", "wired"]
+            "enum": [
+              "wireless",
+              "wired"
+            ]
           }
         }
       },
@@ -1180,7 +1262,9 @@
       },
       "GroupInput": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1209,7 +1293,11 @@
       },
       "TemplateInput": {
         "type": "object",
-        "required": ["name", "device_type", "template"],
+        "required": [
+          "name",
+          "device_type",
+          "template"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1241,7 +1329,10 @@
       },
       "WLANInput": {
         "type": "object",
-        "required": ["essid", "type"],
+        "required": [
+          "essid",
+          "type"
+        ],
         "properties": {
           "essid": {
             "type": "string"
@@ -1273,7 +1364,10 @@
       },
       "DeviceInput": {
         "type": "object",
-        "required": ["serial", "mac_address"],
+        "required": [
+          "serial",
+          "mac_address"
+        ],
         "properties": {
           "serial": {
             "type": "string"
@@ -1299,7 +1393,10 @@
       },
       "PortalInput": {
         "type": "object",
-        "required": ["name", "auth_type"],
+        "required": [
+          "name",
+          "auth_type"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1328,7 +1425,10 @@
       },
       "VisitorInput": {
         "type": "object",
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1396,5 +1496,25 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Audit"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Configuration"
+    },
+    {
+      "name": "Device Management"
+    },
+    {
+      "name": "Guest Management"
+    },
+    {
+      "name": "Monitoring"
+    }
+  ]
 }

--- a/apis/openapi/askneo.io/api/1.0.0/openapi.json
+++ b/apis/openapi/askneo.io/api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "AskNeo API",
     "version": "1.0.0",
     "description": "AI-powered assistant and knowledge management API",
-    "x-jentic-source-url": "https://app.askneo.io/docs/api"
+    "x-jentic-source-url": "https://app.askneo.io/docs/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -30,7 +31,9 @@
   "paths": {
     "/query": {
       "post": {
-        "tags": ["Queries"],
+        "tags": [
+          "Queries"
+        ],
         "summary": "Submit query",
         "description": "Submit a query to the AI assistant",
         "operationId": "submitQuery",
@@ -66,7 +69,9 @@
     },
     "/conversations": {
       "get": {
-        "tags": ["Queries"],
+        "tags": [
+          "Queries"
+        ],
         "summary": "List conversations",
         "description": "Retrieve list of conversations",
         "operationId": "listConversations",
@@ -105,7 +110,9 @@
         }
       },
       "post": {
-        "tags": ["Queries"],
+        "tags": [
+          "Queries"
+        ],
         "summary": "Create conversation",
         "description": "Start a new conversation",
         "operationId": "createConversation",
@@ -141,7 +148,9 @@
     },
     "/conversations/{conversationId}": {
       "get": {
-        "tags": ["Queries"],
+        "tags": [
+          "Queries"
+        ],
         "summary": "Get conversation",
         "description": "Retrieve conversation details and history",
         "operationId": "getConversation",
@@ -177,7 +186,9 @@
     },
     "/knowledge": {
       "get": {
-        "tags": ["Knowledge Base"],
+        "tags": [
+          "Knowledge Base"
+        ],
         "summary": "List knowledge items",
         "description": "Retrieve knowledge base items",
         "operationId": "listKnowledge",
@@ -224,7 +235,9 @@
         }
       },
       "post": {
-        "tags": ["Knowledge Base"],
+        "tags": [
+          "Knowledge Base"
+        ],
         "summary": "Add knowledge item",
         "description": "Add a new item to the knowledge base",
         "operationId": "addKnowledge",
@@ -260,7 +273,9 @@
     },
     "/knowledge/{knowledgeId}": {
       "get": {
-        "tags": ["Knowledge Base"],
+        "tags": [
+          "Knowledge Base"
+        ],
         "summary": "Get knowledge item",
         "description": "Retrieve specific knowledge item",
         "operationId": "getKnowledge",
@@ -294,7 +309,9 @@
         }
       },
       "delete": {
-        "tags": ["Knowledge Base"],
+        "tags": [
+          "Knowledge Base"
+        ],
         "summary": "Delete knowledge item",
         "description": "Remove item from knowledge base",
         "operationId": "deleteKnowledge",
@@ -333,7 +350,9 @@
     "schemas": {
       "QueryRequest": {
         "type": "object",
-        "required": ["query"],
+        "required": [
+          "query"
+        ],
         "properties": {
           "query": {
             "type": "string",
@@ -404,7 +423,10 @@
               "properties": {
                 "role": {
                   "type": "string",
-                  "enum": ["user", "assistant"]
+                  "enum": [
+                    "user",
+                    "assistant"
+                  ]
                 },
                 "content": {
                   "type": "string"
@@ -498,7 +520,10 @@
       },
       "AddKnowledgeRequest": {
         "type": "object",
-        "required": ["title", "content"],
+        "required": [
+          "title",
+          "content"
+        ],
         "properties": {
           "title": {
             "type": "string"

--- a/apis/openapi/assembly.com/assembly/1.0.0/openapi.json
+++ b/apis/openapi/assembly.com/assembly/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Assembly API",
     "description": "Assembly is a client portal and collaboration platform that enables teams to work with clients, share files, manage tasks, and handle billing.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://docs.assembly.com"
+    "x-jentic-source-url": "https://docs.assembly.com",
+    "contact": {}
   },
   "servers": [
     {
@@ -22,7 +23,9 @@
       "get": {
         "summary": "List all clients",
         "operationId": "listClients",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -54,12 +57,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List all clients"
       },
       "post": {
         "summary": "Create a new client",
         "operationId": "createClient",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -101,14 +107,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a new client"
       }
     },
     "/clients/{id}": {
       "get": {
         "summary": "Retrieve specific client details",
         "operationId": "getClient",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -151,12 +160,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve specific client details"
       },
       "patch": {
         "summary": "Update client information",
         "operationId": "updateClient",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -209,12 +221,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Update client information"
       },
       "delete": {
         "summary": "Remove a client",
         "operationId": "deleteClient",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -262,14 +277,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove a client"
       }
     },
     "/companies": {
       "get": {
         "summary": "List all companies",
         "operationId": "listCompanies",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -301,12 +319,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List all companies"
       },
       "post": {
         "summary": "Create a new company",
         "operationId": "createCompany",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -348,14 +369,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a new company"
       }
     },
     "/companies/{id}": {
       "get": {
         "summary": "Retrieve company details",
         "operationId": "getCompany",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -398,12 +422,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve company details"
       },
       "patch": {
         "summary": "Update company information",
         "operationId": "updateCompany",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -456,12 +483,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Update company information"
       },
       "delete": {
         "summary": "Remove a company",
         "operationId": "deleteCompany",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -509,14 +539,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove a company"
       }
     },
     "/internal-users": {
       "get": {
         "summary": "List internal users",
         "operationId": "listInternalUsers",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -548,14 +581,17 @@
               }
             }
           }
-        }
+        },
+        "description": "List internal users"
       }
     },
     "/internal-users/{id}": {
       "get": {
         "summary": "Retrieve internal user",
         "operationId": "getInternalUser",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -598,14 +634,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve internal user"
       }
     },
     "/workspaces/{id}": {
       "get": {
         "summary": "Retrieve workspace details",
         "operationId": "getWorkspace",
-        "tags": ["Workspaces"],
+        "tags": [
+          "Workspaces"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -648,14 +687,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve workspace details"
       }
     },
     "/notes": {
       "get": {
         "summary": "List notes",
         "operationId": "listNotes",
-        "tags": ["CRM"],
+        "tags": [
+          "CRM"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -687,12 +729,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List notes"
       },
       "post": {
         "summary": "Create a note",
         "operationId": "createNote",
-        "tags": ["CRM"],
+        "tags": [
+          "CRM"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -734,14 +779,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a note"
       }
     },
     "/notes/{id}": {
       "get": {
         "summary": "Retrieve note",
         "operationId": "getNote",
-        "tags": ["CRM"],
+        "tags": [
+          "CRM"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -784,12 +832,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve note"
       },
       "patch": {
         "summary": "Update note",
         "operationId": "updateNote",
-        "tags": ["CRM"],
+        "tags": [
+          "CRM"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -842,12 +893,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Update note"
       },
       "delete": {
         "summary": "Remove note",
         "operationId": "deleteNote",
-        "tags": ["CRM"],
+        "tags": [
+          "CRM"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -895,14 +949,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove note"
       }
     },
     "/tasks": {
       "get": {
         "summary": "List tasks",
         "operationId": "listTasks",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -934,12 +991,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List tasks"
       },
       "post": {
         "summary": "Create task",
         "operationId": "createTask",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -981,14 +1041,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create task"
       }
     },
     "/tasks/{id}": {
       "get": {
         "summary": "Retrieve task",
         "operationId": "getTask",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1031,12 +1094,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve task"
       },
       "patch": {
         "summary": "Update task",
         "operationId": "updateTask",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1089,12 +1155,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Update task"
       },
       "delete": {
         "summary": "Delete task",
         "operationId": "deleteTask",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1142,14 +1211,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete task"
       }
     },
     "/files": {
       "get": {
         "summary": "List files",
         "operationId": "listFiles",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -1181,12 +1253,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List files"
       },
       "post": {
         "summary": "Create/upload file",
         "operationId": "createFile",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1228,14 +1303,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/upload file"
       }
     },
     "/files/{id}": {
       "get": {
         "summary": "Retrieve file",
         "operationId": "getFile",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1278,12 +1356,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve file"
       },
       "delete": {
         "summary": "Delete file",
         "operationId": "deleteFile",
-        "tags": ["Files"],
+        "tags": [
+          "Files"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1331,14 +1412,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete file"
       }
     },
     "/invoices": {
       "get": {
         "summary": "List invoices",
         "operationId": "listInvoices",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -1370,12 +1454,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List invoices"
       },
       "post": {
         "summary": "Create invoice",
         "operationId": "createInvoice",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1417,14 +1504,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create invoice"
       }
     },
     "/invoices/{id}": {
       "get": {
         "summary": "Retrieve invoice",
         "operationId": "getInvoice",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1467,14 +1557,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve invoice"
       }
     },
     "/subscriptions": {
       "get": {
         "summary": "List subscriptions",
         "operationId": "listSubscriptions",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -1506,12 +1599,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions"
       },
       "post": {
         "summary": "Create subscription",
         "operationId": "createSubscription",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1553,14 +1649,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Create subscription"
       }
     },
     "/subscriptions/{id}": {
       "get": {
         "summary": "Retrieve subscription",
         "operationId": "getSubscription",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1603,14 +1702,17 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve subscription"
       }
     },
     "/subscriptions/{id}/cancel": {
       "post": {
         "summary": "Cancel subscription",
         "operationId": "cancelSubscription",
-        "tags": ["Billing"],
+        "tags": [
+          "Billing"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1653,7 +1755,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel subscription"
       }
     }
   },

--- a/apis/openapi/assetpanda.com/panda-api/1.0.0/openapi.json
+++ b/apis/openapi/assetpanda.com/panda-api/1.0.0/openapi.json
@@ -21,12 +21,14 @@
     }
   ],
   "paths": {
-    "/api/1.0/user/schema/": {
+    "/api/1.0/user/schema": {
       "get": {
         "summary": "Get User Schema",
         "description": "Returns the schema definition for user objects",
         "operationId": "getUserSchema",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -41,12 +43,14 @@
         }
       }
     },
-    "/api/1.0/user/": {
+    "/api/1.0/user": {
       "get": {
         "summary": "List Users",
         "description": "Returns a list of all users",
         "operationId": "listUsers",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -75,14 +79,20 @@
         "summary": "Create User",
         "description": "Creates a new user",
         "operationId": "createUser",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email", "first_name", "last_name"],
+                "required": [
+                  "email",
+                  "first_name",
+                  "last_name"
+                ],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -113,12 +123,14 @@
         }
       }
     },
-    "/api/1.0/user/{id}/": {
+    "/api/1.0/user/{id}": {
       "get": {
         "summary": "Get User",
         "description": "Fetches a single user by ID",
         "operationId": "getUser",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -146,7 +158,9 @@
         "summary": "Update User",
         "description": "Updates a user",
         "operationId": "updateUser",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -194,12 +208,14 @@
         }
       }
     },
-    "/api/1.0/task/schema/": {
+    "/api/1.0/task/schema": {
       "get": {
         "summary": "Get Task Schema",
         "description": "Returns the schema definition for task objects",
         "operationId": "getTaskSchema",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -214,19 +230,28 @@
         }
       }
     },
-    "/api/1.0/task/": {
+    "/api/1.0/task": {
       "get": {
         "summary": "List Tasks",
         "description": "Returns a list of tasks with optional filtering by status or date",
         "operationId": "listTasks",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
           {
             "name": "status",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORT REQUESTED", "ABORTED"]
+              "enum": [
+                "PENDING",
+                "STARTED",
+                "SUCCESS",
+                "FAILURE",
+                "ABORT REQUESTED",
+                "ABORTED"
+              ]
             }
           },
           {
@@ -276,12 +301,14 @@
         }
       }
     },
-    "/api/1.0/task/{id}/": {
+    "/api/1.0/task/{id}": {
       "get": {
         "summary": "Get Task",
         "description": "Fetches a single task by ID",
         "operationId": "getTask",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -306,12 +333,14 @@
         }
       }
     },
-    "/api/1.0/dataset/schema/": {
+    "/api/1.0/dataset/schema": {
       "get": {
         "summary": "Get Dataset Schema",
         "description": "Returns the schema definition for dataset objects",
         "operationId": "getDatasetSchema",
-        "tags": ["Datasets"],
+        "tags": [
+          "Datasets"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -326,12 +355,14 @@
         }
       }
     },
-    "/api/1.0/dataset/": {
+    "/api/1.0/dataset": {
       "get": {
         "summary": "List Datasets",
         "description": "Returns a list of datasets with optional filtering",
         "operationId": "listDatasets",
-        "tags": ["Datasets"],
+        "tags": [
+          "Datasets"
+        ],
         "parameters": [
           {
             "name": "category",
@@ -395,14 +426,19 @@
         "summary": "Create Dataset",
         "description": "Creates a new dataset",
         "operationId": "createDataset",
-        "tags": ["Datasets"],
+        "tags": [
+          "Datasets"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["title", "description"],
+                "required": [
+                  "title",
+                  "description"
+                ],
                 "properties": {
                   "title": {
                     "type": "string"
@@ -429,12 +465,14 @@
         }
       }
     },
-    "/api/1.0/dataset/{slug}/": {
+    "/api/1.0/dataset/{slug}": {
       "get": {
         "summary": "Get Dataset",
         "description": "Fetches a single dataset by slug",
         "operationId": "getDataset",
-        "tags": ["Datasets"],
+        "tags": [
+          "Datasets"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -459,12 +497,14 @@
         }
       }
     },
-    "/api/1.0/dataset/{slug}/data/": {
+    "/api/1.0/dataset/{slug}/data": {
       "get": {
         "summary": "List Dataset Data",
         "description": "Returns data records from a dataset",
         "operationId": "listDatasetData",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -533,7 +573,9 @@
         "summary": "Create Dataset Record",
         "description": "Creates or updates a single data record",
         "operationId": "createDatasetRecord",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -571,7 +613,9 @@
         "summary": "Bulk Update Dataset Records",
         "description": "Creates or updates multiple data records",
         "operationId": "bulkUpdateDatasetRecords",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -588,7 +632,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["objects"],
+                "required": [
+                  "objects"
+                ],
                 "properties": {
                   "objects": {
                     "type": "array",
@@ -611,7 +657,9 @@
         "summary": "Delete All Dataset Data",
         "description": "Deletes all data records from a dataset",
         "operationId": "deleteAllDatasetData",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -629,12 +677,14 @@
         }
       }
     },
-    "/api/1.0/dataset/{slug}/data/{external_id}/": {
+    "/api/1.0/dataset/{slug}/data/{external_id}": {
       "get": {
         "summary": "Get Dataset Record",
         "description": "Fetches a single data record by external ID",
         "operationId": "getDatasetRecord",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -670,7 +720,9 @@
         "summary": "Update Dataset Record",
         "description": "Updates a single data record",
         "operationId": "updateDatasetRecord",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -709,7 +761,9 @@
         "summary": "Delete Dataset Record",
         "description": "Deletes a single data record",
         "operationId": "deleteDatasetRecord",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -735,12 +789,14 @@
         }
       }
     },
-    "/api/1.0/category/schema/": {
+    "/api/1.0/category/schema": {
       "get": {
         "summary": "Get Category Schema",
         "description": "Returns the schema definition for category objects",
         "operationId": "getCategorySchema",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -755,12 +811,14 @@
         }
       }
     },
-    "/api/1.0/category/": {
+    "/api/1.0/category": {
       "get": {
         "summary": "List Categories",
         "description": "Returns a list of all categories including 'Uncategorized'",
         "operationId": "listCategories",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -786,12 +844,14 @@
         }
       }
     },
-    "/api/1.0/category/{slug}/": {
+    "/api/1.0/category/{slug}": {
       "get": {
         "summary": "Get Category",
         "description": "Fetches a single category by slug",
         "operationId": "getCategory",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "parameters": [
           {
             "name": "slug",
@@ -859,7 +919,14 @@
           },
           "status": {
             "type": "string",
-            "enum": ["PENDING", "STARTED", "SUCCESS", "FAILURE", "ABORT REQUESTED", "ABORTED"]
+            "enum": [
+              "PENDING",
+              "STARTED",
+              "SUCCESS",
+              "FAILURE",
+              "ABORT REQUESTED",
+              "ABORTED"
+            ]
           },
           "end": {
             "type": "string",
@@ -922,5 +989,22 @@
         "description": "API authentication requires email and api_key parameters. Also provide format=json parameter. Alternatively, use PANDA_EMAIL and PANDA_API_KEY headers."
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Categories"
+    },
+    {
+      "name": "Data"
+    },
+    {
+      "name": "Datasets"
+    },
+    {
+      "name": "Tasks"
+    },
+    {
+      "name": "Users"
+    }
+  ]
 }

--- a/apis/openapi/atlassian.com/fisheye-rest-api/1.0.0/openapi.json
+++ b/apis/openapi/atlassian.com/fisheye-rest-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "FishEye REST API",
     "version": "1.0.0",
     "description": "Atlassian FishEye REST API for querying repositories, changesets, revision data, and searching code across repositories.",
-    "x-jentic-source-url": "https://docs.atlassian.com/fisheye-crucible/latest_backup/wadl/fisheye.wadl"
+    "x-jentic-source-url": "https://docs.atlassian.com/fisheye-crucible/latest_backup/wadl/fisheye.wadl",
+    "contact": {}
   },
   "servers": [
     {
@@ -98,7 +99,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get repository info"
       }
     },
     "/rest-service-fe/changeset-v1/listChangesets": {
@@ -184,7 +186,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List changesets matching criteria"
       }
     },
     "/rest-service-fe/revisionData-v1/changesetList/{repository}": {
@@ -263,7 +266,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get changeset list for repository"
       }
     },
     "/rest-service-fe/revisionData-v1/pathList/{repository}": {
@@ -321,7 +325,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List files/directories in a path"
       }
     },
     "/rest-service-fe/revisionData-v1/revisionInfo/{repository}": {
@@ -386,7 +391,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get file revision information"
       }
     },
     "/rest-service-fe/revisionData-v1/revisionTags/{repository}": {
@@ -451,7 +457,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List tags for a file revision"
       }
     },
     "/rest-service-fe/revisionData-v1/pathHistory/{repository}": {
@@ -509,7 +516,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get file revision history"
       }
     },
     "/rest-service-fe/revisionData-v1/changeset/{repository}/{csid}": {
@@ -568,7 +576,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get specific changeset details"
       }
     },
     "/rest-service-fe/commit-graph-v1/slice/{repository}": {
@@ -649,7 +658,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Find slice data for commit graph"
       }
     },
     "/rest-service-fe/commit-graph-v1/details/{repository}": {
@@ -700,7 +710,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get detailed changeset information"
       }
     },
     "/rest-service-fe/search-v1/query/{repository}": {
@@ -766,7 +777,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Execute FishEye query on repository"
       }
     },
     "/rest-service-fe/search-v1/crossRepositoryQuery": {
@@ -831,7 +843,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search across repositories"
       }
     },
     "/rest-service-fe/search-v1/queryAsRows/{repository}": {
@@ -897,7 +910,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Execute FishEye query with return statement"
       }
     },
     "/rest-service-fe/search-v1/reviewsForChangeset/{repository}": {
@@ -957,7 +971,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get reviews for a changeset"
       }
     },
     "/rest-service-fe/search-v1/reviewsForChangesets/{repository}": {
@@ -1017,7 +1032,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get reviews for multiple changesets"
       }
     }
   },
@@ -1049,6 +1065,23 @@
   "security": [
     {
       "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Changesets"
+    },
+    {
+      "name": "Commit Graph"
+    },
+    {
+      "name": "Repositories"
+    },
+    {
+      "name": "Revision Data"
+    },
+    {
+      "name": "Search"
     }
   ]
 }

--- a/apis/openapi/audiomack.com/audiomack/1.0.0/openapi.json
+++ b/apis/openapi/audiomack.com/audiomack/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Audiomack API",
     "version": "1.0.0",
     "description": "API for Audiomack, a music streaming and discovery platform. Provides access to songs, albums, playlists, artists, and trending content.",
-    "x-jentic-source-url": "https://www.audiomack.com/data-api/docs"
+    "x-jentic-source-url": "https://www.audiomack.com/data-api/docs",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,32 +18,50 @@
         "operationId": "searchMusic",
         "summary": "Search for music",
         "description": "Search for songs, albums, and playlists on Audiomack",
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "parameters": [
           {
             "name": "q",
             "in": "query",
             "required": true,
             "description": "Search query string",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "type",
             "in": "query",
             "description": "Type of content to search for",
-            "schema": { "type": "string", "enum": ["song", "album", "playlist", "artist"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "song",
+                "album",
+                "playlist",
+                "artist"
+              ]
+            }
           },
           {
             "name": "page",
             "in": "query",
             "description": "Page number for pagination",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "Number of results per page",
-            "schema": { "type": "integer", "default": 20 }
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
           }
         ],
         "responses": {
@@ -50,12 +69,32 @@
             "description": "Search results",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SearchResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "429": { "description": "Rate limit exceeded", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Rate limit exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -64,23 +103,37 @@
         "operationId": "getSong",
         "summary": "Get song details",
         "description": "Retrieve details for a specific song by its URL slug",
-        "tags": ["Music"],
+        "tags": [
+          "Music"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the song (artist-slug/song-slug)",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Song details",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Song" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Song"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Song not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Song not found"
+          }
         }
       }
     },
@@ -89,23 +142,37 @@
         "operationId": "getAlbum",
         "summary": "Get album details",
         "description": "Retrieve details for a specific album by its URL slug",
-        "tags": ["Music"],
+        "tags": [
+          "Music"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the album",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Album details",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Album" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Album"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Album not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Album not found"
+          }
         }
       }
     },
@@ -114,23 +181,37 @@
         "operationId": "getPlaylist",
         "summary": "Get playlist details",
         "description": "Retrieve details for a specific playlist",
-        "tags": ["Music"],
+        "tags": [
+          "Music"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the playlist",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Playlist details",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Playlist" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Playlist"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Playlist not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Playlist not found"
+          }
         }
       }
     },
@@ -139,27 +220,42 @@
         "operationId": "getTrending",
         "summary": "Get trending music",
         "description": "Retrieve currently trending songs on Audiomack",
-        "tags": ["Discovery"],
+        "tags": [
+          "Discovery"
+        ],
         "parameters": [
           {
             "name": "genre",
             "in": "query",
             "description": "Filter by genre",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
             "in": "query",
             "description": "Page number",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Trending songs",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SongListResponse" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SongListResponse"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" }
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -168,23 +264,37 @@
         "operationId": "getArtist",
         "summary": "Get artist profile",
         "description": "Retrieve an artist's profile information",
-        "tags": ["Artists"],
+        "tags": [
+          "Artists"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the artist",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Artist profile",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Artist" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Artist"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Artist not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Artist not found"
+          }
         }
       }
     },
@@ -193,29 +303,46 @@
         "operationId": "getArtistSongs",
         "summary": "Get artist's songs",
         "description": "Retrieve songs uploaded by an artist",
-        "tags": ["Artists"],
+        "tags": [
+          "Artists"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the artist",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
             "in": "query",
             "description": "Page number",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "List of songs",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SongListResponse" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SongListResponse"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Artist not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Artist not found"
+          }
         }
       }
     },
@@ -224,29 +351,46 @@
         "operationId": "getArtistAlbums",
         "summary": "Get artist's albums",
         "description": "Retrieve albums uploaded by an artist",
-        "tags": ["Artists"],
+        "tags": [
+          "Artists"
+        ],
         "parameters": [
           {
             "name": "slug",
             "in": "path",
             "required": true,
             "description": "URL slug of the artist",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
             "in": "query",
             "description": "Page number",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "List of albums",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AlbumListResponse" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlbumListResponse"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" },
-          "404": { "description": "Artist not found" }
+          "401": {
+            "description": "Unauthorized"
+          },
+          "404": {
+            "description": "Artist not found"
+          }
         }
       }
     },
@@ -255,28 +399,43 @@
         "operationId": "getGenre",
         "summary": "Get music by genre",
         "description": "Browse music by genre",
-        "tags": ["Discovery"],
+        "tags": [
+          "Discovery"
+        ],
         "parameters": [
           {
             "name": "genre",
             "in": "path",
             "required": true,
             "description": "Genre name (e.g., rap, afrobeats, r-and-b)",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "page",
             "in": "query",
             "description": "Page number",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Songs in genre",
-            "content": { "application/json": { "schema": { "$ref": "#/components/schemas/SongListResponse" } } }
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SongListResponse"
+                }
+              }
+            }
           },
-          "401": { "description": "Unauthorized" }
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     }
@@ -286,83 +445,190 @@
       "Song": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "url_slug": { "type": "string" },
-          "artist": { "type": "string" },
-          "genre": { "type": "string" },
-          "image": { "type": "string", "format": "uri" },
-          "streaming_url": { "type": "string", "format": "uri" },
-          "plays": { "type": "integer" },
-          "favorites": { "type": "integer" },
-          "duration": { "type": "integer", "description": "Duration in seconds" },
-          "released": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url_slug": {
+            "type": "string"
+          },
+          "artist": {
+            "type": "string"
+          },
+          "genre": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "streaming_url": {
+            "type": "string",
+            "format": "uri"
+          },
+          "plays": {
+            "type": "integer"
+          },
+          "favorites": {
+            "type": "integer"
+          },
+          "duration": {
+            "type": "integer",
+            "description": "Duration in seconds"
+          },
+          "released": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Album": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "url_slug": { "type": "string" },
-          "artist": { "type": "string" },
-          "image": { "type": "string", "format": "uri" },
-          "tracks": { "type": "array", "items": { "$ref": "#/components/schemas/Song" } },
-          "released": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url_slug": {
+            "type": "string"
+          },
+          "artist": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Song"
+            }
+          },
+          "released": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Playlist": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "title": { "type": "string" },
-          "url_slug": { "type": "string" },
-          "creator": { "type": "string" },
-          "image": { "type": "string", "format": "uri" },
-          "tracks": { "type": "array", "items": { "$ref": "#/components/schemas/Song" } }
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "url_slug": {
+            "type": "string"
+          },
+          "creator": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "tracks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Song"
+            }
+          }
         }
       },
       "Artist": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "url_slug": { "type": "string" },
-          "image": { "type": "string", "format": "uri" },
-          "bio": { "type": "string" },
-          "followers": { "type": "integer" },
-          "verified": { "type": "boolean" }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url_slug": {
+            "type": "string"
+          },
+          "image": {
+            "type": "string",
+            "format": "uri"
+          },
+          "bio": {
+            "type": "string"
+          },
+          "followers": {
+            "type": "integer"
+          },
+          "verified": {
+            "type": "boolean"
+          }
         }
       },
       "SearchResponse": {
         "type": "object",
         "properties": {
-          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Song" } },
-          "total": { "type": "integer" },
-          "page": { "type": "integer" }
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Song"
+            }
+          },
+          "total": {
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          }
         }
       },
       "SongListResponse": {
         "type": "object",
         "properties": {
-          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Song" } },
-          "total": { "type": "integer" },
-          "page": { "type": "integer" }
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Song"
+            }
+          },
+          "total": {
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          }
         }
       },
       "AlbumListResponse": {
         "type": "object",
         "properties": {
-          "results": { "type": "array", "items": { "$ref": "#/components/schemas/Album" } },
-          "total": { "type": "integer" },
-          "page": { "type": "integer" }
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Album"
+            }
+          },
+          "total": {
+            "type": "integer"
+          },
+          "page": {
+            "type": "integer"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "error": { "type": "string" },
-          "message": { "type": "string" }
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -380,12 +646,26 @@
     }
   },
   "security": [
-    { "oauth": [] }
+    {
+      "oauth": []
+    }
   ],
   "tags": [
-    { "name": "Search", "description": "Search for music content" },
-    { "name": "Music", "description": "Access songs, albums, and playlists" },
-    { "name": "Artists", "description": "Access artist profiles and content" },
-    { "name": "Discovery", "description": "Trending and genre-based discovery" }
+    {
+      "name": "Search",
+      "description": "Search for music content"
+    },
+    {
+      "name": "Music",
+      "description": "Access songs, albums, and playlists"
+    },
+    {
+      "name": "Artists",
+      "description": "Access artist profiles and content"
+    },
+    {
+      "name": "Discovery",
+      "description": "Trending and genre-based discovery"
+    }
   ]
 }

--- a/apis/openapi/aunoa.ai/aunoa-api/1.0.0/openapi.json
+++ b/apis/openapi/aunoa.ai/aunoa-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Aunoa API",
     "version": "1.0.0",
     "description": "Aunoa is a conversational AI platform. The REST API provides endpoints for managing WhatsApp templates, sending template messages, accessing reports and dashboards.",
-    "x-jentic-source-url": "https://developers.aunoa.ai"
+    "x-jentic-source-url": "https://developers.aunoa.ai",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all WhatsApp templates"
       }
     },
     "/bots/whatsapp/templates/{templateName}": {
@@ -97,7 +99,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get template details"
       },
       "post": {
         "operationId": "sendWhatsappTemplate",
@@ -149,7 +152,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Send template to phone numbers"
       }
     },
     "/bots/{botId}/dashboards/reports": {
@@ -193,7 +197,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List available reports"
       }
     },
     "/bots/{botId}/dashboards/reports/{reportId}/{date}/download": {
@@ -262,7 +267,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download a report"
       }
     },
     "/bots/{botId}/dashboards/report/{reportId}/{widgetId}": {
@@ -345,7 +351,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get dashboard widget data"
       }
     }
   },
@@ -424,6 +431,17 @@
   "security": [
     {
       "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Dashboards"
+    },
+    {
+      "name": "Reports"
+    },
+    {
+      "name": "Templates"
     }
   ]
 }

--- a/apis/openapi/auravant.com/auravant-livestock-api/1.0.0/openapi.json
+++ b/apis/openapi/auravant.com/auravant-livestock-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Auravant Livestock API",
     "version": "1.0.0",
     "description": "The Auravant Livestock API provides endpoints for managing paddocks, herds, and livestock transactions.",
-    "x-jentic-source-url": "https://developers.auravant.com/en/docs/apis/reference/api_ref_livestock/"
+    "x-jentic-source-url": "https://developers.auravant.com/en/docs/apis/reference/api_ref_livestock/",
+    "contact": {}
   },
   "servers": [
     {
@@ -59,7 +60,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List paddocks"
       },
       "post": {
         "operationId": "createPaddock",
@@ -108,7 +110,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create paddock"
       }
     },
     "/livestock/paddock/{paddock_uuid}": {
@@ -160,7 +163,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get paddock"
       },
       "patch": {
         "operationId": "updatePaddock",
@@ -228,7 +232,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update paddock"
       },
       "delete": {
         "operationId": "deletePaddock",
@@ -271,7 +276,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete paddock"
       }
     },
     "/livestock/herd": {
@@ -312,7 +318,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List herds"
       },
       "post": {
         "operationId": "createHerd",
@@ -361,7 +368,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create herd"
       }
     },
     "/livestock/herd/{herd_uuid}": {
@@ -423,7 +431,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update herd"
       },
       "delete": {
         "operationId": "deleteHerd",
@@ -466,7 +475,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete herd"
       }
     },
     "/livestock/herd/categories": {
@@ -507,7 +517,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List herd categories"
       }
     },
     "/livestock/transaction/paddock": {
@@ -558,7 +569,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Change paddock for herd"
       }
     },
     "/livestock/transaction/exit": {
@@ -609,7 +621,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Record livestock exit"
       }
     },
     "/livestock/transaction/exit/types": {
@@ -650,7 +663,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List exit types"
       }
     }
   },
@@ -950,6 +964,17 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Herds"
+    },
+    {
+      "name": "Paddocks"
+    },
+    {
+      "name": "Transactions"
     }
   ]
 }

--- a/apis/openapi/aurorainbox.com/aurora-inbox-api/1.0.0/openapi.json
+++ b/apis/openapi/aurorainbox.com/aurora-inbox-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Aurora Platform API",
     "version": "1.0.0",
     "description": "Aurora Inbox is a multi-channel messaging platform API for managing chats, contacts, companies, opportunities, teams, users, and webhooks across WhatsApp, Messenger and other channels.",
-    "x-jentic-source-url": "https://developers.aurorainbox.com/"
+    "x-jentic-source-url": "https://developers.aurorainbox.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -26,7 +27,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List WhatsApp Business channels"
       }
     },
     "/Channels/WhatsAppCloudAPI": {
@@ -43,7 +45,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List WhatsApp Cloud API channels"
       }
     },
     "/Channels/Messenger": {
@@ -60,7 +63,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List Messenger channels"
       }
     },
     "/Chatbots": {
@@ -77,7 +81,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List chatbots"
       }
     },
     "/Chats": {
@@ -107,7 +112,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a chat"
       }
     },
     "/Chats/{id}": {
@@ -134,7 +140,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a chat"
       }
     },
     "/Chats/{id}/Messages": {
@@ -174,7 +181,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Send a message in a chat"
       }
     },
     "/Chats/Search": {
@@ -201,7 +209,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Search chats"
       }
     },
     "/Contacts": {
@@ -218,7 +227,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List contacts"
       },
       "post": {
         "operationId": "createContact",
@@ -246,7 +256,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a contact"
       }
     },
     "/Contacts/{id}": {
@@ -273,7 +284,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a contact"
       },
       "put": {
         "operationId": "updateContact",
@@ -308,7 +320,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a contact"
       },
       "delete": {
         "operationId": "deleteContact",
@@ -333,7 +346,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a contact"
       }
     },
     "/Contacts/Upsert": {
@@ -360,7 +374,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Upsert a contact"
       }
     },
     "/Companies": {
@@ -377,7 +392,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List companies"
       },
       "post": {
         "operationId": "createCompany",
@@ -402,7 +418,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a company"
       }
     },
     "/Companies/{id}": {
@@ -429,7 +446,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a company"
       },
       "put": {
         "operationId": "updateCompany",
@@ -464,7 +482,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a company"
       },
       "delete": {
         "operationId": "deleteCompany",
@@ -489,7 +508,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a company"
       }
     },
     "/Opportunities": {
@@ -516,7 +536,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an opportunity"
       }
     },
     "/Opportunities/{id}": {
@@ -553,7 +574,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an opportunity"
       },
       "delete": {
         "operationId": "deleteOpportunity",
@@ -578,7 +600,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an opportunity"
       }
     },
     "/Teams": {
@@ -595,7 +618,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List teams"
       }
     },
     "/Teams/{id}": {
@@ -622,7 +646,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a team"
       }
     },
     "/Users": {
@@ -639,7 +664,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List users"
       }
     },
     "/Webhooks": {
@@ -666,7 +692,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a webhook"
       },
       "get": {
         "operationId": "listWebhooks",
@@ -681,7 +708,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List webhooks"
       }
     },
     "/Webhooks/{id}": {
@@ -708,7 +736,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a webhook"
       },
       "put": {
         "operationId": "updateWebhook",
@@ -743,7 +772,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a webhook"
       },
       "delete": {
         "operationId": "deleteWebhook",
@@ -768,7 +798,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a webhook"
       }
     },
     "/Webhooks/{id}/Test": {
@@ -795,32 +826,43 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Api-Key"
+        },
+        "description": "Test a webhook"
       }
     }
   },
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Channels"
+    },
+    {
+      "name": "Chatbots"
+    },
+    {
+      "name": "Chats"
+    },
+    {
+      "name": "Companies"
+    },
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Opportunities"
+    },
+    {
+      "name": "Teams"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/aurorainbox.com/aurora-inbox-api/1.0.0/openapi.json
+++ b/apis/openapi/aurorainbox.com/aurora-inbox-api/1.0.0/openapi.json
@@ -864,5 +864,14 @@
     {
       "name": "Webhooks"
     }
-  ]
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
+  }
 }

--- a/apis/openapi/autobound.ai/autobound-api/2.0.0/openapi.json
+++ b/apis/openapi/autobound.ai/autobound-api/2.0.0/openapi.json
@@ -4,10 +4,13 @@
     "title": "Autobound API",
     "version": "2.0.0",
     "description": "Autobound API for generating personalized sales content including cold outbound emails and openers based on prospect and seller information.",
-    "x-jentic-source-url": "https://autobound-api.readme.io/docs/autobound-api-documentation"
+    "x-jentic-source-url": "https://autobound-api.readme.io/docs/autobound-api-documentation",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://api.autobound.ai/api/external" }
+    {
+      "url": "https://api.autobound.ai/api/external"
+    }
   ],
   "paths": {
     "/generate-content/v2.0": {
@@ -15,19 +18,50 @@
         "operationId": "generateContent",
         "summary": "Generate personalized sales content",
         "description": "Generates personalized sales content (emails, openers, etc.) based on prospect and seller information",
-        "tags": ["Content Generation"],
+        "tags": [
+          "Content Generation"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/GenerateContentRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/GenerateContentRequest"
+              }
             }
           }
         },
         "responses": {
-          "200": { "description": "Generated content", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GenerateContentResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Generated content",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GenerateContentResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -36,15 +70,53 @@
     "schemas": {
       "GenerateContentRequest": {
         "type": "object",
-        "required": ["contactEmail", "userEmail", "contentType"],
+        "required": [
+          "contactEmail",
+          "userEmail",
+          "contentType"
+        ],
         "properties": {
-          "contactEmail": { "type": "string", "format": "email", "description": "Prospect email address" },
-          "userEmail": { "type": "string", "format": "email", "description": "Seller email address" },
-          "contentType": { "type": "string", "enum": ["COLD_OUTBOUND_EMAIL", "COLD_OUTBOUND_OPENER"], "description": "Type of content to generate" },
-          "n": { "type": "integer", "minimum": 1, "maximum": 3, "default": 1, "description": "Number of unique content pieces" },
-          "generationModel": { "type": "string", "enum": ["turbo", "ultra"], "description": "AI model to use" },
-          "additionalContext": { "type": "string", "description": "Custom instructions for generation" },
-          "salesAsset": { "type": "string", "description": "Content/instructions for AI incorporation" }
+          "contactEmail": {
+            "type": "string",
+            "format": "email",
+            "description": "Prospect email address"
+          },
+          "userEmail": {
+            "type": "string",
+            "format": "email",
+            "description": "Seller email address"
+          },
+          "contentType": {
+            "type": "string",
+            "enum": [
+              "COLD_OUTBOUND_EMAIL",
+              "COLD_OUTBOUND_OPENER"
+            ],
+            "description": "Type of content to generate"
+          },
+          "n": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3,
+            "default": 1,
+            "description": "Number of unique content pieces"
+          },
+          "generationModel": {
+            "type": "string",
+            "enum": [
+              "turbo",
+              "ultra"
+            ],
+            "description": "AI model to use"
+          },
+          "additionalContext": {
+            "type": "string",
+            "description": "Custom instructions for generation"
+          },
+          "salesAsset": {
+            "type": "string",
+            "description": "Content/instructions for AI incorporation"
+          }
         }
       },
       "GenerateContentResponse": {
@@ -55,25 +127,76 @@
             "items": {
               "type": "object",
               "properties": {
-                "subject": { "type": "string" },
-                "content": { "type": "string" },
-                "contentItemId": { "type": "string" },
-                "includedInsights": { "type": "array", "items": { "type": "string" } },
-                "insightsUsed": { "type": "array", "items": { "type": "string" } },
-                "valuePropsUsed": { "type": "array", "items": { "type": "string" } },
-                "templateId": { "type": "string" }
+                "subject": {
+                  "type": "string"
+                },
+                "content": {
+                  "type": "string"
+                },
+                "contentItemId": {
+                  "type": "string"
+                },
+                "includedInsights": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "insightsUsed": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "valuePropsUsed": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "templateId": {
+                  "type": "string"
+                }
               }
             }
           }
         }
       },
-      "ErrorResponse": { "type": "object", "properties": { "status": { "type": "string", "enum": ["error"] }, "code": { "type": "string" }, "message": { "type": "string" } } }
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "apiKey": { "type": "apiKey", "in": "header", "name": "X-API-KEY", "description": "API key obtained from sales@autobound.ai" }
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-KEY",
+        "description": "API key obtained from sales@autobound.ai"
+      }
     }
   },
   "security": [
-    { "apiKey": [] }
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Content Generation"
+    }
   ]
 }

--- a/apis/openapi/autodata-group.com/autodatagroup/1.0.0/openapi.json
+++ b/apis/openapi/autodata-group.com/autodatagroup/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Autodata API",
     "version": "1.0.0",
     "description": "Automotive technical data and repair information",
-    "x-jentic-source-url": "https://developer.autodata-group.com/"
+    "x-jentic-source-url": "https://developer.autodata-group.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/autodata-group.com/autodatagroup/1.0.0/openapi.json
+++ b/apis/openapi/autodata-group.com/autodatagroup/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/autoro.io/autoro-api/1.0.0/openapi.json
+++ b/apis/openapi/autoro.io/autoro-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "AUTORO API",
     "version": "1.0.0",
     "description": "AUTORO (formerly Robotic Crowd) is a cloud-based RPA platform. The API provides workflow management, session queue control, and token generation.",
-    "x-jentic-source-url": "https://developer.autoro.io/#overview"
+    "x-jentic-source-url": "https://developer.autoro.io/#overview",
+    "contact": {}
   },
   "servers": [
     {
@@ -493,6 +494,17 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Session Queues"
+    },
+    {
+      "name": "Workflows"
     }
   ]
 }

--- a/apis/openapi/availity.com/availity-api/1.0.0/openapi.json
+++ b/apis/openapi/availity.com/availity-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Availity API",
     "version": "1.0.0",
     "description": "Availity provides healthcare IT solutions. The API enables payer list queries, service reviews, coverages, and claim status operations via OAuth 2.0 authentication.",
-    "x-jentic-source-url": "https://developer.availity.com/blog/2025/3/25/availity-api-guide"
+    "x-jentic-source-url": "https://developer.availity.com/blog/2025/3/25/availity-api-guide",
+    "contact": {}
   },
   "servers": [
     {
@@ -75,7 +76,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get OAuth access token"
       }
     },
     "/v1/availity-payer-list": {
@@ -128,7 +130,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List available payers"
       }
     },
     "/v2/service-reviews": {
@@ -162,7 +165,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List service reviews"
       }
     },
     "/v2/service-reviews/{id}": {
@@ -206,7 +210,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get service review"
       }
     }
   },
@@ -244,6 +249,17 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Payers"
+    },
+    {
+      "name": "Service Reviews"
     }
   ]
 }

--- a/apis/openapi/avena.com/Avena/1.0.0/openapi.json
+++ b/apis/openapi/avena.com/Avena/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Avena API",
     "description": "API for agricultural management and crop monitoring",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://documenter.getpostman.com/view/7657407/Uz5JHafi"
+    "x-jentic-source-url": "https://documenter.getpostman.com/view/7657407/Uz5JHafi",
+    "contact": {}
   },
   "servers": [
     {
@@ -43,7 +44,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "fields"
+        ]
       },
       "post": {
         "operationId": "createField",
@@ -106,7 +110,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "fields"
+        ]
       }
     },
     "/measurements": {
@@ -171,7 +178,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "measurements"
+        ]
       }
     }
   },
@@ -201,5 +211,13 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "fields"
+    },
+    {
+      "name": "measurements"
+    }
+  ]
 }

--- a/apis/openapi/axerto.com/axerto-api/1.0.0/openapi.json
+++ b/apis/openapi/axerto.com/axerto-api/1.0.0/openapi.json
@@ -223,5 +223,14 @@
     {
       "name": "Webhooks"
     }
-  ]
+  ],
+  "components": {
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
+  }
 }

--- a/apis/openapi/axerto.com/axerto-api/1.0.0/openapi.json
+++ b/apis/openapi/axerto.com/axerto-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Axerto API",
     "version": "1.0.0",
     "description": "Axerto landing page and lead management API. Provides endpoints for authentication, webhook subscriptions, landing page listing, and lead retrieval.",
-    "x-jentic-source-url": "https://axerto.com/api/zapier/docs/"
+    "x-jentic-source-url": "https://axerto.com/api/zapier/docs/",
+    "contact": {}
   },
   "servers": [
     {
@@ -12,7 +13,7 @@
     }
   ],
   "paths": {
-    "/api/zapier/auth/": {
+    "/api/zapier/auth": {
       "get": {
         "operationId": "testAuth",
         "summary": "Test authentication",
@@ -38,10 +39,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Test authentication"
       }
     },
-    "/api/zapier/subscribe/": {
+    "/api/zapier/subscribe": {
       "post": {
         "operationId": "subscribeHook",
         "summary": "Subscribe to webhook",
@@ -95,10 +97,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Subscribe to webhook"
       }
     },
-    "/api/zapier/unsubscribe/": {
+    "/api/zapier/unsubscribe": {
       "delete": {
         "operationId": "unsubscribeHook",
         "summary": "Unsubscribe from webhook",
@@ -133,10 +136,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Unsubscribe from webhook"
       }
     },
-    "/api/zapier/landings/": {
+    "/api/zapier/landings": {
       "get": {
         "operationId": "listLandings",
         "summary": "List landing pages",
@@ -168,10 +172,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List landing pages"
       }
     },
-    "/api/zapier/leads/": {
+    "/api/zapier/leads": {
       "get": {
         "operationId": "listLeads",
         "summary": "List recent leads",
@@ -195,35 +200,28 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "apiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-KEY"
+        },
+        "description": "List recent leads"
       }
     }
   },
   "security": [
     {
       "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Landings"
+    },
+    {
+      "name": "Leads"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/axis96.com/zilus-api/1.0.0/openapi.json
+++ b/apis/openapi/axis96.com/zilus-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Zilus (SwiftChats) API",
     "version": "1.0.0",
     "description": "Zilus/SwiftChats API for managing contacts and messaging.",
-    "x-jentic-source-url": "https://swiftchats-documentation.axis96.com/api-reference/endpoint/contacts/get"
+    "x-jentic-source-url": "https://swiftchats-documentation.axis96.com/api-reference/endpoint/contacts/get",
+    "contact": {}
   },
   "servers": [
     {
@@ -59,7 +60,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List contacts"
       }
     }
   },
@@ -136,6 +138,11 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Contacts"
     }
   ]
 }

--- a/apis/openapi/ayrshare.com/ayrshare-api/2.0.0/openapi.json
+++ b/apis/openapi/ayrshare.com/ayrshare-api/2.0.0/openapi.json
@@ -4,107 +4,368 @@
     "title": "Ayrshare API",
     "version": "2.0.0",
     "description": "Ayrshare social media API to post, schedule, get analytics, and manage multiple users' social media accounts across platforms.",
-    "x-jentic-source-url": "https://www.ayrshare.com"
+    "x-jentic-source-url": "https://www.ayrshare.com",
+    "contact": {}
   },
-  "servers": [{ "url": "https://app.ayrshare.com/api" }],
+  "servers": [
+    {
+      "url": "https://app.ayrshare.com/api"
+    }
+  ],
   "paths": {
     "/post": {
       "post": {
         "operationId": "createPost",
         "summary": "Create social post",
         "description": "Post to one or more social media platforms",
-        "tags": ["Posts"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreatePostRequest" } } } },
+        "tags": [
+          "Posts"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreatePostRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Post created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PostResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Post created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PostResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       },
       "get": {
         "operationId": "getPosts",
         "summary": "Get post history",
-        "tags": ["Posts"],
+        "tags": [
+          "Posts"
+        ],
         "parameters": [
-          { "name": "lastDays", "in": "query", "schema": { "type": "integer" } },
-          { "name": "lastRecords", "in": "query", "schema": { "type": "integer" } }
+          {
+            "name": "lastDays",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "lastRecords",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Posts", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/PostResponse" } } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Posts",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/PostResponse"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get post history"
       }
     },
     "/delete": {
       "delete": {
         "operationId": "deletePost",
         "summary": "Delete post",
-        "tags": ["Posts"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "id": { "type": "string" }, "bulk": { "type": "array", "items": { "type": "string" } } } } } } },
+        "tags": [
+          "Posts"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "bulk": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Deleted" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Delete post"
       }
     },
     "/analytics/post": {
       "post": {
         "operationId": "getPostAnalytics",
         "summary": "Get post analytics",
-        "tags": ["Analytics"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "id": { "type": "string" }, "platforms": { "type": "array", "items": { "type": "string" } } }, "required": ["id"] } } } },
+        "tags": [
+          "Analytics"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string"
+                  },
+                  "platforms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "id"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Analytics data", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AnalyticsResponse" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Analytics data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get post analytics"
       }
     },
     "/analytics/social": {
       "post": {
         "operationId": "getSocialAnalytics",
         "summary": "Get social account analytics",
-        "tags": ["Analytics"],
-        "requestBody": { "content": { "application/json": { "schema": { "type": "object", "properties": { "platforms": { "type": "array", "items": { "type": "string" } } } } } } },
+        "tags": [
+          "Analytics"
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "platforms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Social analytics", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AnalyticsResponse" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Social analytics",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnalyticsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get social account analytics"
       }
     },
     "/comments/{id}": {
       "get": {
         "operationId": "getComments",
         "summary": "Get post comments",
-        "tags": ["Comments"],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
+        "tags": [
+          "Comments"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Comments", "content": { "application/json": { "schema": { "type": "object", "properties": { "comments": { "type": "array", "items": { "$ref": "#/components/schemas/Comment" } } } } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Comments",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "comments": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Comment"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get post comments"
       },
       "post": {
         "operationId": "postComment",
         "summary": "Post a comment",
-        "tags": ["Comments"],
-        "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "comment": { "type": "string" }, "platforms": { "type": "array", "items": { "type": "string" } } }, "required": ["comment"] } } } },
+        "tags": [
+          "Comments"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "comment": {
+                    "type": "string"
+                  },
+                  "platforms": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "required": [
+                  "comment"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Comment posted" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Comment posted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Post a comment"
       }
     },
     "/user": {
       "get": {
         "operationId": "getUser",
         "summary": "Get user profile",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "responses": {
-          "200": { "description": "User info", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UserProfile" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "User info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/UserProfile"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get user profile"
       }
     },
     "/profiles": {
@@ -112,11 +373,49 @@
         "operationId": "createProfile",
         "summary": "Create user profile",
         "description": "Create a sub-user profile for multi-user management",
-        "tags": ["Users"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "title": { "type": "string" } }, "required": ["title"] } } } },
+        "tags": [
+          "Users"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Profile created", "content": { "application/json": { "schema": { "type": "object", "properties": { "profileKey": { "type": "string" }, "title": { "type": "string" } } } } } },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Profile created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "profileKey": {
+                      "type": "string"
+                    },
+                    "title": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -124,35 +423,238 @@
       "post": {
         "operationId": "uploadMedia",
         "summary": "Upload media",
-        "tags": ["Media"],
-        "requestBody": { "required": true, "content": { "multipart/form-data": { "schema": { "type": "object", "properties": { "file": { "type": "string", "format": "binary" } } } } } },
+        "tags": [
+          "Media"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Uploaded", "content": { "application/json": { "schema": { "type": "object", "properties": { "url": { "type": "string", "format": "uri" } } } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized" }
-        }
+          "200": {
+            "description": "Uploaded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "url": {
+                      "type": "string",
+                      "format": "uri"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Upload media"
       }
     }
   },
   "components": {
     "schemas": {
-      "CreatePostRequest": { "type": "object", "properties": { "post": { "type": "string" }, "platforms": { "type": "array", "items": { "type": "string", "enum": ["twitter", "facebook", "instagram", "linkedin", "pinterest", "tiktok", "youtube", "reddit", "telegram"] } }, "mediaUrls": { "type": "array", "items": { "type": "string", "format": "uri" } }, "scheduleDate": { "type": "string", "format": "date-time" }, "shortenLinks": { "type": "boolean" } }, "required": ["post", "platforms"] },
-      "PostResponse": { "type": "object", "properties": { "id": { "type": "string" }, "status": { "type": "string" }, "postIds": { "type": "array", "items": { "type": "object", "properties": { "platform": { "type": "string" }, "postId": { "type": "string" }, "postUrl": { "type": "string" } } } }, "post": { "type": "string" }, "created": { "type": "string", "format": "date-time" } } },
-      "AnalyticsResponse": { "type": "object", "properties": { "analytics": { "type": "object" }, "status": { "type": "string" } } },
-      "Comment": { "type": "object", "properties": { "id": { "type": "string" }, "text": { "type": "string" }, "author": { "type": "string" }, "created": { "type": "string", "format": "date-time" } } },
-      "UserProfile": { "type": "object", "properties": { "email": { "type": "string" }, "displayName": { "type": "string" }, "created": { "type": "string", "format": "date-time" }, "activeSocialAccounts": { "type": "array", "items": { "type": "string" } } } },
-      "ErrorResponse": { "type": "object", "properties": { "status": { "type": "string" }, "message": { "type": "string" }, "code": { "type": "integer" } } }
+      "CreatePostRequest": {
+        "type": "object",
+        "properties": {
+          "post": {
+            "type": "string"
+          },
+          "platforms": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "twitter",
+                "facebook",
+                "instagram",
+                "linkedin",
+                "pinterest",
+                "tiktok",
+                "youtube",
+                "reddit",
+                "telegram"
+              ]
+            }
+          },
+          "mediaUrls": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "format": "uri"
+            }
+          },
+          "scheduleDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "shortenLinks": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "post",
+          "platforms"
+        ]
+      },
+      "PostResponse": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "postIds": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "platform": {
+                  "type": "string"
+                },
+                "postId": {
+                  "type": "string"
+                },
+                "postUrl": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "post": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "AnalyticsResponse": {
+        "type": "object",
+        "properties": {
+          "analytics": {
+            "type": "object"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "Comment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "text": {
+            "type": "string"
+          },
+          "author": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "UserProfile": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "activeSocialAccounts": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer"
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "bearerAuth": { "type": "http", "scheme": "bearer", "description": "API key as Bearer token" }
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "description": "API key as Bearer token"
+      }
     }
   },
-  "security": [{ "bearerAuth": [] }],
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "tags": [
-    { "name": "Posts", "description": "Create and manage social media posts" },
-    { "name": "Analytics", "description": "Post and account analytics" },
-    { "name": "Comments", "description": "Comment management" },
-    { "name": "Users", "description": "User and profile management" },
-    { "name": "Media", "description": "Media uploads" }
+    {
+      "name": "Posts",
+      "description": "Create and manage social media posts"
+    },
+    {
+      "name": "Analytics",
+      "description": "Post and account analytics"
+    },
+    {
+      "name": "Comments",
+      "description": "Comment management"
+    },
+    {
+      "name": "Users",
+      "description": "User and profile management"
+    },
+    {
+      "name": "Media",
+      "description": "Media uploads"
+    }
   ]
 }

--- a/apis/openapi/az511.com/az511/2.0.0/openapi.json
+++ b/apis/openapi/az511.com/az511/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "AZ511 Traffic Data API",
     "description": "Access traffic data from the Arizona Department of Transportation (ADOT) API. Provides real-time information about traffic cameras, weather stations, message signs, events, alerts, and rest areas across Arizona.",
     "version": "2.0.0",
-    "x-jentic-source-url": "https://www.az511.com/developers/doc"
+    "x-jentic-source-url": "https://www.az511.com/developers/doc",
+    "contact": {}
   },
   "servers": [
     {
@@ -46,7 +47,9 @@
   "paths": {
     "/get/cameras": {
       "get": {
-        "tags": ["Cameras"],
+        "tags": [
+          "Cameras"
+        ],
         "summary": "Get all traffic cameras",
         "operationId": "getCameras",
         "parameters": [
@@ -88,12 +91,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all traffic cameras"
       }
     },
     "/get/weatherstations": {
       "get": {
-        "tags": ["Weather Stations"],
+        "tags": [
+          "Weather Stations"
+        ],
         "summary": "Get all weather stations",
         "operationId": "getWeatherStations",
         "parameters": [
@@ -135,12 +141,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all weather stations"
       }
     },
     "/get/messagesigns": {
       "get": {
-        "tags": ["Message Signs"],
+        "tags": [
+          "Message Signs"
+        ],
         "summary": "Get all variable message signs",
         "operationId": "getMessageSigns",
         "parameters": [
@@ -182,12 +191,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all variable message signs"
       }
     },
     "/get/event": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Get all traffic events",
         "operationId": "getEvents",
         "parameters": [
@@ -229,12 +241,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all traffic events"
       }
     },
     "/get/alerts": {
       "get": {
-        "tags": ["Alerts"],
+        "tags": [
+          "Alerts"
+        ],
         "summary": "Get all traffic alerts",
         "operationId": "getAlerts",
         "parameters": [
@@ -276,12 +291,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all traffic alerts"
       }
     },
     "/get/restareas": {
       "get": {
-        "tags": ["Rest Areas"],
+        "tags": [
+          "Rest Areas"
+        ],
         "summary": "Get all rest areas",
         "operationId": "getRestAreas",
         "parameters": [
@@ -323,7 +341,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all rest areas"
       }
     }
   },
@@ -343,7 +362,10 @@
         "required": false,
         "schema": {
           "type": "string",
-          "enum": ["json", "xml"],
+          "enum": [
+            "json",
+            "xml"
+          ],
           "default": "json"
         },
         "description": "Response format (json or xml, defaults to json)"
@@ -583,7 +605,11 @@
           },
           "EventType": {
             "type": "string",
-            "enum": ["roadwork", "closures", "accidentsAndIncidents"],
+            "enum": [
+              "roadwork",
+              "closures",
+              "accidentsAndIncidents"
+            ],
             "description": "Type of event"
           },
           "IsFullClosure": {

--- a/apis/openapi/azupay.com.au/apidocsazupay/1.0.0/openapi.json
+++ b/apis/openapi/azupay.com.au/apidocsazupay/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Azupay API",
     "version": "1.0.0",
     "description": "Azupay developer portal for Australian instant payment services",
-    "x-jentic-source-url": "https://api-docs.azupay.com.au/"
+    "x-jentic-source-url": "https://api-docs.azupay.com.au/",
+    "contact": {}
   },
   "servers": [
     {
@@ -188,5 +189,13 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Payments"
+    }
+  ]
 }

--- a/apis/openapi/azupay.com.au/azupay/1.0.0/openapi.json
+++ b/apis/openapi/azupay.com.au/azupay/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Azupay Payment API",
     "description": "Azupay API for Australian payment processing including PayID, PayTo, NPP, and payment requests",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developer.azupay.com.au/"
+    "x-jentic-source-url": "https://developer.azupay.com.au/",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,7 +19,9 @@
         "summary": "Create payment request",
         "description": "Create a PayID payment request",
         "operationId": "createPayIdPaymentRequest",
-        "tags": ["Payment Requests"],
+        "tags": [
+          "Payment Requests"
+        ],
         "security": [
           {
             "apiKey": []
@@ -91,7 +94,9 @@
         "summary": "Get payment request",
         "description": "Retrieve a payment request by ID",
         "operationId": "getPaymentRequest",
-        "tags": ["Payment Requests"],
+        "tags": [
+          "Payment Requests"
+        ],
         "security": [
           {
             "apiKey": []
@@ -151,7 +156,9 @@
         "summary": "Delete payment request",
         "description": "Delete a payment request",
         "operationId": "deletePaymentRequest",
-        "tags": ["Payment Requests"],
+        "tags": [
+          "Payment Requests"
+        ],
         "security": [
           {
             "apiKey": []
@@ -190,7 +197,9 @@
         "summary": "Refund payment request",
         "description": "Refund a payment request",
         "operationId": "refundPaymentRequest",
-        "tags": ["Payment Requests"],
+        "tags": [
+          "Payment Requests"
+        ],
         "security": [
           {
             "apiKey": []
@@ -255,7 +264,9 @@
         "summary": "Search payment requests",
         "description": "Search for payment requests",
         "operationId": "searchPaymentRequests",
-        "tags": ["Payment Requests"],
+        "tags": [
+          "Payment Requests"
+        ],
         "security": [
           {
             "apiKey": []
@@ -314,7 +325,9 @@
         "summary": "Make payment",
         "description": "Make a payment",
         "operationId": "makePayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []
@@ -383,7 +396,9 @@
         "summary": "Get payment",
         "description": "Retrieve a payment by ID",
         "operationId": "getPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []
@@ -443,7 +458,9 @@
         "summary": "Search payments",
         "description": "Search for payments",
         "operationId": "searchPayments",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []
@@ -502,7 +519,9 @@
         "summary": "Create payment agreement",
         "description": "Create agreement for recurring payments",
         "operationId": "createPaymentAgreement",
-        "tags": ["Payment Agreements"],
+        "tags": [
+          "Payment Agreements"
+        ],
         "security": [
           {
             "apiKey": []
@@ -571,7 +590,9 @@
         "summary": "Account enquiry",
         "description": "Check account BSB for NPP and PayTo reachability",
         "operationId": "accountEnquiry",
-        "tags": ["Account Verification"],
+        "tags": [
+          "Account Verification"
+        ],
         "security": [
           {
             "apiKey": []
@@ -636,7 +657,9 @@
         "summary": "PayID enquiry",
         "description": "Check the status of the PayID",
         "operationId": "payIdEnquiry",
-        "tags": ["Account Verification"],
+        "tags": [
+          "Account Verification"
+        ],
         "security": [
           {
             "apiKey": []
@@ -697,7 +720,9 @@
         "summary": "Get balance",
         "description": "Get current balance",
         "operationId": "getBalance",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "security": [
           {
             "apiKey": []
@@ -732,7 +757,9 @@
         "summary": "Get report",
         "description": "Get reports",
         "operationId": "getReport",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "security": [
           {
             "apiKey": []

--- a/apis/openapi/backblaze.com/backblaze-b2-api/4.0.0/openapi.json
+++ b/apis/openapi/backblaze.com/backblaze-b2-api/4.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Backblaze B2 Cloud Storage API",
     "version": "4.0.0",
     "description": "Backblaze B2 is a cloud storage service. The B2 Native API provides operations for authentication, bucket management, file upload/download, and lifecycle management.",
-    "x-jentic-source-url": "https://www.backblaze.com/apidocs/introduction-to-api-documentation"
+    "x-jentic-source-url": "https://www.backblaze.com/apidocs/introduction-to-api-documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -108,7 +109,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create bucket"
       }
     },
     "/b2_delete_bucket": {
@@ -160,7 +162,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete bucket"
       }
     },
     "/b2_list_buckets": {
@@ -209,7 +212,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List buckets"
       }
     },
     "/b2_update_bucket": {
@@ -253,7 +257,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update bucket"
       }
     },
     "/b2_get_upload_url": {
@@ -302,7 +307,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get upload URL"
       }
     },
     "/b2_upload_file": {
@@ -336,7 +342,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload file"
       }
     },
     "/b2_delete_file_version": {
@@ -388,7 +395,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete file version"
       }
     },
     "/b2_list_file_names": {
@@ -440,7 +448,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List file names"
       }
     },
     "/b2_list_file_versions": {
@@ -489,7 +498,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List file versions"
       }
     },
     "/b2_get_file_info": {
@@ -538,7 +548,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get file info"
       }
     },
     "/b2_download_file_by_id": {
@@ -587,7 +598,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download file by ID"
       }
     },
     "/b2_download_file_by_name": {
@@ -621,7 +633,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download file by name"
       }
     },
     "/b2_copy_file": {
@@ -673,7 +686,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Copy file"
       }
     },
     "/b2_hide_file": {
@@ -725,7 +739,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Hide file"
       }
     },
     "/b2_create_key": {
@@ -769,7 +784,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create application key"
       }
     },
     "/b2_delete_key": {
@@ -818,7 +834,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete application key"
       }
     },
     "/b2_list_keys": {
@@ -867,7 +884,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List application keys"
       }
     },
     "/b2_get_upload_part_url": {
@@ -916,7 +934,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get upload part URL"
       }
     },
     "/b2_start_large_file": {
@@ -960,7 +979,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Start large file upload"
       }
     },
     "/b2_finish_large_file": {
@@ -1004,7 +1024,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Finish large file upload"
       }
     },
     "/b2_cancel_large_file": {
@@ -1053,7 +1074,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel large file upload"
       }
     },
     "/b2_list_parts": {
@@ -1102,7 +1124,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List parts of large file"
       }
     },
     "/b2_list_unfinished_large_files": {
@@ -1151,7 +1174,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List unfinished large files"
       }
     }
   },
@@ -1184,6 +1208,23 @@
   "security": [
     {
       "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Buckets"
+    },
+    {
+      "name": "Files"
+    },
+    {
+      "name": "Keys"
+    },
+    {
+      "name": "Large Files"
     }
   ]
 }

--- a/apis/openapi/balldontlie.io/balldontlie/1.0.0/openapi.json
+++ b/apis/openapi/balldontlie.io/balldontlie/1.0.0/openapi.json
@@ -23,7 +23,8 @@
       }
     ],
     "x-providerName": "balldontlie.io",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/balldontlie.io/1.0.0/openapi.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/balldontlie.io/1.0.0/openapi.yaml",
+    "description": "balldontlie"
   },
   "tags": [
     {

--- a/apis/openapi/bannerify.co/bannerify/1.0.0/openapi.json
+++ b/apis/openapi/bannerify.co/bannerify/1.0.0/openapi.json
@@ -94,6 +94,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "paths": {

--- a/apis/openapi/bannerify.co/bannerify/1.0.0/openapi.json
+++ b/apis/openapi/bannerify.co/bannerify/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bannerify API",
     "version": "1.0.0",
     "description": "Bannerify API for automated banner and social media image generation. Create dynamic images from templates with customizable text, colors, and branding.",
-    "x-jentic-source-url": "https://bannerify.co/docs/api-reference/overview"
+    "x-jentic-source-url": "https://bannerify.co/docs/api-reference/overview",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,26 +18,7 @@
     }
   ],
   "components": {
-    "securitySchemes": {
-      "ApiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key",
-        "description": "API key for authentication"
-      }
-    },
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "error": {
-            "type": "string"
-          }
-        }
-      },
       "GenerateImageRequest": {
         "type": "object",
         "required": [

--- a/apis/openapi/banorte.com/banorte/1.0.0/openapi.json
+++ b/apis/openapi/banorte.com/banorte/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Banorte API",
     "description": "Banorte banking APIs protected by OAuth 2.0 authentication. Provides banking services for Mexican financial institutions including payment processing, account management, and financial services integration.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developers.banorte.com/es/primeros-pasos"
+    "x-jentic-source-url": "https://developers.banorte.com/es/primeros-pasos",
+    "contact": {}
   },
   "servers": [
     {
@@ -27,7 +28,9 @@
         "summary": "Get OAuth access token",
         "description": "Obtain OAuth 2.0 access token using supported grant types",
         "operationId": "getAccessToken",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [],
         "requestBody": {
           "required": true,
@@ -35,11 +38,19 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["grant_type", "client_id", "client_secret"],
+                "required": [
+                  "grant_type",
+                  "client_id",
+                  "client_secret"
+                ],
                 "properties": {
                   "grant_type": {
                     "type": "string",
-                    "enum": ["client_credentials", "authorization_code", "refresh_token"]
+                    "enum": [
+                      "client_credentials",
+                      "authorization_code",
+                      "refresh_token"
+                    ]
                   },
                   "client_id": {
                     "type": "string"
@@ -109,7 +120,9 @@
         "summary": "List accounts",
         "description": "Retrieve list of bank accounts",
         "operationId": "listAccounts",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "responses": {
           "200": {
             "description": "List of accounts",
@@ -140,7 +153,9 @@
         "summary": "Get account details",
         "description": "Retrieve details of a specific account",
         "operationId": "getAccount",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -173,7 +188,9 @@
         "summary": "Get account balance",
         "description": "Retrieve current balance for an account",
         "operationId": "getAccountBalance",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -203,7 +220,9 @@
         "summary": "Get account transactions",
         "description": "Retrieve transaction history for an account",
         "operationId": "getAccountTransactions",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -257,7 +276,9 @@
         "summary": "Create payment",
         "description": "Initiate a payment transaction",
         "operationId": "createPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -288,7 +309,9 @@
         "summary": "List payments",
         "description": "Retrieve list of payments",
         "operationId": "listPayments",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "parameters": [
           {
             "name": "status",
@@ -325,7 +348,9 @@
         "summary": "Get payment details",
         "description": "Retrieve details of a specific payment",
         "operationId": "getPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "parameters": [
           {
             "name": "paymentId",
@@ -358,7 +383,9 @@
         "summary": "Create transfer",
         "description": "Execute a bank transfer",
         "operationId": "createTransfer",
-        "tags": ["Transfers"],
+        "tags": [
+          "Transfers"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -514,7 +541,12 @@
       },
       "PaymentRequest": {
         "type": "object",
-        "required": ["amount", "currency", "sourceAccount", "destinationAccount"],
+        "required": [
+          "amount",
+          "currency",
+          "sourceAccount",
+          "destinationAccount"
+        ],
         "properties": {
           "amount": {
             "type": "number"
@@ -574,7 +606,11 @@
       },
       "TransferRequest": {
         "type": "object",
-        "required": ["amount", "sourceAccount", "destinationAccount"],
+        "required": [
+          "amount",
+          "sourceAccount",
+          "destinationAccount"
+        ],
         "properties": {
           "amount": {
             "type": "number"
@@ -628,5 +664,19 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Payments"
+    },
+    {
+      "name": "Transfers"
+    }
+  ]
 }

--- a/apis/openapi/baremetrics.com/baremetrics-api/1.0.0/openapi.json
+++ b/apis/openapi/baremetrics.com/baremetrics-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Baremetrics API",
     "version": "1.0.0",
     "description": "Subscription analytics and revenue metrics API. Manage customers, subscriptions, plans, charges, annotations, goals, segments, and cancellation insights.",
-    "x-jentic-source-url": "https://developers.baremetrics.com/reference"
+    "x-jentic-source-url": "https://developers.baremetrics.com/reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -40,7 +41,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get account"
       }
     },
     "/sources": {
@@ -71,7 +73,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get sources"
       }
     },
     "/plans": {
@@ -105,7 +108,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List plans"
       },
       "post": {
         "operationId": "createPlan",
@@ -154,7 +158,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create plan"
       }
     },
     "/plans/{id}": {
@@ -195,7 +200,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get plan"
       },
       "put": {
         "operationId": "updatePlan",
@@ -254,7 +260,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update plan"
       },
       "delete": {
         "operationId": "deletePlan",
@@ -286,7 +293,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete plan"
       }
     },
     "/customers": {
@@ -320,7 +328,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List customers"
       },
       "post": {
         "operationId": "createCustomer",
@@ -369,7 +378,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create customer"
       }
     },
     "/customers/{id}": {
@@ -410,7 +420,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get customer"
       },
       "put": {
         "operationId": "updateCustomer",
@@ -469,7 +480,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update customer"
       },
       "delete": {
         "operationId": "deleteCustomer",
@@ -501,7 +513,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete customer"
       }
     },
     "/subscriptions": {
@@ -535,7 +548,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions"
       },
       "post": {
         "operationId": "createSubscription",
@@ -584,7 +598,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create subscription"
       }
     },
     "/subscriptions/{id}": {
@@ -625,7 +640,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get subscription"
       },
       "put": {
         "operationId": "updateSubscription",
@@ -684,7 +700,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update subscription"
       },
       "delete": {
         "operationId": "deleteSubscription",
@@ -716,7 +733,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete subscription"
       }
     },
     "/charges": {
@@ -750,7 +768,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List charges"
       },
       "post": {
         "operationId": "createCharge",
@@ -799,7 +818,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create charge"
       }
     },
     "/charges/{id}": {
@@ -840,7 +860,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get charge"
       },
       "put": {
         "operationId": "updateCharge",
@@ -899,7 +920,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update charge"
       },
       "delete": {
         "operationId": "deleteCharge",
@@ -931,7 +953,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete charge"
       }
     },
     "/annotations": {
@@ -965,7 +988,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List annotations"
       },
       "post": {
         "operationId": "createAnnotation",
@@ -1014,7 +1038,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create annotation"
       }
     },
     "/annotations/{id}": {
@@ -1055,7 +1080,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get annotation"
       },
       "put": {
         "operationId": "updateAnnotation",
@@ -1114,7 +1140,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update annotation"
       },
       "delete": {
         "operationId": "deleteAnnotation",
@@ -1146,7 +1173,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete annotation"
       }
     },
     "/goals": {
@@ -1180,7 +1208,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List goals"
       },
       "post": {
         "operationId": "createGoal",
@@ -1229,7 +1258,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create goal"
       }
     },
     "/goals/{id}": {
@@ -1270,7 +1300,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get goal"
       },
       "put": {
         "operationId": "updateGoal",
@@ -1329,7 +1360,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update goal"
       },
       "delete": {
         "operationId": "deleteGoal",
@@ -1361,7 +1393,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete goal"
       }
     },
     "/subscriptions/{id}/cancel": {
@@ -1395,7 +1428,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel subscription"
       }
     },
     "/customers/{id}/events": {
@@ -1439,7 +1473,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List customer events"
       }
     },
     "/events": {
@@ -1473,7 +1508,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List events"
       }
     },
     "/events/{id}": {
@@ -1514,7 +1550,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get event"
       }
     },
     "/metrics/summary": {
@@ -1545,7 +1582,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get metrics summary"
       }
     },
     "/metrics/{metric}": {
@@ -1579,7 +1617,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get specific metric"
       }
     },
     "/metrics/customers": {
@@ -1603,7 +1642,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get customer metrics"
       }
     },
     "/metrics/plan-breakout": {
@@ -1627,7 +1667,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get plan breakout metrics"
       }
     },
     "/metrics/cohorts": {
@@ -1651,7 +1692,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cohort analysis"
       }
     },
     "/users": {
@@ -1675,7 +1717,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List users"
       }
     },
     "/users/{id}": {
@@ -1709,7 +1752,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user"
       }
     },
     "/segments": {
@@ -1743,7 +1787,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List segments"
       },
       "post": {
         "operationId": "createSegment",
@@ -1785,7 +1830,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create segment"
       }
     },
     "/segments/{id}": {
@@ -1819,7 +1865,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get segment"
       },
       "put": {
         "operationId": "updateSegment",
@@ -1871,7 +1918,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update segment"
       },
       "delete": {
         "operationId": "deleteSegment",
@@ -1903,7 +1951,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete segment"
       }
     },
     "/segments/fields": {
@@ -1927,7 +1976,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List segment fields"
       }
     },
     "/segments/search": {
@@ -1961,7 +2011,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search segments"
       }
     },
     "/attributes": {
@@ -2005,7 +2056,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set customer attributes"
       }
     },
     "/attributes/fields": {
@@ -2029,7 +2081,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List attribute fields"
       },
       "post": {
         "operationId": "createAttributeField",
@@ -2071,7 +2124,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create attribute field"
       }
     },
     "/attributes/fields/{id}": {
@@ -2125,7 +2179,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update attribute field"
       }
     },
     "/cancellation-insights/events": {
@@ -2159,7 +2214,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List cancellation events"
       },
       "post": {
         "operationId": "createCancellationEvent",
@@ -2201,7 +2257,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create cancellation event"
       }
     },
     "/cancellation-insights/events/{id}": {
@@ -2235,7 +2292,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cancellation event"
       },
       "put": {
         "operationId": "updateCancellationEvent",
@@ -2287,7 +2345,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update cancellation event"
       }
     },
     "/cancellation-insights/reasons": {
@@ -2321,7 +2380,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List cancellation reasons"
       },
       "post": {
         "operationId": "createCancellationReason",
@@ -2363,7 +2423,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create cancellation reason"
       }
     },
     "/cancellation-insights/reasons/{id}": {
@@ -2397,7 +2458,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cancellation reason"
       },
       "put": {
         "operationId": "updateCancellationReason",
@@ -2449,7 +2511,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update cancellation reason"
       },
       "delete": {
         "operationId": "deleteCancellationReason",
@@ -2481,7 +2544,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete cancellation reason"
       }
     },
     "/refunds": {
@@ -2505,7 +2569,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List refunds"
       },
       "post": {
         "operationId": "createRefund",
@@ -2547,7 +2612,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create refund"
       }
     },
     "/refunds/{id}": {
@@ -2581,7 +2647,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get refund"
       },
       "delete": {
         "operationId": "deleteRefund",
@@ -2613,7 +2680,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete refund"
       }
     }
   },
@@ -2845,6 +2913,53 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Annotations"
+    },
+    {
+      "name": "Attributes"
+    },
+    {
+      "name": "Cancellation Insights"
+    },
+    {
+      "name": "Charges"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Goals"
+    },
+    {
+      "name": "Metrics"
+    },
+    {
+      "name": "Plans"
+    },
+    {
+      "name": "Refunds"
+    },
+    {
+      "name": "Segments"
+    },
+    {
+      "name": "Sources"
+    },
+    {
+      "name": "Subscriptions"
+    },
+    {
+      "name": "Users"
     }
   ]
 }

--- a/apis/openapi/base.customerpulze.com/pulze-api/1.0.0/openapi.json
+++ b/apis/openapi/base.customerpulze.com/pulze-api/1.0.0/openapi.json
@@ -3,7 +3,8 @@
   "info": {
     "title": "Pulze API",
     "version": "1.0.0",
-    "description": "API for Pulze (Zocra AI) Supabase Edge Functions - meeting management, records, OAuth, and calendar operations."
+    "description": "API for Pulze (Zocra AI) Supabase Edge Functions - meeting management, records, OAuth, and calendar operations.",
+    "contact": {}
   },
   "servers": [
     {
@@ -202,7 +203,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Join a meeting"
       }
     },
     "/calendar-review": {
@@ -243,7 +245,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Review calendar events"
       }
     },
     "/create-record": {
@@ -296,7 +299,8 @@
           "403": {
             "description": "Forbidden"
           }
-        }
+        },
+        "description": "Create a new record"
       }
     },
     "/import-records": {
@@ -381,7 +385,8 @@
           "403": {
             "description": "Forbidden"
           }
-        }
+        },
+        "description": "Get records data"
       },
       "post": {
         "tags": [
@@ -455,7 +460,8 @@
           "403": {
             "description": "Forbidden"
           }
-        }
+        },
+        "description": "Perform actions on records"
       }
     },
     "/oauth-authorize": {
@@ -517,7 +523,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "OAuth 2.0 Authorization"
       }
     },
     "/oauth-token": {
@@ -551,7 +558,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "Exchange code for token"
       }
     }
   }

--- a/apis/openapi/baselinker.com/baselinker/1.0.0/openapi.json
+++ b/apis/openapi/baselinker.com/baselinker/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BaseLinker API",
     "version": "1.0.0",
     "description": "The BaseLinker API enables information exchange between external systems and BaseLinker order manager, inventory management, and shipping. All requests are POST requests to a single connector endpoint, with method name and JSON parameters in the body.",
-    "x-jentic-source-url": "https://api.baselinker.com/?lang=en"
+    "x-jentic-source-url": "https://api.baselinker.com/?lang=en",
+    "contact": {}
   },
   "servers": [
     {
@@ -72,14 +73,6 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-BLToken",
-        "description": "BaseLinker API token from Account & other -> My account -> API"
-      }
-    },
     "schemas": {
       "ApiRequest": {
         "type": "object",
@@ -159,65 +152,6 @@
         "additionalProperties": true,
         "description": "Response body varies per method. Common fields: status (SUCCESS/ERROR). On error: error_code, error_message. On success: method-specific data fields."
       },
-      "Order": {
-        "type": "object",
-        "properties": {
-          "order_id": {
-            "type": "integer"
-          },
-          "shop_order_id": {
-            "type": "string"
-          },
-          "date_add": {
-            "type": "integer"
-          },
-          "date_confirmed": {
-            "type": "integer"
-          },
-          "status_id": {
-            "type": "integer"
-          },
-          "currency": {
-            "type": "string"
-          },
-          "payment_done": {
-            "type": "number"
-          },
-          "delivery_fullname": {
-            "type": "string"
-          },
-          "delivery_company": {
-            "type": "string"
-          },
-          "delivery_address": {
-            "type": "string"
-          },
-          "delivery_postcode": {
-            "type": "string"
-          },
-          "delivery_city": {
-            "type": "string"
-          },
-          "delivery_country_code": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          },
-          "want_invoice": {
-            "type": "boolean"
-          },
-          "products": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/OrderProduct"
-            }
-          }
-        }
-      },
       "OrderProduct": {
         "type": "object",
         "properties": {
@@ -247,36 +181,6 @@
           }
         }
       },
-      "InventoryProduct": {
-        "type": "object",
-        "properties": {
-          "product_id": {
-            "type": "integer"
-          },
-          "ean": {
-            "type": "string"
-          },
-          "sku": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "price_brutto": {
-            "type": "number"
-          },
-          "stock": {
-            "type": "object",
-            "description": "Stock per warehouse"
-          },
-          "category_id": {
-            "type": "integer"
-          },
-          "is_bundle": {
-            "type": "boolean"
-          }
-        }
-      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -292,5 +196,10 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "API"
+    }
+  ]
 }

--- a/apis/openapi/baselinker.com/baselinker/1.0.0/openapi.json
+++ b/apis/openapi/baselinker.com/baselinker/1.0.0/openapi.json
@@ -152,35 +152,6 @@
         "additionalProperties": true,
         "description": "Response body varies per method. Common fields: status (SUCCESS/ERROR). On error: error_code, error_message. On success: method-specific data fields."
       },
-      "OrderProduct": {
-        "type": "object",
-        "properties": {
-          "order_product_id": {
-            "type": "integer"
-          },
-          "product_id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          },
-          "sku": {
-            "type": "string"
-          },
-          "ean": {
-            "type": "string"
-          },
-          "quantity": {
-            "type": "integer"
-          },
-          "price_brutto": {
-            "type": "number"
-          },
-          "tax_rate": {
-            "type": "number"
-          }
-        }
-      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -194,6 +165,13 @@
             "type": "string"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   },

--- a/apis/openapi/basesnap.com/Basesnap/1.0.0/openapi.json
+++ b/apis/openapi/basesnap.com/Basesnap/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Basesnap API",
     "description": "API for database snapshots and backups",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://api.app.basesnap.com/api/v1/docs/"
+    "x-jentic-source-url": "https://api.app.basesnap.com/api/v1/docs/",
+    "contact": {}
   },
   "servers": [
     {
@@ -43,7 +44,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "snapshots"
+        ]
       },
       "post": {
         "operationId": "createSnapshot",
@@ -103,7 +107,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "snapshots"
+        ]
       }
     },
     "/snapshots/{id}/restore": {
@@ -147,6 +154,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "snapshots"
         ]
       }
     }
@@ -177,5 +187,10 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "snapshots"
+    }
+  ]
 }

--- a/apis/openapi/basware.com/basware-network-api/2.0.0/openapi.json
+++ b/apis/openapi/basware.com/basware-network-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Basware Network API",
     "version": "2.0.0",
     "description": "Basware Network API for managing invoices, notifications, and business documents in the Basware procurement network.",
-    "x-jentic-source-url": "https://network-developer.basware.com/api/"
+    "x-jentic-source-url": "https://network-developer.basware.com/api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -63,7 +64,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create notification (v1.1)"
       },
       "get": {
         "operationId": "listNotificationsV1",
@@ -129,7 +131,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List notifications (v1.1)"
       }
     },
     "/v1.1/notifications/{id}": {
@@ -181,7 +184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete notification (v1.1)"
       }
     },
     "/v2/notifications": {
@@ -235,7 +239,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create notification (v2)"
       },
       "get": {
         "operationId": "listNotificationsV2",
@@ -301,7 +306,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List notifications (v2)"
       }
     },
     "/v2/notifications/{id}": {
@@ -353,7 +359,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete notification (v2)"
       }
     },
     "/v3/invoices/{bumId}": {
@@ -406,7 +413,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get invoice details"
       }
     }
   },

--- a/apis/openapi/bbc.co.uk/radio-&-music-services/1.0.0/openapi.json
+++ b/apis/openapi/bbc.co.uk/radio-&-music-services/1.0.0/openapi.json
@@ -6118,65 +6118,6 @@
       },
       "type": "object"
     },
-    "EpisodeSummary": {
-      "properties": {
-        "ancestors": {
-          "items": {
-            "$ref": "#/definitions/AncestorSummary"
-          },
-          "type": "array"
-        },
-        "available_versions": {
-          "items": {
-            "$ref": "#/definitions/AvailableVersions"
-          },
-          "type": "array"
-        },
-        "images": {
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "media_type": {
-          "type": "string"
-        },
-        "network_summary": {
-          "$ref": "#/definitions/NetworkSummary"
-        },
-        "pid": {
-          "type": "string"
-        },
-        "release_date": {
-          "type": "string"
-        },
-        "short_synopsis": {
-          "type": "string"
-        },
-        "titles": {
-          "$ref": "#/definitions/ProgrammeTitles"
-        },
-        "type": {
-          "enum": [
-            "episode_summary"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "ancestors",
-        "available_versions",
-        "images",
-        "media_type",
-        "network_summary",
-        "pid",
-        "release_date",
-        "short_synopsis",
-        "titles",
-        "type"
-      ],
-      "type": "object"
-    },
     "Error": {
       "properties": {
         "href": {

--- a/apis/openapi/bbc.co.uk/radio-&-music-services/1.0.0/openapi.json
+++ b/apis/openapi/bbc.co.uk/radio-&-music-services/1.0.0/openapi.json
@@ -24,7 +24,8 @@
       }
     ],
     "x-providerName": "bbc.co.uk",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bbc.co.uk/1.0.0/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bbc.co.uk/1.0.0/swagger.yaml",
+    "contact": {}
   },
   "consumes": [
     "application/json"
@@ -302,7 +303,8 @@
         "summary": "Broadcasts",
         "tags": [
           "Broadcasts"
-        ]
+        ],
+        "operationId": "get-broadcasts"
       }
     },
     "/broadcasts/latest": {
@@ -403,7 +405,8 @@
         "summary": "Latest Broadcasts",
         "tags": [
           "Broadcasts"
-        ]
+        ],
+        "operationId": "get-broadcasts-latest"
       }
     },
     "/broadcasts/{pid}": {
@@ -494,7 +497,8 @@
         "summary": "List of categories",
         "tags": [
           "Categories"
-        ]
+        ],
+        "operationId": "get-categories"
       }
     },
     "/categories/{id}": {
@@ -533,7 +537,8 @@
         "summary": "Category by ID",
         "tags": [
           "Categories"
-        ]
+        ],
+        "operationId": "get-categories-by-id"
       }
     },
     "/collections/{pid}/members": {
@@ -1129,7 +1134,9 @@
         "summary": "Unfollow category",
         "tags": [
           "Personalised Categories"
-        ]
+        ],
+        "description": "Unfollow category",
+        "operationId": "delete-my-categories-follows"
       },
       "get": {
         "description": "List of followed categories for a given user.\n",
@@ -1181,7 +1188,8 @@
         "summary": "List of followed categories",
         "tags": [
           "Personalised Categories"
-        ]
+        ],
+        "operationId": "get-my-categories-follows"
       },
       "post": {
         "parameters": [
@@ -1229,7 +1237,9 @@
         "summary": "Follow category",
         "tags": [
           "Personalised Categories"
-        ]
+        ],
+        "description": "Follow category",
+        "operationId": "post-my-categories-follows"
       }
     },
     "/my/music/export": {
@@ -3405,7 +3415,9 @@
         "summary": "Unfollow network",
         "tags": [
           "Personalised Networks"
-        ]
+        ],
+        "description": "Unfollow network",
+        "operationId": "delete-my-networks-follows"
       },
       "get": {
         "description": "List of followed networks for a given user.\n",
@@ -3457,7 +3469,8 @@
         "summary": "List of followed networks",
         "tags": [
           "Personalised Networks"
-        ]
+        ],
+        "operationId": "get-my-networks-follows"
       },
       "post": {
         "parameters": [
@@ -3519,7 +3532,9 @@
         "summary": "Follow network",
         "tags": [
           "Personalised Networks"
-        ]
+        ],
+        "description": "Follow network",
+        "operationId": "post-my-networks-follows"
       }
     },
     "/my/plays": {
@@ -3572,7 +3587,9 @@
         "summary": "Write Play Event",
         "tags": [
           "Personalised Plays"
-        ]
+        ],
+        "description": "Write Play Event",
+        "operationId": "post-my-plays"
       }
     },
     "/my/playspace/containers/suggested": {
@@ -5768,60 +5785,6 @@
       ],
       "type": "object"
     },
-    "BrandSummary": {
-      "properties": {
-        "available_versions": {
-          "items": {
-            "$ref": "#/definitions/AvailableVersions"
-          },
-          "type": "array"
-        },
-        "images": {
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "latest_available_episodes": {
-          "items": {
-            "$ref": "#/definitions/EpisodeSummary"
-          },
-          "type": "array"
-        },
-        "network_summary": {
-          "$ref": "#/definitions/NetworkSummary"
-        },
-        "pid": {
-          "type": "string"
-        },
-        "short_synopsis": {
-          "type": "string"
-        },
-        "titles": {
-          "$ref": "#/definitions/ProgrammeTitles"
-        },
-        "total_available_episodes": {
-          "type": "integer"
-        },
-        "type": {
-          "enum": [
-            "brand_summary"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "images",
-        "latest_available_episodes",
-        "network_summary",
-        "pid",
-        "short_synopsis",
-        "titles",
-        "total_available_episodes",
-        "type"
-      ],
-      "type": "object"
-    },
     "Broadcast": {
       "properties": {
         "duration": {
@@ -6100,65 +6063,6 @@
       ],
       "type": "object"
     },
-    "ClipSummary": {
-      "properties": {
-        "ancestors": {
-          "items": {
-            "$ref": "#/definitions/AncestorSummary"
-          },
-          "type": "array"
-        },
-        "available_versions": {
-          "items": {
-            "$ref": "#/definitions/AvailableVersions"
-          },
-          "type": "array"
-        },
-        "images": {
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "media_type": {
-          "type": "string"
-        },
-        "network_summary": {
-          "$ref": "#/definitions/NetworkSummary"
-        },
-        "pid": {
-          "type": "string"
-        },
-        "release_date": {
-          "type": "string"
-        },
-        "short_synopsis": {
-          "type": "string"
-        },
-        "titles": {
-          "$ref": "#/definitions/ProgrammeTitles"
-        },
-        "type": {
-          "enum": [
-            "clip_summary"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "ancestors",
-        "available_versions",
-        "images",
-        "media_type",
-        "network_summary",
-        "pid",
-        "release_date",
-        "short_synopsis",
-        "titles",
-        "type"
-      ],
-      "type": "object"
-    },
     "Contact": {
       "properties": {
         "handle": {
@@ -6213,10 +6117,6 @@
         }
       },
       "type": "object"
-    },
-    "Empty": {
-      "type": "object",
-      "x-nullable": true
     },
     "EpisodeSummary": {
       "properties": {
@@ -7090,21 +6990,6 @@
         }
       },
       "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    "PersonalisedCategories": {
-      "properties": {
-        "created": {
-          "type": "string"
-        },
-        "type": {
-          "type": "string"
-        }
-      },
-      "required": [
-        "created",
         "type"
       ],
       "type": "object"
@@ -8376,55 +8261,6 @@
       ],
       "type": "object"
     },
-    "Programme": {
-      "properties": {
-        "images": {
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "latest_available_episodes": {
-          "items": {
-            "$ref": "#/definitions/EpisodeSummary"
-          },
-          "type": "array"
-        },
-        "network_summary": {
-          "$ref": "#/definitions/NetworkSummary"
-        },
-        "pid": {
-          "type": "string"
-        },
-        "short_synopsis": {
-          "type": "string"
-        },
-        "titles": {
-          "$ref": "#/definitions/ProgrammeTitles"
-        },
-        "total_available_episodes": {
-          "type": "integer"
-        },
-        "type": {
-          "enum": [
-            "brand_summary",
-            "series_summary",
-            "episode_summary",
-            "clip_summary"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "images",
-        "network_summary",
-        "pid",
-        "short_synopsis",
-        "titles",
-        "type"
-      ],
-      "type": "object"
-    },
     "ProgrammeSummary": {
       "properties": {
         "pid": {
@@ -8549,61 +8385,6 @@
       "required": [
         "$schema",
         "errors"
-      ],
-      "type": "object"
-    },
-    "SeriesSummary": {
-      "properties": {
-        "ancestors": {
-          "items": {
-            "$ref": "#/definitions/AncestorSummary"
-          },
-          "type": "array"
-        },
-        "images": {
-          "items": {
-            "$ref": "#/definitions/Image"
-          },
-          "type": "array"
-        },
-        "latest_available_episodes": {
-          "items": {
-            "$ref": "#/definitions/EpisodeSummary"
-          },
-          "type": "array"
-        },
-        "network_summary": {
-          "$ref": "#/definitions/NetworkSummary"
-        },
-        "pid": {
-          "type": "string"
-        },
-        "short_synopsis": {
-          "type": "string"
-        },
-        "titles": {
-          "$ref": "#/definitions/ProgrammeTitles"
-        },
-        "total_available_episodes": {
-          "type": "integer"
-        },
-        "type": {
-          "enum": [
-            "series_summary"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "ancestors",
-        "images",
-        "latest_available_episodes",
-        "network_summary",
-        "pid",
-        "short_synopsis",
-        "titles",
-        "total_available_episodes",
-        "type"
       ],
       "type": "object"
     },

--- a/apis/openapi/bbkonline.com/bbkonline/1.0.0/openapi.json
+++ b/apis/openapi/bbkonline.com/bbkonline/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/bbkonline.com/bbkonline/1.0.0/openapi.json
+++ b/apis/openapi/bbkonline.com/bbkonline/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BBK Open Banking API",
     "version": "1.0.0",
     "description": "Bank of Bahrain and Kuwait open banking",
-    "x-jentic-source-url": "https://developer.bbkonline.com/"
+    "x-jentic-source-url": "https://developer.bbkonline.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/bbot.menu/bbot-api/1.0.0/openapi.json
+++ b/apis/openapi/bbot.menu/bbot-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bbot API",
     "version": "1.0.0",
     "description": "Bbot is a restaurant ordering and delivery platform API. It provides endpoints for managing restaurants, menus, orders, guests, payments, and delivery capabilities.",
-    "x-jentic-source-url": "https://bbot.readme.io/reference/introduction"
+    "x-jentic-source-url": "https://bbot.readme.io/reference/introduction",
+    "contact": {}
   },
   "servers": [
     {
@@ -22,7 +23,9 @@
         "operationId": "authenticate",
         "summary": "Authenticate user",
         "description": "Obtain a JWT token for API access by providing username and password.",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -73,7 +76,9 @@
         "operationId": "listRestaurants",
         "summary": "List all restaurants",
         "description": "Retrieve a list of all restaurants accessible to the authenticated user.",
-        "tags": ["Restaurants"],
+        "tags": [
+          "Restaurants"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -116,7 +121,9 @@
         "operationId": "getRestaurantSettings",
         "summary": "Get restaurant settings",
         "description": "View integration settings for a specific restaurant.",
-        "tags": ["Restaurants"],
+        "tags": [
+          "Restaurants"
+        ],
         "parameters": [
           {
             "name": "restaurant_id",
@@ -167,7 +174,9 @@
         "operationId": "updateRestaurantSettings",
         "summary": "Update restaurant settings",
         "description": "Modify restaurant integration settings.",
-        "tags": ["Restaurants"],
+        "tags": [
+          "Restaurants"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -210,7 +219,9 @@
         "operationId": "listOrders",
         "summary": "List orders",
         "description": "Retrieve orders for a restaurant with optional filtering.",
-        "tags": ["Orders"],
+        "tags": [
+          "Orders"
+        ],
         "parameters": [
           {
             "name": "restaurant_id",
@@ -274,7 +285,9 @@
         "operationId": "getOrder",
         "summary": "Get a single order",
         "description": "Get detailed information for a single order.",
-        "tags": ["Orders"],
+        "tags": [
+          "Orders"
+        ],
         "parameters": [
           {
             "name": "order_id",
@@ -325,7 +338,9 @@
         "operationId": "getMenus",
         "summary": "Get menus",
         "description": "Retrieve menu structure with items and modifiers for a restaurant.",
-        "tags": ["Menus"],
+        "tags": [
+          "Menus"
+        ],
         "parameters": [
           {
             "name": "restaurant_id",
@@ -388,7 +403,9 @@
         "operationId": "asyncUpsertMenu",
         "summary": "Async upsert menu",
         "description": "Asynchronously create or update menu data.",
-        "tags": ["Menus"],
+        "tags": [
+          "Menus"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -438,7 +455,9 @@
         "operationId": "getAsyncUpsertStatus",
         "summary": "Check async upsert status",
         "description": "Check the status of an async menu upsert operation.",
-        "tags": ["Menus"],
+        "tags": [
+          "Menus"
+        ],
         "parameters": [
           {
             "name": "idempotency_id",
@@ -489,7 +508,9 @@
         "operationId": "getTables",
         "summary": "Get ordering pages",
         "description": "Get ordering page configurations (tables) for a restaurant.",
-        "tags": ["Tables"],
+        "tags": [
+          "Tables"
+        ],
         "parameters": [
           {
             "name": "restaurant_id",
@@ -543,7 +564,9 @@
         "operationId": "getFulfillableMenuItems",
         "summary": "Get fulfillable menu items",
         "description": "Get available menu items for a specific ordering page.",
-        "tags": ["Menus"],
+        "tags": [
+          "Menus"
+        ],
         "parameters": [
           {
             "name": "table_short_id",
@@ -594,7 +617,9 @@
         "operationId": "canDeliver",
         "summary": "Check delivery capability",
         "description": "Check if a restaurant can deliver to a given address.",
-        "tags": ["Delivery"],
+        "tags": [
+          "Delivery"
+        ],
         "parameters": [
           {
             "name": "restaurant_id",
@@ -650,7 +675,9 @@
         "operationId": "createGuest",
         "summary": "Create a guest",
         "description": "Create a new guest account.",
-        "tags": ["Guests"],
+        "tags": [
+          "Guests"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -700,7 +727,9 @@
         "operationId": "getGuests",
         "summary": "Get guest information",
         "description": "Retrieve guest profile information.",
-        "tags": ["Guests"],
+        "tags": [
+          "Guests"
+        ],
         "parameters": [
           {
             "name": "guest_id",
@@ -751,7 +780,9 @@
         "operationId": "priceCheck",
         "summary": "Price check",
         "description": "Calculate cart prices with taxes and fees.",
-        "tags": ["Pricing"],
+        "tags": [
+          "Pricing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -801,7 +832,9 @@
         "operationId": "createStripeSetupIntent",
         "summary": "Create Stripe setup intent",
         "description": "Initialize a Stripe payment setup intent.",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "responses": {
           "200": {
             "description": "Setup intent created",
@@ -847,14 +880,19 @@
         "operationId": "saveStripePaymentMethod",
         "summary": "Save Stripe payment method",
         "description": "Save a payment method for a guest.",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["stripe_payment_method_id", "guest_id"],
+                "required": [
+                  "stripe_payment_method_id",
+                  "guest_id"
+                ],
                 "properties": {
                   "stripe_payment_method_id": {
                     "type": "string",
@@ -913,7 +951,9 @@
         "operationId": "getPaymentMethods",
         "summary": "Get payment methods",
         "description": "List saved payment methods for a guest.",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "parameters": [
           {
             "name": "guest_id",
@@ -967,7 +1007,9 @@
         "operationId": "checkout",
         "summary": "Checkout",
         "description": "Submit an order for payment processing.",
-        "tags": ["Checkout"],
+        "tags": [
+          "Checkout"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1017,152 +1059,318 @@
     "schemas": {
       "AuthRequest": {
         "type": "object",
-        "required": ["username", "password"],
+        "required": [
+          "username",
+          "password"
+        ],
         "properties": {
-          "username": { "type": "string" },
-          "password": { "type": "string" }
+          "username": {
+            "type": "string"
+          },
+          "password": {
+            "type": "string"
+          }
         }
       },
       "AuthResponse": {
         "type": "object",
         "properties": {
-          "token": { "type": "string", "description": "JWT token for API access" }
+          "token": {
+            "type": "string",
+            "description": "JWT token for API access"
+          }
         }
       },
       "Restaurant": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "description": "Restaurant ID" },
-          "name": { "type": "string", "description": "Restaurant name" },
-          "address": { "type": "string" }
+          "id": {
+            "type": "string",
+            "description": "Restaurant ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Restaurant name"
+          },
+          "address": {
+            "type": "string"
+          }
         }
       },
       "RestaurantSettings": {
         "type": "object",
         "properties": {
-          "restaurant_id": { "type": "string" },
-          "settings": { "type": "object" }
+          "restaurant_id": {
+            "type": "string"
+          },
+          "settings": {
+            "type": "object"
+          }
         }
       },
       "Order": {
         "type": "object",
         "properties": {
-          "order_id": { "type": "string" },
-          "restaurant_id": { "type": "string" },
-          "status": { "type": "string" },
-          "items": { "type": "array", "items": { "$ref": "#/components/schemas/OrderItem" } },
-          "total": { "type": "number", "format": "float" },
-          "created_at": { "type": "string", "format": "date-time" }
+          "order_id": {
+            "type": "string"
+          },
+          "restaurant_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OrderItem"
+            }
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "OrderItem": {
         "type": "object",
         "properties": {
-          "item_id": { "type": "string" },
-          "name": { "type": "string" },
-          "quantity": { "type": "integer" },
-          "price": { "type": "number", "format": "float" },
-          "modifications": { "type": "array", "items": { "type": "string" } }
+          "item_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "modifications": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "Menu": {
         "type": "object",
         "properties": {
-          "menu_id": { "type": "string" },
-          "name": { "type": "string" },
-          "items": { "type": "array", "items": { "$ref": "#/components/schemas/MenuItem" } }
+          "menu_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MenuItem"
+            }
+          }
         }
       },
       "MenuItem": {
         "type": "object",
         "properties": {
-          "item_id": { "type": "string" },
-          "name": { "type": "string" },
-          "description": { "type": "string" },
-          "price": { "type": "number", "format": "float" },
-          "modifiers": { "type": "array", "items": { "type": "object" } }
+          "item_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "price": {
+            "type": "number",
+            "format": "float"
+          },
+          "modifiers": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
         }
       },
       "AsyncUpsertResponse": {
         "type": "object",
         "properties": {
-          "idempotency_id": { "type": "string" },
-          "status": { "type": "string", "enum": ["pending"] }
+          "idempotency_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending"
+            ]
+          }
         }
       },
       "AsyncUpsertStatus": {
         "type": "object",
         "properties": {
-          "idempotency_id": { "type": "string" },
-          "status": { "type": "string", "enum": ["pending", "success", "failure"] },
-          "results": { "type": "object" }
+          "idempotency_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "success",
+              "failure"
+            ]
+          },
+          "results": {
+            "type": "object"
+          }
         }
       },
       "Table": {
         "type": "object",
         "properties": {
-          "table_id": { "type": "string" },
-          "short_id": { "type": "string" },
-          "name": { "type": "string" },
-          "fulfillment_methods": { "type": "array", "items": { "type": "string" } }
+          "table_id": {
+            "type": "string"
+          },
+          "short_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "fulfillment_methods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "FulfillableMenuItemsResponse": {
         "type": "object",
         "properties": {
-          "item_ids": { "type": "array", "items": { "type": "string" } },
-          "hash": { "type": "string" }
+          "item_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "hash": {
+            "type": "string"
+          }
         }
       },
       "Guest": {
         "type": "object",
         "properties": {
-          "guest_id": { "type": "string" },
-          "email": { "type": "string" },
-          "name": { "type": "string" },
-          "phone": { "type": "string" }
+          "guest_id": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
         }
       },
       "GuestCreateRequest": {
         "type": "object",
         "properties": {
-          "email": { "type": "string" },
-          "name": { "type": "string" },
-          "phone": { "type": "string" }
+          "email": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
         }
       },
       "PriceCheckResponse": {
         "type": "object",
         "properties": {
-          "line_items": { "type": "array", "items": { "type": "object" } },
-          "taxes": { "type": "number", "format": "float" },
-          "fees": { "type": "number", "format": "float" },
-          "total": { "type": "number", "format": "float" }
+          "line_items": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "taxes": {
+            "type": "number",
+            "format": "float"
+          },
+          "fees": {
+            "type": "number",
+            "format": "float"
+          },
+          "total": {
+            "type": "number",
+            "format": "float"
+          }
         }
       },
       "PaymentMethod": {
         "type": "object",
         "properties": {
-          "card_id": { "type": "string" },
-          "last4": { "type": "string" },
-          "brand": { "type": "string" },
-          "exp_month": { "type": "integer" },
-          "exp_year": { "type": "integer" }
+          "card_id": {
+            "type": "string"
+          },
+          "last4": {
+            "type": "string"
+          },
+          "brand": {
+            "type": "string"
+          },
+          "exp_month": {
+            "type": "integer"
+          },
+          "exp_year": {
+            "type": "integer"
+          }
         }
       },
       "CheckoutResponse": {
         "type": "object",
         "properties": {
-          "order_ids": { "type": "array", "items": { "type": "string" } },
-          "success": { "type": "boolean" }
+          "order_ids": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "success": {
+            "type": "boolean"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "enum": ["error"] },
-          "code": { "type": "string" },
-          "message": { "type": "string" }
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -1177,6 +1385,38 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Checkout"
+    },
+    {
+      "name": "Delivery"
+    },
+    {
+      "name": "Guests"
+    },
+    {
+      "name": "Menus"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "Payments"
+    },
+    {
+      "name": "Pricing"
+    },
+    {
+      "name": "Restaurants"
+    },
+    {
+      "name": "Tables"
     }
   ]
 }

--- a/apis/openapi/beanstream.com/beanstream-payments/1.0.1/openapi.json
+++ b/apis/openapi/beanstream.com/beanstream-payments/1.0.1/openapi.json
@@ -30,7 +30,8 @@
       "bank-neutral",
       "omni-channel reporting"
     ],
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/beanstream.com/1.0.1/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/beanstream.com/1.0.1/swagger.yaml",
+    "contact": {}
   },
   "produces": [
     "application/json"
@@ -95,7 +96,8 @@
         "summary": "Make Payment",
         "tags": [
           "Payments"
-        ]
+        ],
+        "operationId": "post-payments"
       }
     },
     "/payments/{transId}": {
@@ -158,7 +160,8 @@
         "summary": "Get payment",
         "tags": [
           "Payments"
-        ]
+        ],
+        "operationId": "get-payments-by-transid"
       }
     },
     "/payments/{transId}/completions": {
@@ -228,7 +231,8 @@
         "summary": "Complete pre-auth",
         "tags": [
           "Payments"
-        ]
+        ],
+        "operationId": "post-payments-by-transid-completions"
       }
     },
     "/payments/{transId}/returns": {
@@ -299,7 +303,8 @@
         "summary": "Return payment",
         "tags": [
           "Payments"
-        ]
+        ],
+        "operationId": "post-payments-by-transid-returns"
       }
     },
     "/payments/{transId}/void": {
@@ -370,7 +375,8 @@
         "summary": "Void Transaction",
         "tags": [
           "Payments"
-        ]
+        ],
+        "operationId": "post-payments-by-transid-void"
       }
     },
     "/profiles": {
@@ -433,7 +439,8 @@
         "summary": "Create Profile",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "post-profiles"
       }
     },
     "/profiles/{profileId}": {
@@ -495,7 +502,8 @@
         "summary": "Delete profile",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "delete-profiles-by-profileid"
       },
       "get": {
         "description": "Get a Payment Profile using the profile ID, also known as the Customer Code.",
@@ -555,7 +563,8 @@
         "summary": "Get profile",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "get-profiles-by-profileid"
       },
       "put": {
         "description": "Create a new Payment Profile using either a card or a Legato token. You must supply one of them.",
@@ -623,7 +632,8 @@
         "summary": "Update Profile",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "put-profiles-by-profileid"
       }
     },
     "/profiles/{profileId}/cards": {
@@ -685,7 +695,8 @@
         "summary": "Get cards",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "get-profiles-by-profileid-cards"
       },
       "post": {
         "description": "Add a card to the profile. Note that there is a default limit of 1 card per profile. You can change this in your Profiles settings in the back office.",
@@ -754,7 +765,8 @@
         "summary": "Add card",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "post-profiles-by-profileid-cards"
       }
     },
     "/profiles/{profileId}/cards/{cardId}": {
@@ -824,7 +836,8 @@
         "summary": "Delete card",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "delete-profiles-by-profileid-cards-by-cardid"
       },
       "put": {
         "description": "Update the details of a card on the profile.",
@@ -901,7 +914,8 @@
         "summary": "Update card",
         "tags": [
           "Profiles"
-        ]
+        ],
+        "operationId": "put-profiles-by-profileid-cards-by-cardid"
       }
     },
     "/reports": {
@@ -963,7 +977,8 @@
         "summary": "Search Query",
         "tags": [
           "Reporting"
-        ]
+        ],
+        "operationId": "post-reports"
       }
     },
     "/scripts/tokenization/tokens": {
@@ -989,7 +1004,8 @@
         "summary": "Tokenize credit card",
         "tags": [
           "Tokenization"
-        ]
+        ],
+        "operationId": "post-scripts-tokenization-tokens"
       }
     }
   },
@@ -1356,12 +1372,10 @@
           "type": "number"
         },
         "billing": {
-          "$ref": "#/definitions/Address",
-          "description": "The billing address"
+          "$ref": "#/definitions/Address"
         },
         "card": {
-          "$ref": "#/definitions/Card",
-          "description": "Payment with a credit card. The payment_method must be 'card'"
+          "$ref": "#/definitions/Card"
         },
         "comments": {
           "description": "alphanumeric (256)",
@@ -1387,20 +1401,17 @@
           "type": "string"
         },
         "payment_profile": {
-          "$ref": "#/definitions/ProfilePurchase",
-          "description": "Payment with a Payment Profile. The payment_method must be 'payment_profile'"
+          "$ref": "#/definitions/ProfilePurchase"
         },
         "shipping": {
-          "$ref": "#/definitions/Address",
-          "description": "The shipping address"
+          "$ref": "#/definitions/Address"
         },
         "term_url": {
           "description": "alphanumeric (256)",
           "type": "string"
         },
         "token": {
-          "$ref": "#/definitions/TokenPurchase",
-          "description": "Payment with a Legato token. The payment_method must be 'token'"
+          "$ref": "#/definitions/TokenPurchase"
         }
       },
       "required": [
@@ -2038,5 +2049,19 @@
         "amount"
       ]
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Payments"
+    },
+    {
+      "name": "Profiles"
+    },
+    {
+      "name": "Reporting"
+    },
+    {
+      "name": "Tokenization"
+    }
+  ]
 }

--- a/apis/openapi/beatport.com/beatport-api/4.0.0/openapi.json
+++ b/apis/openapi/beatport.com/beatport-api/4.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Beatport API",
     "version": "4.0.0",
     "description": "Beatport music catalog API for accessing tracks, releases, artists, labels, and charts.",
-    "x-jentic-source-url": "https://api.beatport.com/v4/docs/"
+    "x-jentic-source-url": "https://api.beatport.com/v4/docs/",
+    "contact": {}
   },
   "servers": [
     {
@@ -725,6 +726,26 @@
   "security": [
     {
       "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Artists"
+    },
+    {
+      "name": "Charts"
+    },
+    {
+      "name": "Genres"
+    },
+    {
+      "name": "Labels"
+    },
+    {
+      "name": "Releases"
+    },
+    {
+      "name": "Tracks"
     }
   ]
 }

--- a/apis/openapi/beehiiv.com/beehiiv-api/1.0/openapi.json
+++ b/apis/openapi/beehiiv.com/beehiiv-api/1.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "beehiiv API",
     "version": "1.0",
     "description": "beehiiv newsletter platform API",
-    "x-jentic-source-url": "https://developers.beehiiv.com/"
+    "x-jentic-source-url": "https://developers.beehiiv.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -114,7 +115,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List publications"
       }
     },
     "/publications/{publicationId}": {
@@ -165,7 +167,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get publication"
       }
     },
     "/publications/{publicationId}/posts": {
@@ -216,7 +219,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List posts"
       },
       "post": {
         "summary": "Create post",
@@ -265,7 +269,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create post"
       }
     },
     "/publications/{publicationId}/posts/{postId}": {
@@ -324,7 +329,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get post"
       },
       "delete": {
         "summary": "Delete post",
@@ -381,7 +387,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete post"
       }
     },
     "/publications/{publicationId}/subscriptions": {
@@ -432,7 +439,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions"
       },
       "post": {
         "summary": "Create subscription",
@@ -481,7 +489,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create subscription"
       }
     },
     "/publications/{publicationId}/subscriptions/{subscriptionId}": {
@@ -540,7 +549,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get subscription"
       },
       "patch": {
         "summary": "Update subscription",
@@ -597,7 +607,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update subscription"
       }
     },
     "/publications/{publicationId}/automations": {
@@ -648,7 +659,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List automations"
       }
     },
     "/publications/{publicationId}/segments": {
@@ -699,7 +711,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List segments"
       }
     },
     "/publications/{publicationId}/email_blasts": {
@@ -750,7 +763,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List email blasts"
       }
     },
     "/publications/{publicationId}/referral_program": {
@@ -801,8 +815,32 @@
               }
             }
           }
-        }
+        },
+        "description": "Get referral program"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Automations"
+    },
+    {
+      "name": "Email Blasts"
+    },
+    {
+      "name": "Posts"
+    },
+    {
+      "name": "Publications"
+    },
+    {
+      "name": "Referrals"
+    },
+    {
+      "name": "Segments"
+    },
+    {
+      "name": "Subscriptions"
+    }
+  ]
 }

--- a/apis/openapi/belfius.be/belfius/1.0.0/openapi.json
+++ b/apis/openapi/belfius.be/belfius/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Belfius Open Banking API",
     "description": "Belfius Open Banking APIs for PSD2 compliance including Account Information Services (AIS), Payment Initiation Service (PIS), and Confirmation of Availability of Funds (CAF). Restricted to authorized Third Party Providers operating under PSD2 regulations.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developer.belfius.be/"
+    "x-jentic-source-url": "https://developer.belfius.be/",
+    "contact": {}
   },
   "servers": [
     {
@@ -23,7 +24,9 @@
         "summary": "List accounts",
         "description": "Retrieve list of accounts accessible by the TPP",
         "operationId": "listAccounts",
-        "tags": ["Account Information"],
+        "tags": [
+          "Account Information"
+        ],
         "responses": {
           "200": {
             "description": "List of accounts",
@@ -54,7 +57,9 @@
         "summary": "Get account details",
         "description": "Retrieve details of a specific account",
         "operationId": "getAccount",
-        "tags": ["Account Information"],
+        "tags": [
+          "Account Information"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -87,7 +92,9 @@
         "summary": "Get account balances",
         "description": "Retrieve balances for a specific account",
         "operationId": "getAccountBalances",
-        "tags": ["Account Information"],
+        "tags": [
+          "Account Information"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -125,7 +132,9 @@
         "summary": "Get account transactions",
         "description": "Retrieve transaction history for a specific account",
         "operationId": "getAccountTransactions",
-        "tags": ["Account Information"],
+        "tags": [
+          "Account Information"
+        ],
         "parameters": [
           {
             "name": "accountId",
@@ -179,7 +188,9 @@
         "summary": "Initiate SEPA credit transfer",
         "description": "Initiate a SEPA credit transfer payment",
         "operationId": "initiatePayment",
-        "tags": ["Payment Initiation"],
+        "tags": [
+          "Payment Initiation"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -215,7 +226,9 @@
         "summary": "Get payment status",
         "description": "Retrieve status of a payment initiation",
         "operationId": "getPaymentStatus",
-        "tags": ["Payment Initiation"],
+        "tags": [
+          "Payment Initiation"
+        ],
         "parameters": [
           {
             "name": "paymentId",
@@ -246,7 +259,9 @@
         "summary": "Cancel payment",
         "description": "Cancel a payment initiation",
         "operationId": "cancelPayment",
-        "tags": ["Payment Initiation"],
+        "tags": [
+          "Payment Initiation"
+        ],
         "parameters": [
           {
             "name": "paymentId",
@@ -272,7 +287,9 @@
         "summary": "Confirm funds availability",
         "description": "Check if sufficient funds are available on a payment account",
         "operationId": "confirmFunds",
-        "tags": ["Funds Confirmation"],
+        "tags": [
+          "Funds Confirmation"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -380,7 +397,11 @@
         "properties": {
           "balanceType": {
             "type": "string",
-            "enum": ["closingBooked", "expected", "interimAvailable"]
+            "enum": [
+              "closingBooked",
+              "expected",
+              "interimAvailable"
+            ]
           },
           "balanceAmount": {
             "type": "object",
@@ -437,7 +458,12 @@
       },
       "PaymentInitiationRequest": {
         "type": "object",
-        "required": ["instructedAmount", "debtorAccount", "creditorAccount", "creditorName"],
+        "required": [
+          "instructedAmount",
+          "debtorAccount",
+          "creditorAccount",
+          "creditorName"
+        ],
         "properties": {
           "instructedAmount": {
             "type": "object",
@@ -493,13 +519,24 @@
         "properties": {
           "transactionStatus": {
             "type": "string",
-            "enum": ["ACCP", "ACTC", "ACSC", "ACSP", "RJCT", "CANC", "PDNG"]
+            "enum": [
+              "ACCP",
+              "ACTC",
+              "ACSC",
+              "ACSP",
+              "RJCT",
+              "CANC",
+              "PDNG"
+            ]
           }
         }
       },
       "FundsConfirmationRequest": {
         "type": "object",
-        "required": ["account", "instructedAmount"],
+        "required": [
+          "account",
+          "instructedAmount"
+        ],
         "properties": {
           "account": {
             "type": "object",
@@ -559,5 +596,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Account Information"
+    },
+    {
+      "name": "Funds Confirmation"
+    },
+    {
+      "name": "Payment Initiation"
+    }
+  ]
 }

--- a/apis/openapi/besmartee.com/besmartee-api/1.0.0/openapi.json
+++ b/apis/openapi/besmartee.com/besmartee-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BeSmartee API",
     "version": "1.0.0",
     "description": "BeSmartee provides mortgage technology API for lenders, partners, and AMC integrations including loan management, pricing, and document handling.",
-    "x-jentic-source-url": "https://api.besmartee.com/api/docs/overview"
+    "x-jentic-source-url": "https://api.besmartee.com/api/docs/overview",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Generate authentication token"
       }
     },
     "/access-token/destroy": {
@@ -97,7 +99,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Revoke authentication token"
       }
     },
     "/broker-setup-url": {
@@ -141,7 +144,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create broker setup URL"
       }
     },
     "/connect-vendor": {
@@ -185,7 +189,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Connect vendor"
       }
     },
     "/set-signup-product-pricing": {
@@ -229,7 +234,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set product pricing"
       }
     },
     "/app-signup": {
@@ -263,7 +269,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Application signup"
       }
     },
     "/email-application": {
@@ -307,7 +314,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Email application"
       }
     },
     "/update-headshot": {
@@ -351,7 +359,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update profile image"
       }
     },
     "/set-account-status": {
@@ -395,7 +404,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set account status"
       }
     },
     "/add-users": {
@@ -439,7 +449,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add users"
       }
     },
     "/update/user": {
@@ -483,7 +494,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update user"
       }
     },
     "/get-single-sign-on-url": {
@@ -527,7 +539,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get SSO URL"
       }
     },
     "/get-apr-closing-costs": {
@@ -571,7 +584,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get APR and closing costs"
       }
     },
     "/get-ppe-anonymous": {
@@ -615,7 +629,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get anonymous pricing data"
       }
     },
     "/rate-watch": {
@@ -659,7 +674,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Rate monitoring"
       }
     },
     "/get-list-loans": {
@@ -703,7 +719,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get loan list"
       }
     },
     "/create-notifications": {
@@ -747,7 +764,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create notifications"
       }
     },
     "/get-internal-users": {
@@ -791,7 +809,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get internal users"
       }
     },
     "/custom-ppe/update-rates-points": {
@@ -835,7 +854,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update custom pricing"
       }
     },
     "/create-loan": {
@@ -879,7 +899,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create loan"
       }
     },
     "/import-loan": {
@@ -923,7 +944,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Import loan"
       }
     },
     "/download-documents": {
@@ -967,7 +989,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download documents"
       }
     },
     "/upload-documents": {
@@ -1011,7 +1034,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload documents"
       }
     },
     "/download-condition-documents": {
@@ -1055,7 +1079,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download condition documents"
       }
     },
     "/set-esign-url": {
@@ -1099,7 +1124,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set e-signature URL"
       }
     },
     "/add-coborrowers": {
@@ -1143,7 +1169,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add co-borrowers"
       }
     },
     "/get-loan-data": {
@@ -1187,7 +1214,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get loan data"
       }
     },
     "/get-loan-borrower-data": {
@@ -1231,7 +1259,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get borrower data"
       }
     },
     "/create-lead": {
@@ -1275,7 +1304,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create lead"
       }
     },
     "/add-conditions": {
@@ -1319,7 +1349,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add conditions"
       }
     },
     "/update-loan-data": {
@@ -1363,7 +1394,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update loan data"
       }
     },
     "/update-loan-fee": {
@@ -1407,7 +1439,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update loan fee"
       }
     },
     "/orders": {
@@ -1451,7 +1484,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Submit appraisal order"
       }
     },
     "/order": {
@@ -1495,7 +1529,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get single order"
       }
     },
     "/order/status": {
@@ -1539,7 +1574,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Check order status"
       }
     },
     "/order/update": {
@@ -1583,7 +1619,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update order status"
       }
     }
   },
@@ -1617,6 +1654,32 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "AMC"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Documents"
+    },
+    {
+      "name": "Leads"
+    },
+    {
+      "name": "Lender"
+    },
+    {
+      "name": "Loans"
+    },
+    {
+      "name": "Notifications"
+    },
+    {
+      "name": "Pricing"
     }
   ]
 }

--- a/apis/openapi/bestbuy.com/bestbuy-api/1.0.0/openapi.json
+++ b/apis/openapi/bestbuy.com/bestbuy-api/1.0.0/openapi.json
@@ -26,7 +26,9 @@
         "operationId": "getProducts",
         "summary": "Get Products",
         "description": "Retrieve a collection of products. Supports search, filtering, sorting, and pagination.",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "format",
@@ -34,7 +36,10 @@
             "description": "Response format",
             "schema": {
               "type": "string",
-              "enum": ["json", "xml"],
+              "enum": [
+                "json",
+                "xml"
+              ],
               "default": "xml"
             }
           },
@@ -133,7 +138,9 @@
         "operationId": "getProductBySku",
         "summary": "Get Product by SKU",
         "description": "Retrieve details for a specific product by its SKU number.",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -183,7 +190,9 @@
         "operationId": "getProductWarranties",
         "summary": "Get Product Warranties",
         "description": "Retrieve warranty information for a specific product SKU.",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -229,7 +238,9 @@
         "operationId": "getProductStoreAvailability",
         "summary": "Get Product Store Availability",
         "description": "Check in-store availability for a specific product.",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -291,14 +302,19 @@
         "operationId": "getStores",
         "summary": "Get Stores",
         "description": "Retrieve a collection of Best Buy store locations. Supports area search, filtering, and pagination.",
-        "tags": ["Stores"],
+        "tags": [
+          "Stores"
+        ],
         "parameters": [
           {
             "name": "format",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["json", "xml"],
+              "enum": [
+                "json",
+                "xml"
+              ],
               "default": "xml"
             }
           },
@@ -363,7 +379,9 @@
         "operationId": "getStoreById",
         "summary": "Get Store by ID",
         "description": "Retrieve details for a specific Best Buy store.",
-        "tags": ["Stores"],
+        "tags": [
+          "Stores"
+        ],
         "parameters": [
           {
             "name": "storeId",
@@ -411,14 +429,19 @@
         "operationId": "getCategories",
         "summary": "Get Categories",
         "description": "Retrieve a collection of product categories.",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "parameters": [
           {
             "name": "format",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["json", "xml"],
+              "enum": [
+                "json",
+                "xml"
+              ],
               "default": "xml"
             }
           },
@@ -475,7 +498,9 @@
         "operationId": "getCategoryById",
         "summary": "Get Category by ID",
         "description": "Retrieve details for a specific category.",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "parameters": [
           {
             "name": "categoryId",
@@ -513,7 +538,9 @@
         "operationId": "getTrendingViewedProducts",
         "summary": "Get Trending Viewed Products",
         "description": "Retrieve trending products by category. Returns products that are most popular right now.",
-        "tags": ["Recommendations"],
+        "tags": [
+          "Recommendations"
+        ],
         "parameters": [
           {
             "name": "categoryId",
@@ -552,7 +579,9 @@
         "operationId": "getMostViewedProducts",
         "summary": "Get Most Viewed Products",
         "description": "Retrieve the most viewed products by category.",
-        "tags": ["Recommendations"],
+        "tags": [
+          "Recommendations"
+        ],
         "parameters": [
           {
             "name": "categoryId",
@@ -590,7 +619,9 @@
         "operationId": "getAlsoViewedProducts",
         "summary": "Get Also Viewed Products",
         "description": "Retrieve products that were also viewed by customers who viewed the specified product.",
-        "tags": ["Recommendations"],
+        "tags": [
+          "Recommendations"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -628,7 +659,9 @@
         "operationId": "getAlsoBoughtProducts",
         "summary": "Get Also Bought Products",
         "description": "Retrieve products frequently purchased together with the specified product.",
-        "tags": ["Recommendations"],
+        "tags": [
+          "Recommendations"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -666,7 +699,9 @@
         "operationId": "getViewedUltimatelyBoughtProducts",
         "summary": "Get Viewed Ultimately Bought Products",
         "description": "Retrieve products that customers ultimately purchased after viewing the specified product.",
-        "tags": ["Recommendations"],
+        "tags": [
+          "Recommendations"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -704,7 +739,9 @@
         "operationId": "getOpenBoxBySku",
         "summary": "Get Open Box Offers for SKU",
         "description": "Retrieve open box offers and pricing for a specific product SKU.",
-        "tags": ["Open Box"],
+        "tags": [
+          "Open Box"
+        ],
         "parameters": [
           {
             "name": "sku",
@@ -742,7 +779,9 @@
         "operationId": "getOpenBoxProducts",
         "summary": "Get Open Box Products",
         "description": "Retrieve open box product offers filtered by SKU list or category.",
-        "tags": ["Open Box"],
+        "tags": [
+          "Open Box"
+        ],
         "parameters": [
           {
             "name": "categoryId",
@@ -1308,5 +1347,22 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Categories"
+    },
+    {
+      "name": "Open Box"
+    },
+    {
+      "name": "Products"
+    },
+    {
+      "name": "Recommendations"
+    },
+    {
+      "name": "Stores"
+    }
+  ]
 }

--- a/apis/openapi/bic-boxtech.org/bic-boxtech/2.0.0/openapi.json
+++ b/apis/openapi/bic-boxtech.org/bic-boxtech/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BIC-BoxTech API",
     "description": "Container technical detail for the global container fleet. The BoxTech API provides access to the BIC Global Container Database, enabling lookup of container specifications, BIC code verification, fleet management, and alert handling.",
     "version": "2.0.0",
-    "x-jentic-source-url": "https://docs.bic-boxtech.org/"
+    "x-jentic-source-url": "https://docs.bic-boxtech.org/",
+    "contact": {}
   },
   "servers": [
     {
@@ -54,7 +55,9 @@
   "paths": {
     "/oauth/token": {
       "post": {
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "summary": "Obtain an access token",
         "operationId": "getToken",
         "security": [
@@ -68,11 +71,15 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["grant_type"],
+                "required": [
+                  "grant_type"
+                ],
                 "properties": {
                   "grant_type": {
                     "type": "string",
-                    "enum": ["client_credentials"],
+                    "enum": [
+                      "client_credentials"
+                    ],
                     "description": "OAuth2 grant type"
                   }
                 }
@@ -111,12 +118,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Obtain an access token"
       }
     },
     "/codes/{bicCode}": {
       "get": {
-        "tags": ["BIC Codes"],
+        "tags": [
+          "BIC Codes"
+        ],
         "summary": "Look up a BIC code holder",
         "operationId": "getBICCode",
         "parameters": [
@@ -172,12 +182,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Look up a BIC code holder"
       }
     },
     "/container": {
       "post": {
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "summary": "Upload container fleet data",
         "operationId": "uploadContainers",
         "requestBody": {
@@ -235,12 +248,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload container fleet data"
       }
     },
     "/container/{containerNumber}": {
       "get": {
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "summary": "Get container technical details",
         "operationId": "getContainer",
         "parameters": [
@@ -296,10 +312,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get container technical details"
       },
       "delete": {
-        "tags": ["Containers"],
+        "tags": [
+          "Containers"
+        ],
         "summary": "Remove a container from the database",
         "operationId": "deleteContainer",
         "parameters": [
@@ -344,12 +363,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove a container from the database"
       }
     },
     "/tare_kg/{containerNumber}": {
       "get": {
-        "tags": ["Weight"],
+        "tags": [
+          "Weight"
+        ],
         "summary": "Get container tare weight in kilograms",
         "operationId": "getTareWeight",
         "parameters": [
@@ -395,12 +417,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get container tare weight in kilograms"
       }
     },
     "/max_gross_mass_kgs/{containerNumber}": {
       "get": {
-        "tags": ["Weight"],
+        "tags": [
+          "Weight"
+        ],
         "summary": "Get container maximum gross mass in kilograms",
         "operationId": "getMaxGrossMass",
         "parameters": [
@@ -446,12 +471,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get container maximum gross mass in kilograms"
       }
     },
     "/iso/size_type_code/{sizeTypeCode}": {
       "get": {
-        "tags": ["ISO Codes"],
+        "tags": [
+          "ISO Codes"
+        ],
         "summary": "Look up an ISO size type code",
         "operationId": "getSizeTypeCode",
         "parameters": [
@@ -497,12 +525,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Look up an ISO size type code"
       }
     },
     "/alert": {
       "post": {
-        "tags": ["Alerts"],
+        "tags": [
+          "Alerts"
+        ],
         "summary": "Create a container alert",
         "operationId": "createAlert",
         "requestBody": {
@@ -546,12 +577,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a container alert"
       }
     },
     "/alert/{containerNumber}/{alertType}": {
       "delete": {
-        "tags": ["Alerts"],
+        "tags": [
+          "Alerts"
+        ],
         "summary": "Deactivate a container alert",
         "operationId": "deleteAlert",
         "parameters": [
@@ -570,7 +604,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["SOLD", "SCRAPPED", "LOST", "STOLEN"]
+              "enum": [
+                "SOLD",
+                "SCRAPPED",
+                "LOST",
+                "STOLEN"
+              ]
             },
             "description": "Type of alert to deactivate"
           }
@@ -606,12 +645,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Deactivate a container alert"
       }
     },
     "/uploads": {
       "get": {
-        "tags": ["Uploads"],
+        "tags": [
+          "Uploads"
+        ],
         "summary": "Get all file uploads",
         "operationId": "getUploads",
         "responses": {
@@ -648,12 +690,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all file uploads"
       }
     },
     "/uploads/{uploadId}": {
       "get": {
-        "tags": ["Uploads"],
+        "tags": [
+          "Uploads"
+        ],
         "summary": "Get a specific upload file",
         "operationId": "getUpload",
         "parameters": [
@@ -673,7 +718,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["FAILED", "ORIGINAL"]
+              "enum": [
+                "FAILED",
+                "ORIGINAL"
+              ]
             },
             "description": "Type of file to retrieve"
           }
@@ -709,7 +757,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific upload file"
       }
     }
   },
@@ -870,7 +919,9 @@
       },
       "FleetIn": {
         "type": "object",
-        "required": ["container_number"],
+        "required": [
+          "container_number"
+        ],
         "properties": {
           "container_number": {
             "type": "string",
@@ -973,7 +1024,10 @@
       },
       "AlertRequest": {
         "type": "object",
-        "required": ["container_number", "type"],
+        "required": [
+          "container_number",
+          "type"
+        ],
         "properties": {
           "container_number": {
             "type": "string",
@@ -981,7 +1035,12 @@
           },
           "type": {
             "type": "string",
-            "enum": ["SOLD", "SCRAPPED", "LOST", "STOLEN"],
+            "enum": [
+              "SOLD",
+              "SCRAPPED",
+              "LOST",
+              "STOLEN"
+            ],
             "description": "Alert type"
           },
           "message": {

--- a/apis/openapi/bigcartel.com/big-cartel-api/1.0.0/openapi.json
+++ b/apis/openapi/bigcartel.com/big-cartel-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Big Cartel API",
     "version": "1.0.0",
     "description": "Big Cartel e-commerce platform API for managing shops, products, orders, and discounts.",
-    "x-jentic-source-url": "https://help.bigcartel.com/developers/api/v1/"
+    "x-jentic-source-url": "https://help.bigcartel.com/developers/api/v1/",
+    "contact": {}
   },
   "servers": [
     {
@@ -60,7 +61,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get account"
       }
     },
     "/accounts/{account_id}/products": {
@@ -122,7 +124,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List products"
       }
     },
     "/accounts/{account_id}/products/{product_id}": {
@@ -181,7 +184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get product"
       }
     },
     "/accounts/{account_id}/orders": {
@@ -250,7 +254,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List orders"
       }
     },
     "/accounts/{account_id}/orders/{order_id}": {
@@ -309,7 +314,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get order"
       }
     },
     "/accounts/{account_id}/discounts": {
@@ -371,7 +377,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List discounts"
       }
     },
     "/accounts/{account_id}/artists": {
@@ -433,7 +440,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List artists"
       }
     }
   },
@@ -556,6 +564,23 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Artists"
+    },
+    {
+      "name": "Discounts"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "Products"
     }
   ]
 }

--- a/apis/openapi/bigdatacloud.net/ip-geolocation-api/1.0.0/openapi.json
+++ b/apis/openapi/bigdatacloud.net/ip-geolocation-api/1.0.0/openapi.json
@@ -26,7 +26,11 @@
     "x-providerName": "bigdatacloud.net",
     "x-jentic-source-url": "https://api.apis.guru/v2/specs/bigdatacloud.net/1.0.0/openapi.yaml"
   },
-  "tags": [],
+  "tags": [
+    {
+      "name": "data"
+    }
+  ],
   "paths": {
     "/data/ip-geolocation-full": {
       "get": {
@@ -66,7 +70,10 @@
             "description": ""
           }
         },
-        "summary": "IP Geolocation with Confidence Area and Hazard Report API"
+        "summary": "IP Geolocation with Confidence Area and Hazard Report API",
+        "tags": [
+          "data"
+        ]
       }
     },
     "/data/ip-geolocation-with-confidence": {
@@ -107,7 +114,10 @@
             "description": ""
           }
         },
-        "summary": "IP Geolocation with Confidence Area API"
+        "summary": "IP Geolocation with Confidence Area API",
+        "tags": [
+          "data"
+        ]
       }
     }
   }

--- a/apis/openapi/bigoven.com/bigoven-api/2.0.0/openapi.json
+++ b/apis/openapi/bigoven.com/bigoven-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BigOven API",
     "version": "2.0.0",
     "description": "The BigOven API provides access to over 1,000,000 recipes with search, grocery list management, user profiles, collections, reviews, and recipe photo management. Supports recipe search with dietary filters, ingredient inclusion/exclusion, cuisine filtering, and more.",
-    "x-jentic-source-url": "https://api2.bigoven.com/"
+    "x-jentic-source-url": "https://api2.bigoven.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,126 +18,164 @@
         "operationId": "searchRecipes",
         "summary": "Search recipes",
         "description": "Search recipes by keyword, ingredient, cuisine, dietary restrictions, and other filters.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
           {
             "name": "title_kw",
             "in": "query",
             "description": "Title keyword search",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "any_kw",
             "in": "query",
             "description": "Search across all recipe fields",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "include_ing",
             "in": "query",
             "description": "Include recipes with these ingredients (comma-separated, max 3)",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "exclude_ing",
             "in": "query",
             "description": "Exclude recipes with these ingredients (comma-separated, max 3)",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "veg",
             "in": "query",
             "description": "Filter for vegetarian recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "vgn",
             "in": "query",
             "description": "Filter for vegan recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "gluten_free",
             "in": "query",
             "description": "Filter for gluten-free recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "nut_free",
             "in": "query",
             "description": "Filter for nut-free recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "dairy_free",
             "in": "query",
             "description": "Filter for dairy-free recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "seafood_free",
             "in": "query",
             "description": "Filter for seafood-free recipes",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "cuisine",
             "in": "query",
             "description": "Filter by cuisine type",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "cat",
             "in": "query",
             "description": "Filter by primary category",
             "required": false,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "max_prep_time",
             "in": "query",
             "description": "Maximum preparation time in minutes",
             "required": false,
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "max_total_time",
             "in": "query",
             "description": "Maximum total time in minutes",
             "required": false,
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "photos_only",
             "in": "query",
             "description": "Only return recipes with photos",
             "required": false,
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           },
           {
             "name": "pg",
             "in": "query",
             "description": "Page number",
             "required": false,
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "rpp",
             "in": "query",
             "description": "Results per page",
             "required": false,
-            "schema": { "type": "integer", "default": 10 }
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
           }
         ],
         "responses": {
@@ -144,12 +183,32 @@
             "description": "Successful search results",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/RecipeSearchResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/RecipeSearchResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -158,15 +217,61 @@
         "operationId": "getRecipe",
         "summary": "Get recipe details",
         "description": "Retrieve full details for a specific recipe including ingredients, instructions, nutrition, photos, and ratings.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "responses": {
-          "200": { "description": "Recipe details", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Recipe" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Recipe not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Recipe details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Recipe"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Recipe not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -175,34 +280,134 @@
         "operationId": "getRecipePhotos",
         "summary": "Get recipe photos",
         "description": "Retrieve photos for a specific recipe with pagination.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" },
-          { "name": "pg", "in": "query", "required": false, "schema": { "type": "integer", "default": 1 }, "description": "Page number" },
-          { "name": "rpp", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 }, "description": "Results per page" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          },
+          {
+            "name": "pg",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            },
+            "description": "Page number"
+          },
+          {
+            "name": "rpp",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            },
+            "description": "Results per page"
+          }
         ],
         "responses": {
-          "200": { "description": "Recipe photos", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PhotoListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Recipe photos",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PhotoListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "uploadRecipePhoto",
         "summary": "Upload recipe photo",
         "description": "Upload a new photo for a recipe.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "requestBody": {
           "required": true,
-          "content": { "multipart/form-data": { "schema": { "type": "object", "properties": { "photo": { "type": "string", "format": "binary" }, "caption": { "type": "string" } } } } }
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "photo": {
+                    "type": "string",
+                    "format": "binary"
+                  },
+                  "caption": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Photo uploaded successfully" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Photo uploaded successfully"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -211,34 +416,132 @@
         "operationId": "getRecipeReviews",
         "summary": "Get recipe reviews",
         "description": "Retrieve reviews for a specific recipe.",
-        "tags": ["Reviews"],
+        "tags": [
+          "Reviews"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" },
-          { "name": "pg", "in": "query", "required": false, "schema": { "type": "integer", "default": 1 }, "description": "Page number" },
-          { "name": "rpp", "in": "query", "required": false, "schema": { "type": "integer", "default": 10 }, "description": "Results per page" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          },
+          {
+            "name": "pg",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 1
+            },
+            "description": "Page number"
+          },
+          {
+            "name": "rpp",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 10
+            },
+            "description": "Results per page"
+          }
         ],
         "responses": {
-          "200": { "description": "Recipe reviews", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ReviewListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Recipe reviews",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "createRecipeReview",
         "summary": "Post a recipe review",
         "description": "Create a new review with star rating for a recipe.",
-        "tags": ["Reviews"],
+        "tags": [
+          "Reviews"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ReviewCreateRequest" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReviewCreateRequest"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Review created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Review" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Review created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Review"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -247,18 +550,54 @@
         "operationId": "addRecipeNote",
         "summary": "Add a note to a recipe",
         "description": "Add a personal note to a recipe with optional meal context.",
-        "tags": ["Reviews"],
+        "tags": [
+          "Reviews"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/NoteCreateRequest" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NoteCreateRequest"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Note added" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Note added"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -267,10 +606,30 @@
         "operationId": "getRandomRecipe",
         "summary": "Get a random recipe",
         "description": "Retrieve a randomly selected recipe.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "responses": {
-          "200": { "description": "Random recipe", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Recipe" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Random recipe",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Recipe"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -279,14 +638,54 @@
         "operationId": "autocompleteRecipes",
         "summary": "Autocomplete recipe search",
         "description": "Get autocomplete suggestions for recipe search.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
-          { "name": "query", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Partial search query" }
+          {
+            "name": "query",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Partial search query"
+          }
         ],
         "responses": {
-          "200": { "description": "Autocomplete suggestions", "content": { "application/json": { "schema": { "type": "array", "items": { "type": "string" } } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Autocomplete suggestions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -295,14 +694,51 @@
         "operationId": "getRelatedRecipes",
         "summary": "Get related recipes",
         "description": "Retrieve recipes related to the specified recipe.",
-        "tags": ["Recipes"],
+        "tags": [
+          "Recipes"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "responses": {
-          "200": { "description": "Related recipes", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RecipeSearchResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Related recipes",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecipeSearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -311,10 +747,30 @@
         "operationId": "getGroceryList",
         "summary": "Get grocery list",
         "description": "Retrieve the authenticated user's grocery list.",
-        "tags": ["Grocery List"],
+        "tags": [
+          "Grocery List"
+        ],
         "responses": {
-          "200": { "description": "Grocery list", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GroceryList" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Grocery list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GroceryList"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -323,29 +779,87 @@
         "operationId": "addGroceryItem",
         "summary": "Add item to grocery list",
         "description": "Add a single item to the grocery list.",
-        "tags": ["Grocery List"],
+        "tags": [
+          "Grocery List"
+        ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/GroceryItemRequest" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/GroceryItemRequest"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Item added" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Item added"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "operationId": "removeGroceryItem",
         "summary": "Remove item from grocery list",
         "description": "Remove a specific item from the grocery list.",
-        "tags": ["Grocery List"],
+        "tags": [
+          "Grocery List"
+        ],
         "parameters": [
-          { "name": "itemId", "in": "query", "required": true, "schema": { "type": "string" }, "description": "Grocery item ID to remove" }
+          {
+            "name": "itemId",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Grocery item ID to remove"
+          }
         ],
         "responses": {
-          "200": { "description": "Item removed" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Item removed"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -354,14 +868,44 @@
         "operationId": "addRecipeToGroceryList",
         "summary": "Add recipe ingredients to grocery list",
         "description": "Add all ingredients from a recipe to the grocery list.",
-        "tags": ["Grocery List"],
+        "tags": [
+          "Grocery List"
+        ],
         "parameters": [
-          { "name": "recipeId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Recipe ID" }
+          {
+            "name": "recipeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Recipe ID"
+          }
         ],
         "responses": {
-          "200": { "description": "Recipe ingredients added to grocery list" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Recipe ingredients added to grocery list"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -370,10 +914,23 @@
         "operationId": "departmentalizeGroceryList",
         "summary": "Departmentalize grocery list",
         "description": "Organize grocery list items by department.",
-        "tags": ["Grocery List"],
+        "tags": [
+          "Grocery List"
+        ],
         "responses": {
-          "200": { "description": "Grocery list departmentalized" },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Grocery list departmentalized"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -382,10 +939,30 @@
         "operationId": "getMe",
         "summary": "Get authenticated user info",
         "description": "Retrieve information about the currently authenticated user.",
-        "tags": ["User"],
+        "tags": [
+          "User"
+        ],
         "responses": {
-          "200": { "description": "User info", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/User" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "User info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/User"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -394,14 +971,51 @@
         "operationId": "getCollection",
         "summary": "Get recipe collection",
         "description": "Retrieve a curated recipe collection by ID.",
-        "tags": ["Collections"],
+        "tags": [
+          "Collections"
+        ],
         "parameters": [
-          { "name": "collectionId", "in": "path", "required": true, "schema": { "type": "integer" }, "description": "Collection ID" }
+          {
+            "name": "collectionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Collection ID"
+          }
         ],
         "responses": {
-          "200": { "description": "Collection details", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Collection" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Collection details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Collection"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -411,153 +1025,336 @@
       "Recipe": {
         "type": "object",
         "properties": {
-          "RecipeID": { "type": "integer", "description": "Unique recipe identifier" },
-          "Title": { "type": "string", "description": "Recipe title" },
-          "Description": { "type": "string", "description": "Recipe description" },
-          "Category": { "type": "string", "description": "Primary category" },
-          "Subcategory": { "type": "string", "description": "Subcategory" },
-          "Cuisine": { "type": "string", "description": "Cuisine type" },
-          "StarRating": { "type": "number", "description": "Average star rating" },
-          "ReviewCount": { "type": "integer", "description": "Number of reviews" },
-          "TotalMinutes": { "type": "integer", "description": "Total preparation and cooking time" },
-          "ActiveMinutes": { "type": "integer", "description": "Active preparation time" },
-          "Servings": { "type": "integer", "description": "Number of servings" },
-          "YieldNumber": { "type": "number", "description": "Yield amount" },
-          "YieldUnit": { "type": "string", "description": "Yield unit" },
-          "Ingredients": { "type": "array", "items": { "$ref": "#/components/schemas/Ingredient" } },
-          "Instructions": { "type": "string", "description": "Cooking instructions" },
-          "PhotoUrl": { "type": "string", "description": "Main photo URL" },
-          "IsVegetarian": { "type": "boolean" },
-          "IsVegan": { "type": "boolean" },
-          "IsGlutenFree": { "type": "boolean" },
-          "NutritionInfo": { "$ref": "#/components/schemas/NutritionInfo" }
+          "RecipeID": {
+            "type": "integer",
+            "description": "Unique recipe identifier"
+          },
+          "Title": {
+            "type": "string",
+            "description": "Recipe title"
+          },
+          "Description": {
+            "type": "string",
+            "description": "Recipe description"
+          },
+          "Category": {
+            "type": "string",
+            "description": "Primary category"
+          },
+          "Subcategory": {
+            "type": "string",
+            "description": "Subcategory"
+          },
+          "Cuisine": {
+            "type": "string",
+            "description": "Cuisine type"
+          },
+          "StarRating": {
+            "type": "number",
+            "description": "Average star rating"
+          },
+          "ReviewCount": {
+            "type": "integer",
+            "description": "Number of reviews"
+          },
+          "TotalMinutes": {
+            "type": "integer",
+            "description": "Total preparation and cooking time"
+          },
+          "ActiveMinutes": {
+            "type": "integer",
+            "description": "Active preparation time"
+          },
+          "Servings": {
+            "type": "integer",
+            "description": "Number of servings"
+          },
+          "YieldNumber": {
+            "type": "number",
+            "description": "Yield amount"
+          },
+          "YieldUnit": {
+            "type": "string",
+            "description": "Yield unit"
+          },
+          "Ingredients": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Ingredient"
+            }
+          },
+          "Instructions": {
+            "type": "string",
+            "description": "Cooking instructions"
+          },
+          "PhotoUrl": {
+            "type": "string",
+            "description": "Main photo URL"
+          },
+          "IsVegetarian": {
+            "type": "boolean"
+          },
+          "IsVegan": {
+            "type": "boolean"
+          },
+          "IsGlutenFree": {
+            "type": "boolean"
+          },
+          "NutritionInfo": {
+            "$ref": "#/components/schemas/NutritionInfo"
+          }
         }
       },
       "Ingredient": {
         "type": "object",
         "properties": {
-          "IngredientID": { "type": "integer" },
-          "Name": { "type": "string" },
-          "Quantity": { "type": "number" },
-          "Unit": { "type": "string" },
-          "DisplayQuantity": { "type": "string" }
+          "IngredientID": {
+            "type": "integer"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Quantity": {
+            "type": "number"
+          },
+          "Unit": {
+            "type": "string"
+          },
+          "DisplayQuantity": {
+            "type": "string"
+          }
         }
       },
       "NutritionInfo": {
         "type": "object",
         "properties": {
-          "Calories": { "type": "number" },
-          "Fat": { "type": "number" },
-          "Protein": { "type": "number" },
-          "Carbs": { "type": "number" },
-          "Fiber": { "type": "number" },
-          "Sugar": { "type": "number" },
-          "Sodium": { "type": "number" }
+          "Calories": {
+            "type": "number"
+          },
+          "Fat": {
+            "type": "number"
+          },
+          "Protein": {
+            "type": "number"
+          },
+          "Carbs": {
+            "type": "number"
+          },
+          "Fiber": {
+            "type": "number"
+          },
+          "Sugar": {
+            "type": "number"
+          },
+          "Sodium": {
+            "type": "number"
+          }
         }
       },
       "RecipeSearchResponse": {
         "type": "object",
         "properties": {
-          "ResultCount": { "type": "integer" },
-          "Results": { "type": "array", "items": { "$ref": "#/components/schemas/Recipe" } }
+          "ResultCount": {
+            "type": "integer"
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Recipe"
+            }
+          }
         }
       },
       "Review": {
         "type": "object",
         "properties": {
-          "ReviewID": { "type": "integer" },
-          "StarRating": { "type": "integer" },
-          "ReviewText": { "type": "string" },
-          "Reviewer": { "type": "string" },
-          "DatePosted": { "type": "string", "format": "date-time" }
+          "ReviewID": {
+            "type": "integer"
+          },
+          "StarRating": {
+            "type": "integer"
+          },
+          "ReviewText": {
+            "type": "string"
+          },
+          "Reviewer": {
+            "type": "string"
+          },
+          "DatePosted": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "ReviewCreateRequest": {
         "type": "object",
         "properties": {
-          "StarRating": { "type": "integer", "minimum": 1, "maximum": 5 },
-          "ReviewText": { "type": "string" }
+          "StarRating": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "ReviewText": {
+            "type": "string"
+          }
         },
-        "required": ["StarRating"]
+        "required": [
+          "StarRating"
+        ]
       },
       "ReviewListResponse": {
         "type": "object",
         "properties": {
-          "ResultCount": { "type": "integer" },
-          "Results": { "type": "array", "items": { "$ref": "#/components/schemas/Review" } }
+          "ResultCount": {
+            "type": "integer"
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Review"
+            }
+          }
         }
       },
       "NoteCreateRequest": {
         "type": "object",
         "properties": {
-          "NoteText": { "type": "string" },
-          "MealContext": { "type": "string" }
+          "NoteText": {
+            "type": "string"
+          },
+          "MealContext": {
+            "type": "string"
+          }
         },
-        "required": ["NoteText"]
+        "required": [
+          "NoteText"
+        ]
       },
       "PhotoListResponse": {
         "type": "object",
         "properties": {
-          "ResultCount": { "type": "integer" },
-          "Results": { "type": "array", "items": { "$ref": "#/components/schemas/Photo" } }
+          "ResultCount": {
+            "type": "integer"
+          },
+          "Results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Photo"
+            }
+          }
         }
       },
       "Photo": {
         "type": "object",
         "properties": {
-          "PhotoID": { "type": "integer" },
-          "PhotoUrl": { "type": "string" },
-          "Caption": { "type": "string" }
+          "PhotoID": {
+            "type": "integer"
+          },
+          "PhotoUrl": {
+            "type": "string"
+          },
+          "Caption": {
+            "type": "string"
+          }
         }
       },
       "GroceryList": {
         "type": "object",
         "properties": {
-          "Items": { "type": "array", "items": { "$ref": "#/components/schemas/GroceryItem" } }
+          "Items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/GroceryItem"
+            }
+          }
         }
       },
       "GroceryItem": {
         "type": "object",
         "properties": {
-          "ItemId": { "type": "string" },
-          "Name": { "type": "string" },
-          "Department": { "type": "string" },
-          "IsChecked": { "type": "boolean" },
-          "Quantity": { "type": "string" }
+          "ItemId": {
+            "type": "string"
+          },
+          "Name": {
+            "type": "string"
+          },
+          "Department": {
+            "type": "string"
+          },
+          "IsChecked": {
+            "type": "boolean"
+          },
+          "Quantity": {
+            "type": "string"
+          }
         }
       },
       "GroceryItemRequest": {
         "type": "object",
         "properties": {
-          "Name": { "type": "string" },
-          "Quantity": { "type": "string" }
+          "Name": {
+            "type": "string"
+          },
+          "Quantity": {
+            "type": "string"
+          }
         },
-        "required": ["Name"]
+        "required": [
+          "Name"
+        ]
       },
       "User": {
         "type": "object",
         "properties": {
-          "UserID": { "type": "integer" },
-          "UserName": { "type": "string" },
-          "FirstName": { "type": "string" },
-          "LastName": { "type": "string" }
+          "UserID": {
+            "type": "integer"
+          },
+          "UserName": {
+            "type": "string"
+          },
+          "FirstName": {
+            "type": "string"
+          },
+          "LastName": {
+            "type": "string"
+          }
         }
       },
       "Collection": {
         "type": "object",
         "properties": {
-          "CollectionID": { "type": "integer" },
-          "Title": { "type": "string" },
-          "Description": { "type": "string" },
-          "Recipes": { "type": "array", "items": { "$ref": "#/components/schemas/Recipe" } }
+          "CollectionID": {
+            "type": "integer"
+          },
+          "Title": {
+            "type": "string"
+          },
+          "Description": {
+            "type": "string"
+          },
+          "Recipes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Recipe"
+            }
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "enum": ["error"] },
-          "code": { "type": "string" },
-          "message": { "type": "string" }
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -576,6 +1373,25 @@
     }
   },
   "security": [
-    { "ApiKeyHeader": [] }
+    {
+      "ApiKeyHeader": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Collections"
+    },
+    {
+      "name": "Grocery List"
+    },
+    {
+      "name": "Recipes"
+    },
+    {
+      "name": "Reviews"
+    },
+    {
+      "name": "User"
+    }
   ]
 }

--- a/apis/openapi/bika.ai/bika-ai-api/1.0.0/openapi.json
+++ b/apis/openapi/bika.ai/bika-ai-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bika.ai API",
     "version": "1.0.0",
     "description": "Bika.ai OpenAPI for managing spaces, databases, records, automations, webhooks, and file attachments in the Bika.ai platform.",
-    "x-jentic-source-url": "https://bika.ai/en/help/guide/developer/openapi"
+    "x-jentic-source-url": "https://bika.ai/en/help/guide/developer/openapi",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,17 +18,30 @@
         "operationId": "getSystemMeta",
         "summary": "Get system metadata",
         "description": "Retrieves system version, environment, and request metadata.",
-        "tags": ["System"],
+        "tags": [
+          "System"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/SystemMetaResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/SystemMetaResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -36,11 +50,43 @@
         "operationId": "listSpaces",
         "summary": "List spaces",
         "description": "Retrieves all spaces accessible to the authenticated user.",
-        "tags": ["Spaces"],
+        "tags": [
+          "Spaces"
+        ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Space" } } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Space"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -49,47 +95,203 @@
         "operationId": "getRecords",
         "summary": "Get records",
         "description": "Retrieves records from a database node within a space.",
-        "tags": ["Records"],
+        "tags": [
+          "Records"
+        ],
         "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "description": "The ID of the space", "schema": { "type": "string" } },
-          { "name": "nodeId", "in": "path", "required": true, "description": "The ID of the database node", "schema": { "type": "string" } }
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the database node",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Record" } } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Record"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "createRecord",
         "summary": "Create a record",
         "description": "Creates a new record in a database node within a space.",
-        "tags": ["Records"],
-        "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "description": "The ID of the space", "schema": { "type": "string" } },
-          { "name": "nodeId", "in": "path", "required": true, "description": "The ID of the database node", "schema": { "type": "string" } }
+        "tags": [
+          "Records"
         ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/CreateRecordRequest" } } } },
+        "parameters": [
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the database node",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateRecordRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Record" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Record"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "patch": {
         "operationId": "updateRecord",
         "summary": "Update a record",
         "description": "Updates an existing record in a database node within a space.",
-        "tags": ["Records"],
-        "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "description": "The ID of the space", "schema": { "type": "string" } },
-          { "name": "nodeId", "in": "path", "required": true, "description": "The ID of the database node", "schema": { "type": "string" } }
+        "tags": [
+          "Records"
         ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/UpdateRecordRequest" } } } },
+        "parameters": [
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the space",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "description": "The ID of the database node",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateRecordRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Record" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Record"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -98,16 +300,59 @@
         "operationId": "deleteRecord",
         "summary": "Delete a record",
         "description": "Deletes a record from a database node within a space.",
-        "tags": ["Records"],
+        "tags": [
+          "Records"
+        ],
         "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "nodeId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "recordId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "recordId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful deletion" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful deletion"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -116,15 +361,61 @@
         "operationId": "listAutomationTriggers",
         "summary": "List automation triggers",
         "description": "Retrieves automation triggers for a given automation node.",
-        "tags": ["Automations"],
+        "tags": [
+          "Automations"
+        ],
         "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "nodeId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "nodeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/AutomationTrigger" } } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AutomationTrigger"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -133,15 +424,60 @@
         "operationId": "registerOutgoingWebhook",
         "summary": "Register outgoing webhook",
         "description": "Registers an outgoing webhook for a space.",
-        "tags": ["Webhooks"],
-        "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "schema": { "type": "string" } }
+        "tags": [
+          "Webhooks"
         ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/RegisterWebhookRequest" } } } },
+        "parameters": [
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterWebhookRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Webhook" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Webhook"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -150,35 +486,261 @@
         "operationId": "uploadAttachment",
         "summary": "Upload attachment",
         "description": "Uploads a file attachment to a space.",
-        "tags": ["Attachments"],
-        "parameters": [
-          { "name": "spaceId", "in": "path", "required": true, "schema": { "type": "string" } }
+        "tags": [
+          "Attachments"
         ],
-        "requestBody": { "required": true, "content": { "multipart/form-data": { "schema": { "type": "object", "properties": { "file": { "type": "string", "format": "binary" } }, "required": ["file"] } } } },
+        "parameters": [
+          {
+            "name": "spaceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "file": {
+                    "type": "string",
+                    "format": "binary"
+                  }
+                },
+                "required": [
+                  "file"
+                ]
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Attachment" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attachment"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "SystemMetaResponse": { "type": "object", "properties": { "version": { "type": "string" }, "appEnv": { "type": "string" }, "hostname": { "type": "string" }, "headers": { "type": "object" } } },
-      "Space": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" } } },
-      "Record": { "type": "object", "properties": { "id": { "type": "string" }, "cells": { "type": "object" } } },
-      "CreateRecordRequest": { "type": "object", "properties": { "cells": { "type": "object" } }, "required": ["cells"] },
-      "UpdateRecordRequest": { "type": "object", "properties": { "id": { "type": "string" }, "cells": { "type": "object" } }, "required": ["id", "cells"] },
-      "AutomationTrigger": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "type": { "type": "string" } } },
-      "RegisterWebhookRequest": { "type": "object", "properties": { "eventType": { "type": "string" }, "name": { "type": "string" }, "description": { "type": "string" }, "callbackURL": { "type": "string" } }, "required": ["eventType", "callbackURL"] },
-      "Webhook": { "type": "object", "properties": { "id": { "type": "string" }, "eventType": { "type": "string" }, "name": { "type": "string" }, "callbackURL": { "type": "string" }, "createdAt": { "type": "string", "format": "date-time" } } },
-      "Attachment": { "type": "object", "properties": { "id": { "type": "string" }, "name": { "type": "string" }, "url": { "type": "string" }, "size": { "type": "integer" } } },
-      "ErrorResponse": { "type": "object", "properties": { "status": { "type": "string", "enum": ["error"] }, "code": { "type": "string" }, "message": { "type": "string" } } }
+      "SystemMetaResponse": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "string"
+          },
+          "appEnv": {
+            "type": "string"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "headers": {
+            "type": "object"
+          }
+        }
+      },
+      "Space": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Record": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "cells": {
+            "type": "object"
+          }
+        }
+      },
+      "CreateRecordRequest": {
+        "type": "object",
+        "properties": {
+          "cells": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "cells"
+        ]
+      },
+      "UpdateRecordRequest": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "cells": {
+            "type": "object"
+          }
+        },
+        "required": [
+          "id",
+          "cells"
+        ]
+      },
+      "AutomationTrigger": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "RegisterWebhookRequest": {
+        "type": "object",
+        "properties": {
+          "eventType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "callbackURL": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "eventType",
+          "callbackURL"
+        ]
+      },
+      "Webhook": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "eventType": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "callbackURL": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "Attachment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "size": {
+            "type": "integer"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "bearerAuth": { "type": "http", "scheme": "bearer" }
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   },
-  "security": [{ "bearerAuth": [] }]
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Attachments"
+    },
+    {
+      "name": "Automations"
+    },
+    {
+      "name": "Records"
+    },
+    {
+      "name": "Spaces"
+    },
+    {
+      "name": "System"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }

--- a/apis/openapi/bikewise.org/bikewise-api-v2/v2/openapi.json
+++ b/apis/openapi/bikewise.org/bikewise-api-v2/v2/openapi.json
@@ -172,7 +172,8 @@
         },
         "tags": [
           "incidents"
-        ]
+        ],
+        "description": "Get  version incidents  id   format "
       }
     },
     "/v2/locations": {

--- a/apis/openapi/bilflo.com/bilflo-api/1.0.0/openapi.json
+++ b/apis/openapi/bilflo.com/bilflo-api/1.0.0/openapi.json
@@ -765,6 +765,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   },
   "security": [

--- a/apis/openapi/bilflo.com/bilflo-api/1.0.0/openapi.json
+++ b/apis/openapi/bilflo.com/bilflo-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bilflo API",
     "version": "1.0.0",
     "description": "Bilflo provides staffing and recruitment management APIs for managing clients, contract jobs, company settings, dashboards, custom fields, and more.",
-    "x-jentic-source-url": "https://api.bilflo.com/swagger/index.html"
+    "x-jentic-source-url": "https://api.bilflo.com/swagger/index.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -49,7 +50,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List clients"
       },
       "post": {
         "operationId": "createClient",
@@ -87,7 +89,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a client"
       }
     },
     "/v1/Clients/{clientId}": {
@@ -122,7 +125,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a client"
       },
       "put": {
         "operationId": "updateClient",
@@ -155,7 +159,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a client"
       }
     },
     "/v1/Clients/contact/{clientId}": {
@@ -190,7 +195,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List client contacts"
       }
     },
     "/v1/Clients/contact": {
@@ -217,7 +223,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a client contact"
       }
     },
     "/v1/Clients/addresses/{clientId}": {
@@ -252,7 +259,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List client addresses"
       }
     },
     "/v1/Clients/address": {
@@ -279,7 +287,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a client address"
       }
     },
     "/v1/Clients/agreements/{clientId}": {
@@ -314,7 +323,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List client agreements"
       }
     },
     "/v1/Clients/agreements": {
@@ -341,7 +351,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a client agreement"
       }
     },
     "/v1/ContractJobs": {
@@ -368,7 +379,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List contract jobs"
       },
       "post": {
         "operationId": "createContractJob",
@@ -393,7 +405,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a contract job"
       }
     },
     "/v1/ContractJobs/{jobId}": {
@@ -428,7 +441,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a contract job"
       },
       "put": {
         "operationId": "updateContractJob",
@@ -461,7 +475,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a contract job"
       }
     },
     "/v1/ContractJobs/terminate": {
@@ -488,7 +503,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Terminate a contract job"
       }
     },
     "/v1/CompanySettings/workersCompCodes": {
@@ -515,7 +531,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get workers comp codes"
       }
     },
     "/v1/CompanySettings/paymentTerms": {
@@ -542,7 +559,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get payment terms"
       }
     },
     "/v1/CompanySettings/payBillItems": {
@@ -569,7 +587,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get pay/bill items"
       }
     },
     "/v1/CompanySettings/states": {
@@ -596,7 +615,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get states"
       }
     },
     "/v1/CustomFields": {
@@ -623,7 +643,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List custom fields"
       }
     },
     "/v1/CustomFields/items": {
@@ -650,7 +671,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List custom field items"
       }
     },
     "/dash/v1/Dashboards": {
@@ -667,7 +689,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List dashboards"
       },
       "post": {
         "operationId": "createDashboard",
@@ -682,7 +705,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a dashboard"
       }
     },
     "/dash/v1/Dashboards/{dashboardId}": {
@@ -709,7 +733,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a dashboard"
       }
     }
   },
@@ -739,29 +764,29 @@
             "type": "string"
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "code": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "BearerAuth": {
-        "type": "http",
-        "scheme": "bearer"
       }
     }
   },
   "security": [
     {
       "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "Company Settings"
+    },
+    {
+      "name": "Contract Jobs"
+    },
+    {
+      "name": "Custom Fields"
+    },
+    {
+      "name": "Dashboards"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Spectral-lint clean **50** OpenAPI specs. All specs now pass `spectral lint` with the default `spectral:oas` ruleset with zero warnings and zero errors.

### Fixes Applied

| Rule | Specs Fixed |
|------|-------------|
| info-contact | 45 |
| operation-tag-defined | 34 |
| operation-description | 26 |
| operation-tags | 5 |
| operation-operationId | 4 |
| unused-components | 4 |
| path-keys-no-trailing-slash | 2 |
| info-description | 1 |
| no-$ref-siblings | 1 |

### APIs Fixed

- arena.fi/smartdialog-api
- arespass.net/arespass.net
- arespass.net/arespass
- arrangr.com/arrangr-api
- artworker.io/artworker-api
- arubanetworks.com/arubanetworks
- askneo.io/api
- assembly.com/assembly
- assetpanda.com/panda-api
- atlassian.com/fisheye-rest-api
- audiomack.com/audiomack
- aunoa.ai/aunoa-api
- auravant.com/auravant-livestock-api
- aurorainbox.com/aurora-inbox-api
- autobound.ai/autobound-api
- autodata-group.com/autodatagroup
- autoro.io/autoro-api
- availity.com/availity-api
- avena.com/Avena
- axerto.com/axerto-api
- axis96.com/zilus-api
- ayrshare.com/ayrshare-api
- az511.com/az511
- azupay.com.au/apidocsazupay
- azupay.com.au/azupay
- backblaze.com/backblaze-b2-api
- balldontlie.io/balldontlie
- bannerify.co/bannerify
- banorte.com/banorte
- baremetrics.com/baremetrics-api
- base.customerpulze.com/pulze-api
- baselinker.com/baselinker
- basesnap.com/Basesnap
- basware.com/basware-network-api
- bbc.co.uk/radio-&-music-services
- bbkonline.com/bbkonline
- bbot.menu/bbot-api
- beanstream.com/beanstream-payments
- beatport.com/beatport-api
- beehiiv.com/beehiiv-api
- belfius.be/belfius
- besmartee.com/besmartee-api
- bestbuy.com/bestbuy-api
- bic-boxtech.org/bic-boxtech
- bigcartel.com/big-cartel-api
- bigdatacloud.net/ip-geolocation-api
- bigoven.com/bigoven-api
- bika.ai/bika-ai-api
- bikewise.org/bikewise-api-v2
- bilflo.com/bilflo-api

## Test plan
- [x] All 50 specs pass `spectral lint` after fixes
