### PR TITLE
Spectral-lint clean 50 OpenAPI specs (batch 005)

### DIFF
--- a/apis/openapi/billetto.com/billetto/2026-02-10/openapi.json
+++ b/apis/openapi/billetto.com/billetto/2026-02-10/openapi.json
@@ -4,7 +4,8 @@
     "title": "Billetto API",
     "version": "2026-02-10",
     "description": "Event ticketing and management platform API for organizers and publishers.",
-    "x-jentic-source-url": "https://api.billetto.com/reference"
+    "x-jentic-source-url": "https://api.billetto.com/reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -26,7 +27,9 @@
         "summary": "List events",
         "description": "Retrieve a list of events for the authenticated organizer",
         "operationId": "listOrganiserEvents",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -57,7 +60,9 @@
         "summary": "Get event",
         "description": "Retrieve details of a specific event",
         "operationId": "getOrganiserEvent",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "parameters": [
           {
             "name": "eventId",
@@ -98,7 +103,9 @@
         "summary": "List attendees",
         "description": "Retrieve a list of attendees across all events",
         "operationId": "listAttendees",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -129,7 +136,9 @@
         "summary": "List event attendees",
         "description": "Retrieve attendees for a specific event",
         "operationId": "listEventAttendees",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "parameters": [
           {
             "name": "eventId",
@@ -170,7 +179,9 @@
         "summary": "List orders",
         "description": "Retrieve a list of ticket orders",
         "operationId": "listOrders",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -201,7 +212,9 @@
         "summary": "Get order",
         "description": "Retrieve details of a specific order",
         "operationId": "getOrder",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "parameters": [
           {
             "name": "orderId",
@@ -242,7 +255,9 @@
         "summary": "List ticket types",
         "description": "Retrieve ticket types for an event",
         "operationId": "listTicketTypes",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "parameters": [
           {
             "name": "eventId",
@@ -283,7 +298,9 @@
         "summary": "List event campaigns",
         "description": "Retrieve promotional campaigns for an event",
         "operationId": "listEventCampaigns",
-        "tags": ["Organiser Events"],
+        "tags": [
+          "Organiser Events"
+        ],
         "parameters": [
           {
             "name": "eventId",
@@ -324,7 +341,9 @@
         "summary": "List ledger entries",
         "description": "Retrieve financial ledger entries",
         "operationId": "listLedgerEntries",
-        "tags": ["Organiser Financials"],
+        "tags": [
+          "Organiser Financials"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -355,7 +374,9 @@
         "summary": "List target groups",
         "description": "Retrieve customer segments and audiences",
         "operationId": "listTargetGroups",
-        "tags": ["Organiser Account"],
+        "tags": [
+          "Organiser Account"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -384,14 +405,18 @@
         "summary": "Create target group",
         "description": "Create a new customer segment",
         "operationId": "createTargetGroup",
-        "tags": ["Organiser Account"],
+        "tags": [
+          "Organiser Account"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -416,7 +441,9 @@
         "summary": "Get target group",
         "description": "Retrieve a specific target group",
         "operationId": "getTargetGroup",
-        "tags": ["Organiser Account"],
+        "tags": [
+          "Organiser Account"
+        ],
         "parameters": [
           {
             "name": "groupId",
@@ -455,7 +482,9 @@
         "summary": "Delete target group",
         "description": "Remove a target group",
         "operationId": "deleteTargetGroup",
-        "tags": ["Organiser Account"],
+        "tags": [
+          "Organiser Account"
+        ],
         "parameters": [
           {
             "name": "groupId",
@@ -481,7 +510,9 @@
         "summary": "List campaigns",
         "description": "Retrieve global promotional campaigns",
         "operationId": "listCampaigns",
-        "tags": ["Organiser Account"],
+        "tags": [
+          "Organiser Account"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -512,7 +543,9 @@
         "summary": "List webhooks",
         "description": "Retrieve configured webhooks",
         "operationId": "listWebhooks",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -541,14 +574,19 @@
         "summary": "Create webhook",
         "description": "Register a new webhook endpoint",
         "operationId": "createWebhook",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["url", "events"],
+                "required": [
+                  "url",
+                  "events"
+                ],
                 "properties": {
                   "url": {
                     "type": "string",
@@ -580,7 +618,9 @@
         "summary": "Update webhook",
         "description": "Modify webhook configuration",
         "operationId": "updateWebhook",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "name": "webhookId",
@@ -625,7 +665,9 @@
         "summary": "Delete webhook",
         "description": "Remove a webhook",
         "operationId": "deleteWebhook",
-        "tags": ["Webhooks"],
+        "tags": [
+          "Webhooks"
+        ],
         "parameters": [
           {
             "name": "webhookId",
@@ -651,7 +693,9 @@
         "summary": "Search public events",
         "description": "Search for publicly available events",
         "operationId": "searchPublicEvents",
-        "tags": ["Public Events"],
+        "tags": [
+          "Public Events"
+        ],
         "parameters": [
           {
             "name": "q",
@@ -689,7 +733,9 @@
         "summary": "Get public event",
         "description": "Retrieve details of a public event",
         "operationId": "getPublicEvent",
-        "tags": ["Public Events"],
+        "tags": [
+          "Public Events"
+        ],
         "parameters": [
           {
             "name": "eventId",
@@ -779,5 +825,22 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Organiser Account"
+    },
+    {
+      "name": "Organiser Events"
+    },
+    {
+      "name": "Organiser Financials"
+    },
+    {
+      "name": "Public Events"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }

--- a/apis/openapi/billplz.com/billplz-api/v4/openapi.json
+++ b/apis/openapi/billplz.com/billplz-api/v4/openapi.json
@@ -4,7 +4,8 @@
     "title": "Billplz API",
     "version": "v4",
     "description": "Billplz provides a REST API for bill creation and payment collection in Malaysia",
-    "x-jentic-source-url": "https://www.billplz.com/api"
+    "x-jentic-source-url": "https://www.billplz.com/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -60,7 +61,10 @@
           "400": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v3"
+        ]
       }
     },
     "/v3/bills": {
@@ -121,7 +125,10 @@
           "400": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v3"
+        ]
       }
     },
     "/v3/bills/{billId}": {
@@ -153,7 +160,10 @@
           "404": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v3"
+        ]
       },
       "delete": {
         "summary": "Delete a bill",
@@ -176,7 +186,10 @@
           "404": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v3"
+        ]
       }
     },
     "/v4/payment_gateways": {
@@ -198,7 +211,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "v4"
+        ]
       }
     },
     "/v4/cards": {
@@ -249,7 +265,10 @@
           "400": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v4"
+        ]
       }
     },
     "/v5/payment_order_collections": {
@@ -279,7 +298,10 @@
           "400": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "tags": [
+          "v5"
+        ]
       }
     }
   },
@@ -376,5 +398,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "v3"
+    },
+    {
+      "name": "v4"
+    },
+    {
+      "name": "v5"
+    }
+  ]
 }

--- a/apis/openapi/bimbala.com/bimbala-api/1.0.0/openapi.json
+++ b/apis/openapi/bimbala.com/bimbala-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bimbala API",
     "description": "Bimbala platform API for managing resources and operations",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://api-docs.bimbala.com/"
+    "x-jentic-source-url": "https://api-docs.bimbala.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -30,7 +31,9 @@
   "paths": {
     "/resources": {
       "get": {
-        "tags": ["Resources"],
+        "tags": [
+          "Resources"
+        ],
         "summary": "List resources",
         "description": "Retrieve all resources",
         "operationId": "listResources",
@@ -77,7 +80,9 @@
         }
       },
       "post": {
-        "tags": ["Resources"],
+        "tags": [
+          "Resources"
+        ],
         "summary": "Create resource",
         "description": "Create a new resource",
         "operationId": "createResource",
@@ -87,7 +92,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -129,7 +136,9 @@
     },
     "/resources/{id}": {
       "get": {
-        "tags": ["Resources"],
+        "tags": [
+          "Resources"
+        ],
         "summary": "Get resource",
         "description": "Retrieve a specific resource by ID",
         "operationId": "getResource",
@@ -169,7 +178,9 @@
     },
     "/users": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List users",
         "description": "Retrieve all users",
         "operationId": "listUsers",
@@ -207,7 +218,9 @@
     },
     "/users/{id}": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user",
         "description": "Retrieve a specific user by ID",
         "operationId": "getUser",

--- a/apis/openapi/biodiversitydata.se/biodiversity-data-api/1.0.0/openapi.json
+++ b/apis/openapi/biodiversitydata.se/biodiversity-data-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Swedish Biodiversity Data API",
     "version": "1.0.0",
     "description": "Web service API for accessing Swedish biodiversity data including species observations, taxonomy, and ecological data.",
-    "x-jentic-source-url": "https://api.biodiversitydata.se/"
+    "x-jentic-source-url": "https://api.biodiversitydata.se/",
+    "contact": {}
   },
   "servers": [
     {
@@ -139,7 +140,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get species details"
       }
     },
     "/observations": {
@@ -287,7 +289,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get observation details"
       }
     }
   },
@@ -402,5 +405,13 @@
       }
     },
     "securitySchemes": {}
-  }
+  },
+  "tags": [
+    {
+      "name": "Observations"
+    },
+    {
+      "name": "Species"
+    }
+  ]
 }

--- a/apis/openapi/bitbadges.io/bitbadges-api/1.0.0/openapi.json
+++ b/apis/openapi/bitbadges.io/bitbadges-api/1.0.0/openapi.json
@@ -211,5 +211,14 @@
     {
       "name": "Users"
     }
-  ]
+  ],
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
+  }
 }

--- a/apis/openapi/bitbadges.io/bitbadges-api/1.0.0/openapi.json
+++ b/apis/openapi/bitbadges.io/bitbadges-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BitBadges API",
     "version": "1.0.0",
     "description": "BitBadges is a platform for creating and managing digital badges and credentials across blockchains. The API provides authentication, badge management, and verification functionality.",
-    "x-jentic-source-url": "https://docs.bitbadges.io"
+    "x-jentic-source-url": "https://docs.bitbadges.io",
+    "contact": {}
   },
   "servers": [
     {
@@ -44,7 +45,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get authentication challenge"
       }
     },
     "/api/v0/auth/verify": {
@@ -79,7 +81,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "Verify authentication"
       }
     },
     "/api/v0/collections": {
@@ -96,7 +99,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List badge collections"
       }
     },
     "/api/v0/collections/{collectionId}": {
@@ -123,7 +127,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a badge collection"
       }
     },
     "/api/v0/users/{address}": {
@@ -150,7 +155,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get user profile"
       }
     },
     "/api/v0/users/{address}/balance/{collectionId}": {
@@ -185,35 +191,25 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "errorCode": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "x-api-key"
+        },
+        "description": "Get user badge balance"
       }
     }
   },
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Collections"
+    },
+    {
+      "name": "Users"
     }
   ]
 }

--- a/apis/openapi/bitcoinaverage.com/bitcoinaverage-api/2.0.0/openapi.json
+++ b/apis/openapi/bitcoinaverage.com/bitcoinaverage-api/2.0.0/openapi.json
@@ -23,7 +23,9 @@
   "paths": {
     "/constants/exchangerates/{market}": {
       "get": {
-        "tags": ["Constants"],
+        "tags": [
+          "Constants"
+        ],
         "summary": "Get exchange rates",
         "description": "Returns global fiat exchange rates used in the current indices calculations.",
         "operationId": "getExchangeRates",
@@ -35,7 +37,10 @@
             "description": "Market type.",
             "schema": {
               "type": "string",
-              "enum": ["global", "local"]
+              "enum": [
+                "global",
+                "local"
+              ]
             }
           }
         ],
@@ -74,7 +79,9 @@
     },
     "/constants/time": {
       "get": {
-        "tags": ["Constants"],
+        "tags": [
+          "Constants"
+        ],
         "summary": "Get server time",
         "description": "Returns the current server time in epoch and ISO format.",
         "operationId": "getServerTime",
@@ -101,9 +108,11 @@
         }
       }
     },
-    "/info/indices/names/": {
+    "/info/indices/names": {
       "get": {
-        "tags": ["Info"],
+        "tags": [
+          "Info"
+        ],
         "summary": "Get index names",
         "description": "Returns full names of supported cryptocurrencies and tokens.",
         "operationId": "getIndexNames",
@@ -126,7 +135,9 @@
     },
     "/info/indices/ticker/{symbol_set}": {
       "get": {
-        "tags": ["Info"],
+        "tags": [
+          "Info"
+        ],
         "summary": "Get supported ticker symbols",
         "description": "Returns supported symbols for ticker endpoints.",
         "operationId": "getTickerSymbols",
@@ -137,7 +148,13 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens", "light"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens",
+                "light"
+              ]
             }
           }
         ],
@@ -165,7 +182,9 @@
     },
     "/info/indices/history/{symbol_set}": {
       "get": {
-        "tags": ["Info"],
+        "tags": [
+          "Info"
+        ],
         "summary": "Get supported history symbols",
         "description": "Returns supported symbols for historical data endpoints.",
         "operationId": "getHistorySymbols",
@@ -176,7 +195,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           }
         ],
@@ -204,7 +228,9 @@
     },
     "/info/exchanges/ticker": {
       "get": {
-        "tags": ["Info"],
+        "tags": [
+          "Info"
+        ],
         "summary": "Get supported exchange ticker symbols",
         "description": "Returns supported exchange symbols for ticker endpoints.",
         "operationId": "getExchangeTickerSymbols",
@@ -230,7 +256,9 @@
     },
     "/info/exchanges/history": {
       "get": {
-        "tags": ["Info"],
+        "tags": [
+          "Info"
+        ],
         "summary": "Get supported exchange history symbols",
         "description": "Returns supported exchange symbols for historical data endpoints.",
         "operationId": "getExchangeHistorySymbols",
@@ -256,7 +284,9 @@
     },
     "/indices/{symbol_set}/ticker/all": {
       "get": {
-        "tags": ["Ticker"],
+        "tags": [
+          "Ticker"
+        ],
         "summary": "Get all tickers",
         "description": "Returns ticker data for all symbols from the specified symbol set.",
         "operationId": "getAllTickers",
@@ -267,7 +297,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           },
           {
@@ -306,7 +341,9 @@
     },
     "/indices/{symbol_set}/ticker/{symbol}": {
       "get": {
-        "tags": ["Ticker"],
+        "tags": [
+          "Ticker"
+        ],
         "summary": "Get ticker",
         "description": "Returns ticker data for a specific symbol.",
         "operationId": "getTicker",
@@ -317,7 +354,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           },
           {
@@ -346,7 +388,9 @@
     },
     "/indices/{symbol_set}/ticker/short": {
       "get": {
-        "tags": ["Ticker"],
+        "tags": [
+          "Ticker"
+        ],
         "summary": "Get short tickers",
         "description": "Returns basic bid/ask/last prices and daily average for symbols.",
         "operationId": "getShortTickers",
@@ -357,7 +401,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           },
           {
@@ -396,7 +445,9 @@
     },
     "/indices/{symbol_set}/ticker/{symbol}/changes": {
       "get": {
-        "tags": ["Ticker"],
+        "tags": [
+          "Ticker"
+        ],
         "summary": "Get ticker with changes",
         "description": "Returns ticker data with price changes across multiple timeframes.",
         "operationId": "getTickerChanges",
@@ -407,7 +458,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           },
           {
@@ -435,7 +491,9 @@
     },
     "/indices/ticker/custom/{inex}/{symbol}": {
       "get": {
-        "tags": ["Ticker"],
+        "tags": [
+          "Ticker"
+        ],
         "summary": "Get custom ticker",
         "description": "Returns ticker values with custom exchange inclusion or exclusion filters.",
         "operationId": "getCustomTicker",
@@ -447,7 +505,10 @@
             "description": "Include or exclude the specified exchanges.",
             "schema": {
               "type": "string",
-              "enum": ["include", "exclude"]
+              "enum": [
+                "include",
+                "exclude"
+              ]
             }
           },
           {
@@ -484,7 +545,9 @@
     },
     "/indices/{symbol_set}/history/{symbol}": {
       "get": {
-        "tags": ["History"],
+        "tags": [
+          "History"
+        ],
         "summary": "Get historical data",
         "description": "Returns historical OHLC data for a symbol. Supports querying by period, since timestamp, or at a specific timestamp.",
         "operationId": "getHistory",
@@ -495,7 +558,12 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local", "crypto", "tokens"]
+              "enum": [
+                "global",
+                "local",
+                "crypto",
+                "tokens"
+              ]
             }
           },
           {
@@ -520,7 +588,10 @@
             "description": "Response format.",
             "schema": {
               "type": "string",
-              "enum": ["json", "csv"]
+              "enum": [
+                "json",
+                "csv"
+              ]
             }
           },
           {
@@ -553,7 +624,11 @@
             "description": "Data resolution.",
             "schema": {
               "type": "string",
-              "enum": ["minute", "hour", "day"]
+              "enum": [
+                "minute",
+                "hour",
+                "day"
+              ]
             }
           }
         ],
@@ -576,7 +651,9 @@
     },
     "/metadata": {
       "get": {
-        "tags": ["Metadata"],
+        "tags": [
+          "Metadata"
+        ],
         "summary": "Get metadata",
         "description": "Returns metadata and market information for all supported symbols.",
         "operationId": "getMetadata",
@@ -599,7 +676,9 @@
     },
     "/exchanges/ticker/{exchange_name}": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchange ticker",
         "description": "Returns all price data for a specific exchange.",
         "operationId": "getExchangeTicker",
@@ -632,7 +711,9 @@
     },
     "/exchanges/ticker/all": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get all exchange tickers",
         "description": "Returns ticker data for all exchanges.",
         "operationId": "getAllExchangeTickers",
@@ -684,7 +765,9 @@
     },
     "/exchanges/history/ohlc/{exchange_name}/{market}": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchange OHLC history",
         "description": "Returns OHLC historical data for a specific exchange and market.",
         "operationId": "getExchangeOHLC",
@@ -725,7 +808,9 @@
     },
     "/exchanges/orderbook/{exchange_name}/{market}": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchange orderbook",
         "description": "Returns the current orderbook snapshot for a specific exchange and market.",
         "operationId": "getExchangeOrderbook",
@@ -763,7 +848,9 @@
     },
     "/exchanges/{state}": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchanges by state",
         "description": "Returns exchanges that are either ignored or inactive.",
         "operationId": "getExchangesByState",
@@ -774,7 +861,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["ignored", "inactive"]
+              "enum": [
+                "ignored",
+                "inactive"
+              ]
             }
           }
         ],
@@ -805,7 +895,9 @@
     },
     "/exchanges/count": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchange count",
         "description": "Returns total exchange counts by status.",
         "operationId": "getExchangeCount",
@@ -839,7 +931,9 @@
     },
     "/exchanges/outliers": {
       "get": {
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "summary": "Get exchange outliers",
         "description": "Returns a list of exchanges that failed sanity checks.",
         "operationId": "getExchangeOutliers",
@@ -873,7 +967,9 @@
     },
     "/weighting/exchanges": {
       "get": {
-        "tags": ["Weighting"],
+        "tags": [
+          "Weighting"
+        ],
         "summary": "Get exchange weights",
         "description": "Returns a list of exchanges, their symbols, and their associated weights.",
         "operationId": "getExchangeWeights",
@@ -907,7 +1003,9 @@
     },
     "/weighting/currencies": {
       "get": {
-        "tags": ["Weighting"],
+        "tags": [
+          "Weighting"
+        ],
         "summary": "Get currency weights",
         "description": "Returns currency weights used in the Global Bitcoin Price Index.",
         "operationId": "getCurrencyWeights",
@@ -930,7 +1028,9 @@
     },
     "/convert/{symbol_set}": {
       "get": {
-        "tags": ["Conversion"],
+        "tags": [
+          "Conversion"
+        ],
         "summary": "Convert between currencies",
         "description": "Converts a price between currencies using the specified symbol set.",
         "operationId": "convert",
@@ -941,7 +1041,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["global", "local"]
+              "enum": [
+                "global",
+                "local"
+              ]
             }
           },
           {
@@ -999,7 +1102,9 @@
     },
     "/blockchain/tx_price/{symbol}/{hash}": {
       "get": {
-        "tags": ["Blockchain"],
+        "tags": [
+          "Blockchain"
+        ],
         "summary": "Get transaction price",
         "description": "Returns the price for the day the transaction was conducted.",
         "operationId": "getTransactionPrice",
@@ -1053,7 +1158,9 @@
     },
     "/websocket/v3/get_ticket": {
       "get": {
-        "tags": ["WebSocket"],
+        "tags": [
+          "WebSocket"
+        ],
         "summary": "Get WebSocket ticket",
         "description": "Returns a ticket for authenticating WebSocket connections (v3).",
         "operationId": "getWebSocketTicket",
@@ -1314,5 +1421,37 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Blockchain"
+    },
+    {
+      "name": "Constants"
+    },
+    {
+      "name": "Conversion"
+    },
+    {
+      "name": "Exchanges"
+    },
+    {
+      "name": "History"
+    },
+    {
+      "name": "Info"
+    },
+    {
+      "name": "Metadata"
+    },
+    {
+      "name": "Ticker"
+    },
+    {
+      "name": "WebSocket"
+    },
+    {
+      "name": "Weighting"
+    }
+  ]
 }

--- a/apis/openapi/bitfinex.com/bitfinex-api/2.0.0/openapi.json
+++ b/apis/openapi/bitfinex.com/bitfinex-api/2.0.0/openapi.json
@@ -22,7 +22,9 @@
   "paths": {
     "/platform/status": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Platform status",
         "description": "Get the current status of the platform. Returns 1 for operative, 0 for maintenance.",
         "operationId": "getPlatformStatus",
@@ -36,7 +38,9 @@
                   "items": {
                     "type": "integer"
                   },
-                  "example": [1]
+                  "example": [
+                    1
+                  ]
                 }
               }
             }
@@ -46,7 +50,9 @@
     },
     "/ticker/{symbol}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Ticker",
         "description": "Returns the ticker for a specified trading pair or funding currency. Use 't' prefix for trading pairs and 'f' prefix for funding currencies.",
         "operationId": "getTicker",
@@ -80,7 +86,9 @@
     },
     "/tickers": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Tickers",
         "description": "Returns tickers for multiple trading pairs or funding currencies with a single request.",
         "operationId": "getTickers",
@@ -115,7 +123,9 @@
     },
     "/tickers/hist": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Tickers history",
         "description": "Returns historic hourly ticker data for multiple pairs.",
         "operationId": "getTickersHistory",
@@ -176,7 +186,9 @@
     },
     "/trades/{symbol}/hist": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Trades",
         "description": "Returns past public trades with price and size details.",
         "operationId": "getTrades",
@@ -220,7 +232,10 @@
             "description": "Sort direction: 1 for ascending, -1 for descending.",
             "schema": {
               "type": "integer",
-              "enum": [-1, 1]
+              "enum": [
+                -1,
+                1
+              ]
             }
           }
         ],
@@ -246,7 +261,9 @@
     },
     "/book/{symbol}/{precision}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Order book",
         "description": "Returns the order book for the given trading pair with customizable precision.",
         "operationId": "getBook",
@@ -266,7 +283,14 @@
             "description": "Level of price aggregation (P0, P1, P2, P3, P4, R0).",
             "schema": {
               "type": "string",
-              "enum": ["P0", "P1", "P2", "P3", "P4", "R0"]
+              "enum": [
+                "P0",
+                "P1",
+                "P2",
+                "P3",
+                "P4",
+                "R0"
+              ]
             }
           },
           {
@@ -275,7 +299,11 @@
             "description": "Number of price points (1, 25, 100).",
             "schema": {
               "type": "integer",
-              "enum": [1, 25, 100],
+              "enum": [
+                1,
+                25,
+                100
+              ],
               "default": 25
             }
           }
@@ -302,7 +330,9 @@
     },
     "/stats1/{key}:{size}:{symbol}:{side}/{section}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Stats",
         "description": "Returns various statistics about the requested trading pair or funding currency.",
         "operationId": "getStats",
@@ -349,7 +379,10 @@
             "description": "Section (last or hist).",
             "schema": {
               "type": "string",
-              "enum": ["last", "hist"]
+              "enum": [
+                "last",
+                "hist"
+              ]
             }
           },
           {
@@ -357,7 +390,10 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "enum": [-1, 1]
+              "enum": [
+                -1,
+                1
+              ]
             }
           },
           {
@@ -401,7 +437,9 @@
     },
     "/candles/{candle}/{section}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Candles",
         "description": "Returns OHLCV (open, high, low, close, volume) candlestick data.",
         "operationId": "getCandles",
@@ -422,7 +460,10 @@
             "description": "Section (last or hist).",
             "schema": {
               "type": "string",
-              "enum": ["last", "hist"]
+              "enum": [
+                "last",
+                "hist"
+              ]
             }
           },
           {
@@ -430,7 +471,10 @@
             "in": "query",
             "schema": {
               "type": "integer",
-              "enum": [-1, 1]
+              "enum": [
+                -1,
+                1
+              ]
             }
           },
           {
@@ -480,7 +524,9 @@
     },
     "/status/deriv": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Derivatives status",
         "description": "Returns information about derivatives pairs.",
         "operationId": "getDerivativesStatus",
@@ -514,7 +560,9 @@
     },
     "/status/deriv/{key}/hist": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Derivatives status history",
         "description": "Returns historical derivatives status data.",
         "operationId": "getDerivativesStatusHistory",
@@ -579,7 +627,9 @@
     },
     "/liquidations/hist": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Liquidations",
         "description": "Returns recent liquidation events.",
         "operationId": "getLiquidations",
@@ -636,7 +686,9 @@
     },
     "/rankings/{key}:{timeframe}:{symbol}/{section}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Leaderboards",
         "description": "Returns leaderboard standings for various metrics.",
         "operationId": "getLeaderboards",
@@ -673,7 +725,10 @@
             "required": true,
             "schema": {
               "type": "string",
-              "enum": ["last", "hist"]
+              "enum": [
+                "last",
+                "hist"
+              ]
             }
           }
         ],
@@ -697,7 +752,9 @@
     },
     "/funding/stats/{symbol}/hist": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Funding statistics",
         "description": "Returns FRR (Flash Return Rate) and funding availability data.",
         "operationId": "getFundingStats",
@@ -757,7 +814,9 @@
     },
     "/conf/pub:{action}:{object}:{detail}": {
       "get": {
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "summary": "Configs",
         "description": "Returns site configuration data such as available pairs, currencies, and settings.",
         "operationId": "getConfigs",
@@ -807,7 +866,9 @@
     },
     "/auth/r/wallets": {
       "post": {
-        "tags": ["Authenticated - Wallets"],
+        "tags": [
+          "Authenticated - Wallets"
+        ],
         "summary": "Get wallets",
         "description": "Retrieve all user wallets.",
         "operationId": "getWallets",
@@ -848,7 +909,9 @@
     },
     "/auth/r/orders": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Get active orders",
         "description": "Fetch all active orders.",
         "operationId": "getActiveOrders",
@@ -888,7 +951,9 @@
     },
     "/auth/r/orders/{symbol}": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Get active orders by symbol",
         "description": "Fetch active orders for a specific trading pair.",
         "operationId": "getActiveOrdersBySymbol",
@@ -938,7 +1003,9 @@
     },
     "/auth/w/order/submit": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Submit order",
         "description": "Create a new order.",
         "operationId": "submitOrder",
@@ -976,7 +1043,9 @@
     },
     "/auth/w/order/update": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Update order",
         "description": "Modify an existing order.",
         "operationId": "updateOrder",
@@ -993,7 +1062,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1030,7 +1101,9 @@
     },
     "/auth/w/order/cancel": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Cancel order",
         "description": "Cancel a single order.",
         "operationId": "cancelOrder",
@@ -1081,7 +1154,9 @@
     },
     "/auth/w/order/cancel/multi": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Cancel multiple orders",
         "description": "Cancel multiple orders at once.",
         "operationId": "cancelMultipleOrders",
@@ -1132,7 +1207,9 @@
     },
     "/auth/r/orders/hist": {
       "post": {
-        "tags": ["Authenticated - Orders"],
+        "tags": [
+          "Authenticated - Orders"
+        ],
         "summary": "Orders history",
         "description": "Returns historical order data.",
         "operationId": "getOrdersHistory",
@@ -1185,7 +1262,9 @@
     },
     "/auth/r/trades/hist": {
       "post": {
-        "tags": ["Authenticated - Trading"],
+        "tags": [
+          "Authenticated - Trading"
+        ],
         "summary": "Trades history",
         "description": "Returns user trade history.",
         "operationId": "getTradesHistory",
@@ -1238,7 +1317,9 @@
     },
     "/auth/r/positions": {
       "post": {
-        "tags": ["Authenticated - Positions"],
+        "tags": [
+          "Authenticated - Positions"
+        ],
         "summary": "Get active positions",
         "description": "Returns current open positions.",
         "operationId": "getPositions",
@@ -1278,7 +1359,9 @@
     },
     "/auth/r/funding/offers": {
       "post": {
-        "tags": ["Authenticated - Funding"],
+        "tags": [
+          "Authenticated - Funding"
+        ],
         "summary": "Get active funding offers",
         "description": "Returns active funding offers.",
         "operationId": "getFundingOffers",
@@ -1318,7 +1401,9 @@
     },
     "/auth/w/funding/offer/submit": {
       "post": {
-        "tags": ["Authenticated - Funding"],
+        "tags": [
+          "Authenticated - Funding"
+        ],
         "summary": "Submit funding offer",
         "description": "Create a new funding offer.",
         "operationId": "submitFundingOffer",
@@ -1335,11 +1420,21 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["type", "symbol", "amount", "rate", "period"],
+                "required": [
+                  "type",
+                  "symbol",
+                  "amount",
+                  "rate",
+                  "period"
+                ],
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["LIMIT", "FRRDELTAVAR", "FRRDELTAFIX"]
+                    "enum": [
+                      "LIMIT",
+                      "FRRDELTAVAR",
+                      "FRRDELTAFIX"
+                    ]
                   },
                   "symbol": {
                     "type": "string"
@@ -1378,7 +1473,9 @@
     },
     "/auth/w/funding/offer/cancel": {
       "post": {
-        "tags": ["Authenticated - Funding"],
+        "tags": [
+          "Authenticated - Funding"
+        ],
         "summary": "Cancel funding offer",
         "description": "Cancel a funding offer.",
         "operationId": "cancelFundingOffer",
@@ -1395,7 +1492,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "integer",
@@ -1423,7 +1522,9 @@
     },
     "/auth/r/ledgers/hist": {
       "post": {
-        "tags": ["Authenticated - Ledger"],
+        "tags": [
+          "Authenticated - Ledger"
+        ],
         "summary": "Ledger entries",
         "description": "Returns account ledger entries.",
         "operationId": "getLedgers",
@@ -1479,7 +1580,9 @@
     },
     "/auth/r/movements/hist": {
       "post": {
-        "tags": ["Authenticated - Movements"],
+        "tags": [
+          "Authenticated - Movements"
+        ],
         "summary": "Movements history",
         "description": "Returns deposit and withdrawal history.",
         "operationId": "getMovements",
@@ -1532,7 +1635,9 @@
     },
     "/auth/w/deposit/address": {
       "post": {
-        "tags": ["Authenticated - Deposit"],
+        "tags": [
+          "Authenticated - Deposit"
+        ],
         "summary": "Generate deposit address",
         "description": "Generate a deposit address for a specific wallet and method.",
         "operationId": "generateDepositAddress",
@@ -1549,7 +1654,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["wallet", "method", "op_renew"],
+                "required": [
+                  "wallet",
+                  "method",
+                  "op_renew"
+                ],
                 "properties": {
                   "wallet": {
                     "type": "string",
@@ -1585,7 +1694,9 @@
     },
     "/auth/w/withdraw": {
       "post": {
-        "tags": ["Authenticated - Withdrawal"],
+        "tags": [
+          "Authenticated - Withdrawal"
+        ],
         "summary": "Withdraw",
         "description": "Initiate a cryptocurrency withdrawal.",
         "operationId": "withdraw",
@@ -1602,7 +1713,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["wallet", "method", "amount", "address"],
+                "required": [
+                  "wallet",
+                  "method",
+                  "amount",
+                  "address"
+                ],
                 "properties": {
                   "wallet": {
                     "type": "string"
@@ -1641,7 +1757,9 @@
     },
     "/auth/r/info/user": {
       "post": {
-        "tags": ["Authenticated - Account"],
+        "tags": [
+          "Authenticated - Account"
+        ],
         "summary": "Get user info",
         "description": "Retrieve user account information.",
         "operationId": "getUserInfo",
@@ -1678,7 +1796,9 @@
     },
     "/auth/r/key/permissions": {
       "post": {
-        "tags": ["Authenticated - Account"],
+        "tags": [
+          "Authenticated - Account"
+        ],
         "summary": "Get API key permissions",
         "description": "Returns permissions for the current API key.",
         "operationId": "getKeyPermissions",
@@ -1737,12 +1857,31 @@
     "schemas": {
       "OrderSubmit": {
         "type": "object",
-        "required": ["type", "symbol", "amount"],
+        "required": [
+          "type",
+          "symbol",
+          "amount"
+        ],
         "properties": {
           "type": {
             "type": "string",
             "description": "Order type.",
-            "enum": ["LIMIT", "EXCHANGE LIMIT", "MARKET", "EXCHANGE MARKET", "STOP", "EXCHANGE STOP", "STOP LIMIT", "EXCHANGE STOP LIMIT", "TRAILING STOP", "EXCHANGE TRAILING STOP", "FOK", "EXCHANGE FOK", "IOC", "EXCHANGE IOC"]
+            "enum": [
+              "LIMIT",
+              "EXCHANGE LIMIT",
+              "MARKET",
+              "EXCHANGE MARKET",
+              "STOP",
+              "EXCHANGE STOP",
+              "STOP LIMIT",
+              "EXCHANGE STOP LIMIT",
+              "TRAILING STOP",
+              "EXCHANGE TRAILING STOP",
+              "FOK",
+              "EXCHANGE FOK",
+              "IOC",
+              "EXCHANGE IOC"
+            ]
           },
           "symbol": {
             "type": "string",
@@ -1797,5 +1936,40 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Authenticated - Account"
+    },
+    {
+      "name": "Authenticated - Deposit"
+    },
+    {
+      "name": "Authenticated - Funding"
+    },
+    {
+      "name": "Authenticated - Ledger"
+    },
+    {
+      "name": "Authenticated - Movements"
+    },
+    {
+      "name": "Authenticated - Orders"
+    },
+    {
+      "name": "Authenticated - Positions"
+    },
+    {
+      "name": "Authenticated - Trading"
+    },
+    {
+      "name": "Authenticated - Wallets"
+    },
+    {
+      "name": "Authenticated - Withdrawal"
+    },
+    {
+      "name": "Public"
+    }
+  ]
 }

--- a/apis/openapi/bitskout.com/bitskout-zapier-api/1.0.0/openapi.json
+++ b/apis/openapi/bitskout.com/bitskout-zapier-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bitskout Zapier API",
     "version": "1.0.0",
     "description": "API for Bitskout interaction with Zapier. Bitskout provides AI-powered document processing workflows.",
-    "x-jentic-source-url": "https://app.swaggerhub.com/apis-docs/bitskout/BitskoutZapier/1.0.0"
+    "x-jentic-source-url": "https://app.swaggerhub.com/apis-docs/bitskout/BitskoutZapier/1.0.0",
+    "contact": {}
   },
   "servers": [
     {
@@ -240,6 +241,14 @@
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Workflows"
     }
   ]
 }

--- a/apis/openapi/bittrex.com/bittrex-api/3.0.0/openapi.json
+++ b/apis/openapi/bittrex.com/bittrex-api/3.0.0/openapi.json
@@ -21,7 +21,9 @@
         "summary": "List markets",
         "description": "Returns a list of all available markets.",
         "operationId": "getMarkets",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "responses": {
           "200": {
             "description": "List of markets",
@@ -29,7 +31,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Market" }
+                  "items": {
+                    "$ref": "#/components/schemas/Market"
+                  }
                 }
               }
             }
@@ -42,13 +46,17 @@
         "summary": "Get market",
         "description": "Returns a specific market by symbol.",
         "operationId": "getMarket",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Market symbol (e.g. BTC-USD)"
           }
         ],
@@ -57,7 +65,9 @@
             "description": "Market details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Market" }
+                "schema": {
+                  "$ref": "#/components/schemas/Market"
+                }
               }
             }
           }
@@ -69,7 +79,9 @@
         "summary": "List market summaries",
         "description": "Returns summary data for all markets.",
         "operationId": "getMarketSummaries",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "responses": {
           "200": {
             "description": "Market summaries",
@@ -77,7 +89,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/MarketSummary" }
+                  "items": {
+                    "$ref": "#/components/schemas/MarketSummary"
+                  }
                 }
               }
             }
@@ -90,13 +104,17 @@
         "summary": "Get market summary",
         "description": "Returns summary data for a specific market.",
         "operationId": "getMarketSummary",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -104,7 +122,9 @@
             "description": "Market summary",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MarketSummary" }
+                "schema": {
+                  "$ref": "#/components/schemas/MarketSummary"
+                }
               }
             }
           }
@@ -116,7 +136,9 @@
         "summary": "List tickers",
         "description": "Returns ticker data for all markets.",
         "operationId": "getTickers",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "responses": {
           "200": {
             "description": "Tickers",
@@ -124,7 +146,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Ticker" }
+                  "items": {
+                    "$ref": "#/components/schemas/Ticker"
+                  }
                 }
               }
             }
@@ -137,13 +161,17 @@
         "summary": "Get market ticker",
         "description": "Returns ticker data for a specific market.",
         "operationId": "getMarketTicker",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -151,7 +179,9 @@
             "description": "Ticker",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Ticker" }
+                "schema": {
+                  "$ref": "#/components/schemas/Ticker"
+                }
               }
             }
           }
@@ -163,18 +193,30 @@
         "summary": "Get order book",
         "description": "Returns the order book for a market.",
         "operationId": "getOrderBook",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "depth",
             "in": "query",
-            "schema": { "type": "integer", "default": 25, "enum": [1, 25, 500] },
+            "schema": {
+              "type": "integer",
+              "default": 25,
+              "enum": [
+                1,
+                25,
+                500
+              ]
+            },
             "description": "Order book depth (1, 25, or 500)"
           }
         ],
@@ -183,7 +225,9 @@
             "description": "Order book",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/OrderBook" }
+                "schema": {
+                  "$ref": "#/components/schemas/OrderBook"
+                }
               }
             }
           }
@@ -195,13 +239,17 @@
         "summary": "Get recent trades",
         "description": "Returns recent trades for a market.",
         "operationId": "getMarketTrades",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -211,7 +259,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Trade" }
+                  "items": {
+                    "$ref": "#/components/schemas/Trade"
+                  }
                 }
               }
             }
@@ -224,25 +274,43 @@
         "summary": "Get recent candles",
         "description": "Returns recent candle (OHLCV) data for a market.",
         "operationId": "getRecentCandles",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "candleType",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "enum": ["TRADE", "MIDPOINT"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "TRADE",
+                "MIDPOINT"
+              ]
+            }
           },
           {
             "name": "candleInterval",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "enum": ["MINUTE_1", "MINUTE_5", "HOUR_1", "DAY_1"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "MINUTE_1",
+                "MINUTE_5",
+                "HOUR_1",
+                "DAY_1"
+              ]
+            }
           }
         ],
         "responses": {
@@ -252,7 +320,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Candle" }
+                  "items": {
+                    "$ref": "#/components/schemas/Candle"
+                  }
                 }
               }
             }
@@ -265,7 +335,9 @@
         "summary": "List currencies",
         "description": "Returns a list of all supported currencies.",
         "operationId": "getCurrencies",
-        "tags": ["Currencies"],
+        "tags": [
+          "Currencies"
+        ],
         "responses": {
           "200": {
             "description": "List of currencies",
@@ -273,7 +345,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Currency" }
+                  "items": {
+                    "$ref": "#/components/schemas/Currency"
+                  }
                 }
               }
             }
@@ -286,13 +360,17 @@
         "summary": "Get currency",
         "description": "Returns a specific currency by symbol.",
         "operationId": "getCurrency",
-        "tags": ["Currencies"],
+        "tags": [
+          "Currencies"
+        ],
         "parameters": [
           {
             "name": "symbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -300,7 +378,9 @@
             "description": "Currency details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Currency" }
+                "schema": {
+                  "$ref": "#/components/schemas/Currency"
+                }
               }
             }
           }
@@ -312,8 +392,14 @@
         "summary": "List balances",
         "description": "Returns all balances for the authenticated account.",
         "operationId": "getBalances",
-        "tags": ["Account"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Account balances",
@@ -321,7 +407,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Balance" }
+                  "items": {
+                    "$ref": "#/components/schemas/Balance"
+                  }
                 }
               }
             }
@@ -334,14 +422,22 @@
         "summary": "Get balance",
         "description": "Returns balance for a specific currency.",
         "operationId": "getBalance",
-        "tags": ["Account"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Account"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "currencySymbol",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -349,7 +445,9 @@
             "description": "Balance",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Balance" }
+                "schema": {
+                  "$ref": "#/components/schemas/Balance"
+                }
               }
             }
           }
@@ -361,19 +459,29 @@
         "summary": "List closed orders",
         "description": "Returns closed orders for the authenticated account.",
         "operationId": "getClosedOrders",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by market symbol"
           },
           {
             "name": "pageSize",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Maximum results per page"
           }
         ],
@@ -384,7 +492,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Order" }
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
                 }
               }
             }
@@ -395,13 +505,21 @@
         "summary": "Create order",
         "description": "Creates a new order.",
         "operationId": "createOrder",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/NewOrder" }
+              "schema": {
+                "$ref": "#/components/schemas/NewOrder"
+              }
             }
           }
         },
@@ -410,7 +528,9 @@
             "description": "Order created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Order" }
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
               }
             }
           }
@@ -422,13 +542,21 @@
         "summary": "List open orders",
         "description": "Returns open orders for the authenticated account.",
         "operationId": "getOpenOrders",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -438,7 +566,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Order" }
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
                 }
               }
             }
@@ -449,13 +579,21 @@
         "summary": "Cancel all open orders",
         "description": "Cancels all open orders, optionally filtered by market.",
         "operationId": "cancelAllOrders",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "marketSymbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -465,7 +603,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Order" }
+                  "items": {
+                    "$ref": "#/components/schemas/Order"
+                  }
                 }
               }
             }
@@ -478,14 +618,23 @@
         "summary": "Get order",
         "description": "Returns a specific order by ID.",
         "operationId": "getOrder",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "orderId",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "format": "uuid" }
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -493,7 +642,9 @@
             "description": "Order details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Order" }
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
               }
             }
           }
@@ -503,14 +654,23 @@
         "summary": "Cancel order",
         "description": "Cancels a specific order.",
         "operationId": "cancelOrder",
-        "tags": ["Orders"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Orders"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "orderId",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "format": "uuid" }
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
@@ -518,7 +678,9 @@
             "description": "Cancelled order",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Order" }
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
               }
             }
           }
@@ -530,8 +692,14 @@
         "summary": "List deposit addresses",
         "description": "Returns deposit addresses for the authenticated account.",
         "operationId": "getAddresses",
-        "tags": ["Addresses"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Addresses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Deposit addresses",
@@ -539,7 +707,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Address" }
+                  "items": {
+                    "$ref": "#/components/schemas/Address"
+                  }
                 }
               }
             }
@@ -550,17 +720,27 @@
         "summary": "Request deposit address",
         "description": "Provisions a new deposit address for a currency.",
         "operationId": "createAddress",
-        "tags": ["Addresses"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Addresses"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["currencySymbol"],
+                "required": [
+                  "currencySymbol"
+                ],
                 "properties": {
-                  "currencySymbol": { "type": "string" }
+                  "currencySymbol": {
+                    "type": "string"
+                  }
                 }
               }
             }
@@ -571,7 +751,9 @@
             "description": "Address created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Address" }
+                "schema": {
+                  "$ref": "#/components/schemas/Address"
+                }
               }
             }
           }
@@ -583,8 +765,14 @@
         "summary": "List withdrawals",
         "description": "Returns withdrawal history.",
         "operationId": "getWithdrawals",
-        "tags": ["Withdrawals"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Withdrawals"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Withdrawals",
@@ -592,7 +780,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Withdrawal" }
+                  "items": {
+                    "$ref": "#/components/schemas/Withdrawal"
+                  }
                 }
               }
             }
@@ -603,13 +793,21 @@
         "summary": "Create withdrawal",
         "description": "Creates a new withdrawal.",
         "operationId": "createWithdrawal",
-        "tags": ["Withdrawals"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Withdrawals"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/NewWithdrawal" }
+              "schema": {
+                "$ref": "#/components/schemas/NewWithdrawal"
+              }
             }
           }
         },
@@ -618,7 +816,9 @@
             "description": "Withdrawal created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Withdrawal" }
+                "schema": {
+                  "$ref": "#/components/schemas/Withdrawal"
+                }
               }
             }
           }
@@ -630,8 +830,14 @@
         "summary": "List deposits",
         "description": "Returns deposit history.",
         "operationId": "getDeposits",
-        "tags": ["Deposits"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Deposits"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Deposits",
@@ -639,7 +845,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": { "$ref": "#/components/schemas/Deposit" }
+                  "items": {
+                    "$ref": "#/components/schemas/Deposit"
+                  }
                 }
               }
             }
@@ -652,7 +860,9 @@
         "summary": "Ping",
         "description": "Returns server timestamp to verify connectivity.",
         "operationId": "ping",
-        "tags": ["System"],
+        "tags": [
+          "System"
+        ],
         "responses": {
           "200": {
             "description": "Server timestamp",
@@ -661,7 +871,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "serverTime": { "type": "integer" }
+                    "serverTime": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -684,38 +896,97 @@
       "Market": {
         "type": "object",
         "properties": {
-          "symbol": { "type": "string" },
-          "baseCurrencySymbol": { "type": "string" },
-          "quoteCurrencySymbol": { "type": "string" },
-          "minTradeSize": { "type": "string" },
-          "precision": { "type": "integer" },
-          "status": { "type": "string", "enum": ["ONLINE", "OFFLINE"] },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "notice": { "type": "string" },
-          "prohibitedIn": { "type": "array", "items": { "type": "string" } },
-          "associatedTermsOfService": { "type": "array", "items": { "type": "string" } },
-          "tags": { "type": "array", "items": { "type": "string" } }
+          "symbol": {
+            "type": "string"
+          },
+          "baseCurrencySymbol": {
+            "type": "string"
+          },
+          "quoteCurrencySymbol": {
+            "type": "string"
+          },
+          "minTradeSize": {
+            "type": "string"
+          },
+          "precision": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ONLINE",
+              "OFFLINE"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "notice": {
+            "type": "string"
+          },
+          "prohibitedIn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "associatedTermsOfService": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "MarketSummary": {
         "type": "object",
         "properties": {
-          "symbol": { "type": "string" },
-          "high": { "type": "string" },
-          "low": { "type": "string" },
-          "volume": { "type": "string" },
-          "quoteVolume": { "type": "string" },
-          "percentChange": { "type": "string" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "symbol": {
+            "type": "string"
+          },
+          "high": {
+            "type": "string"
+          },
+          "low": {
+            "type": "string"
+          },
+          "volume": {
+            "type": "string"
+          },
+          "quoteVolume": {
+            "type": "string"
+          },
+          "percentChange": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Ticker": {
         "type": "object",
         "properties": {
-          "symbol": { "type": "string" },
-          "lastTradeRate": { "type": "string" },
-          "bidRate": { "type": "string" },
-          "askRate": { "type": "string" }
+          "symbol": {
+            "type": "string"
+          },
+          "lastTradeRate": {
+            "type": "string"
+          },
+          "bidRate": {
+            "type": "string"
+          },
+          "askRate": {
+            "type": "string"
+          }
         }
       },
       "OrderBook": {
@@ -723,154 +994,451 @@
         "properties": {
           "bid": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/OrderBookEntry" }
+            "items": {
+              "$ref": "#/components/schemas/OrderBookEntry"
+            }
           },
           "ask": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/OrderBookEntry" }
+            "items": {
+              "$ref": "#/components/schemas/OrderBookEntry"
+            }
           }
         }
       },
       "OrderBookEntry": {
         "type": "object",
         "properties": {
-          "quantity": { "type": "string" },
-          "rate": { "type": "string" }
+          "quantity": {
+            "type": "string"
+          },
+          "rate": {
+            "type": "string"
+          }
         }
       },
       "Trade": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "executedAt": { "type": "string", "format": "date-time" },
-          "quantity": { "type": "string" },
-          "rate": { "type": "string" },
-          "takerSide": { "type": "string", "enum": ["BUY", "SELL"] }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "executedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "rate": {
+            "type": "string"
+          },
+          "takerSide": {
+            "type": "string",
+            "enum": [
+              "BUY",
+              "SELL"
+            ]
+          }
         }
       },
       "Candle": {
         "type": "object",
         "properties": {
-          "startsAt": { "type": "string", "format": "date-time" },
-          "open": { "type": "string" },
-          "high": { "type": "string" },
-          "low": { "type": "string" },
-          "close": { "type": "string" },
-          "volume": { "type": "string" },
-          "quoteVolume": { "type": "string" }
+          "startsAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "open": {
+            "type": "string"
+          },
+          "high": {
+            "type": "string"
+          },
+          "low": {
+            "type": "string"
+          },
+          "close": {
+            "type": "string"
+          },
+          "volume": {
+            "type": "string"
+          },
+          "quoteVolume": {
+            "type": "string"
+          }
         }
       },
       "Currency": {
         "type": "object",
         "properties": {
-          "symbol": { "type": "string" },
-          "name": { "type": "string" },
-          "coinType": { "type": "string" },
-          "status": { "type": "string", "enum": ["ONLINE", "OFFLINE"] },
-          "minConfirmations": { "type": "integer" },
-          "notice": { "type": "string" },
-          "txFee": { "type": "string" },
-          "logoUrl": { "type": "string" },
-          "prohibitedIn": { "type": "array", "items": { "type": "string" } },
-          "baseAddress": { "type": "string" },
-          "associatedTermsOfService": { "type": "array", "items": { "type": "string" } },
-          "tags": { "type": "array", "items": { "type": "string" } }
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "coinType": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "ONLINE",
+              "OFFLINE"
+            ]
+          },
+          "minConfirmations": {
+            "type": "integer"
+          },
+          "notice": {
+            "type": "string"
+          },
+          "txFee": {
+            "type": "string"
+          },
+          "logoUrl": {
+            "type": "string"
+          },
+          "prohibitedIn": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "baseAddress": {
+            "type": "string"
+          },
+          "associatedTermsOfService": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "Balance": {
         "type": "object",
         "properties": {
-          "currencySymbol": { "type": "string" },
-          "total": { "type": "string" },
-          "available": { "type": "string" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "currencySymbol": {
+            "type": "string"
+          },
+          "total": {
+            "type": "string"
+          },
+          "available": {
+            "type": "string"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Order": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "marketSymbol": { "type": "string" },
-          "direction": { "type": "string", "enum": ["BUY", "SELL"] },
-          "type": { "type": "string", "enum": ["LIMIT", "MARKET", "CEILING_LIMIT", "CEILING_MARKET"] },
-          "quantity": { "type": "string" },
-          "limit": { "type": "string" },
-          "ceiling": { "type": "string" },
-          "timeInForce": { "type": "string", "enum": ["GOOD_TIL_CANCELLED", "IMMEDIATE_OR_CANCEL", "FILL_OR_KILL", "POST_ONLY_GOOD_TIL_CANCELLED", "BUY_NOW", "INSTANT"] },
-          "fillQuantity": { "type": "string" },
-          "commission": { "type": "string" },
-          "proceeds": { "type": "string" },
-          "status": { "type": "string", "enum": ["OPEN", "CLOSED", "CANCELLED"] },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" },
-          "closedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "marketSymbol": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "BUY",
+              "SELL"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "LIMIT",
+              "MARKET",
+              "CEILING_LIMIT",
+              "CEILING_MARKET"
+            ]
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "ceiling": {
+            "type": "string"
+          },
+          "timeInForce": {
+            "type": "string",
+            "enum": [
+              "GOOD_TIL_CANCELLED",
+              "IMMEDIATE_OR_CANCEL",
+              "FILL_OR_KILL",
+              "POST_ONLY_GOOD_TIL_CANCELLED",
+              "BUY_NOW",
+              "INSTANT"
+            ]
+          },
+          "fillQuantity": {
+            "type": "string"
+          },
+          "commission": {
+            "type": "string"
+          },
+          "proceeds": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "OPEN",
+              "CLOSED",
+              "CANCELLED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "closedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "NewOrder": {
         "type": "object",
-        "required": ["marketSymbol", "direction", "type", "timeInForce"],
+        "required": [
+          "marketSymbol",
+          "direction",
+          "type",
+          "timeInForce"
+        ],
         "properties": {
-          "marketSymbol": { "type": "string" },
-          "direction": { "type": "string", "enum": ["BUY", "SELL"] },
-          "type": { "type": "string", "enum": ["LIMIT", "MARKET", "CEILING_LIMIT", "CEILING_MARKET"] },
-          "quantity": { "type": "string" },
-          "limit": { "type": "string" },
-          "ceiling": { "type": "string" },
-          "timeInForce": { "type": "string", "enum": ["GOOD_TIL_CANCELLED", "IMMEDIATE_OR_CANCEL", "FILL_OR_KILL", "POST_ONLY_GOOD_TIL_CANCELLED", "BUY_NOW", "INSTANT"] },
-          "clientOrderId": { "type": "string", "format": "uuid" },
-          "useAwards": { "type": "boolean" }
+          "marketSymbol": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string",
+            "enum": [
+              "BUY",
+              "SELL"
+            ]
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "LIMIT",
+              "MARKET",
+              "CEILING_LIMIT",
+              "CEILING_MARKET"
+            ]
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "limit": {
+            "type": "string"
+          },
+          "ceiling": {
+            "type": "string"
+          },
+          "timeInForce": {
+            "type": "string",
+            "enum": [
+              "GOOD_TIL_CANCELLED",
+              "IMMEDIATE_OR_CANCEL",
+              "FILL_OR_KILL",
+              "POST_ONLY_GOOD_TIL_CANCELLED",
+              "BUY_NOW",
+              "INSTANT"
+            ]
+          },
+          "clientOrderId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "useAwards": {
+            "type": "boolean"
+          }
         }
       },
       "Address": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "enum": ["REQUESTED", "PROVISIONED"] },
-          "currencySymbol": { "type": "string" },
-          "cryptoAddress": { "type": "string" },
-          "cryptoAddressTag": { "type": "string" }
+          "status": {
+            "type": "string",
+            "enum": [
+              "REQUESTED",
+              "PROVISIONED"
+            ]
+          },
+          "currencySymbol": {
+            "type": "string"
+          },
+          "cryptoAddress": {
+            "type": "string"
+          },
+          "cryptoAddressTag": {
+            "type": "string"
+          }
         }
       },
       "Withdrawal": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "currencySymbol": { "type": "string" },
-          "quantity": { "type": "string" },
-          "cryptoAddress": { "type": "string" },
-          "cryptoAddressTag": { "type": "string" },
-          "txCost": { "type": "string" },
-          "txId": { "type": "string" },
-          "status": { "type": "string", "enum": ["REQUESTED", "AUTHORIZED", "PENDING", "COMPLETED", "CANCELLED", "ERROR_INVALID_ADDRESS"] },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "completedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "currencySymbol": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "cryptoAddress": {
+            "type": "string"
+          },
+          "cryptoAddressTag": {
+            "type": "string"
+          },
+          "txCost": {
+            "type": "string"
+          },
+          "txId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "REQUESTED",
+              "AUTHORIZED",
+              "PENDING",
+              "COMPLETED",
+              "CANCELLED",
+              "ERROR_INVALID_ADDRESS"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "NewWithdrawal": {
         "type": "object",
-        "required": ["currencySymbol", "quantity", "cryptoAddress"],
+        "required": [
+          "currencySymbol",
+          "quantity",
+          "cryptoAddress"
+        ],
         "properties": {
-          "currencySymbol": { "type": "string" },
-          "quantity": { "type": "string" },
-          "cryptoAddress": { "type": "string" },
-          "cryptoAddressTag": { "type": "string" },
-          "clientWithdrawalId": { "type": "string", "format": "uuid" }
+          "currencySymbol": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "cryptoAddress": {
+            "type": "string"
+          },
+          "cryptoAddressTag": {
+            "type": "string"
+          },
+          "clientWithdrawalId": {
+            "type": "string",
+            "format": "uuid"
+          }
         }
       },
       "Deposit": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "currencySymbol": { "type": "string" },
-          "quantity": { "type": "string" },
-          "cryptoAddress": { "type": "string" },
-          "cryptoAddressTag": { "type": "string" },
-          "txId": { "type": "string" },
-          "confirmations": { "type": "integer" },
-          "updatedAt": { "type": "string", "format": "date-time" },
-          "completedAt": { "type": "string", "format": "date-time" },
-          "status": { "type": "string", "enum": ["PENDING", "COMPLETED", "ORPHANED", "INVALIDATED"] }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "currencySymbol": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "cryptoAddress": {
+            "type": "string"
+          },
+          "cryptoAddressTag": {
+            "type": "string"
+          },
+          "txId": {
+            "type": "string"
+          },
+          "confirmations": {
+            "type": "integer"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "COMPLETED",
+              "ORPHANED",
+              "INVALIDATED"
+            ]
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Addresses"
+    },
+    {
+      "name": "Currencies"
+    },
+    {
+      "name": "Deposits"
+    },
+    {
+      "name": "Markets"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "System"
+    },
+    {
+      "name": "Withdrawals"
+    }
+  ]
 }

--- a/apis/openapi/biztoc.com/biztoc/v1/openapi.json
+++ b/apis/openapi/biztoc.com/biztoc/v1/openapi.json
@@ -23,7 +23,8 @@
       }
     ],
     "x-providerName": "biztoc.com",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/biztoc.com/v1/openapi.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/biztoc.com/v1/openapi.yaml",
+    "contact": {}
   },
   "paths": {
     "/ai/news": {
@@ -44,8 +45,17 @@
             "description": "OK"
           }
         },
-        "summary": "Retrieves the latest news whose content contains the query string."
+        "summary": "Retrieves the latest news whose content contains the query string.",
+        "tags": [
+          "ai"
+        ],
+        "description": "Retrieves the latest news whose content contains the query string."
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "ai"
+    }
+  ]
 }

--- a/apis/openapi/blackbaud.com/blackbaud/1.0.0/openapi.json
+++ b/apis/openapi/blackbaud.com/blackbaud/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Blackbaud API",
     "version": "1.0.0",
     "description": "Nonprofit and education software API",
-    "x-jentic-source-url": "https://developer.blackbaud.com/lo-api/loapi/donations"
+    "x-jentic-source-url": "https://developer.blackbaud.com/lo-api/loapi/donations",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/blackbaud.com/blackbaud/1.0.0/openapi.json
+++ b/apis/openapi/blackbaud.com/blackbaud/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/blip.ai/blip-api/1.0.0/openapi.json
+++ b/apis/openapi/blip.ai/blip-api/1.0.0/openapi.json
@@ -248,6 +248,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/blip.ai/blip-api/1.0.0/openapi.json
+++ b/apis/openapi/blip.ai/blip-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Blip API",
     "version": "1.0.0",
     "description": "Blip chatbot platform API using LIME protocol for sending messages, notifications, and commands to manage bot resources and extensions.",
-    "x-jentic-source-url": "https://docs.blip.ai/#introduction"
+    "x-jentic-source-url": "https://docs.blip.ai/#introduction",
+    "contact": {}
   },
   "servers": [
     {
@@ -48,7 +49,8 @@
           "429": {
             "description": "Rate limit exceeded"
           }
-        }
+        },
+        "description": "Send a message to a user"
       }
     },
     "/notifications": {
@@ -78,7 +80,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Send a notification about message status"
       }
     },
     "/commands": {
@@ -115,29 +118,13 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Send a command to query or manipulate server resources"
       }
     }
   },
   "components": {
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "enum": [
-              "error"
-            ]
-          },
-          "code": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
       "Message": {
         "type": "object",
         "required": [
@@ -261,18 +248,22 @@
           }
         }
       }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
     }
   },
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Commands"
+    },
+    {
+      "name": "Messages"
+    },
+    {
+      "name": "Notifications"
     }
   ]
 }

--- a/apis/openapi/blockchain.com/blockchain-api/1.0.0/openapi.json
+++ b/apis/openapi/blockchain.com/blockchain-api/1.0.0/openapi.json
@@ -21,19 +21,28 @@
         "summary": "Get single block by hash",
         "description": "Returns a single block in JSON format.",
         "operationId": "getRawBlock",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "block_hash",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "The block hash"
           },
           {
             "name": "format",
             "in": "query",
-            "schema": { "type": "string", "enum": ["hex"] },
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hex"
+              ]
+            },
             "description": "Set to 'hex' to get binary block in hex format"
           }
         ],
@@ -42,7 +51,9 @@
             "description": "Block data",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Block" }
+                "schema": {
+                  "$ref": "#/components/schemas/Block"
+                }
               }
             }
           }
@@ -54,19 +65,28 @@
         "summary": "Get single transaction by hash",
         "description": "Returns a single transaction in JSON format.",
         "operationId": "getRawTransaction",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "tx_hash",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "The transaction hash"
           },
           {
             "name": "format",
             "in": "query",
-            "schema": { "type": "string", "enum": ["hex"] },
+            "schema": {
+              "type": "string",
+              "enum": [
+                "hex"
+              ]
+            },
             "description": "Set to 'hex' to get raw transaction in hex format"
           }
         ],
@@ -75,7 +95,9 @@
             "description": "Transaction data",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Transaction" }
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
               }
             }
           }
@@ -87,20 +109,29 @@
         "summary": "Get blocks at a specific height",
         "description": "Returns blocks at the specified height. Sometimes more than one block is mined at the same height.",
         "operationId": "getBlockHeight",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "block_height",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "The block height"
           },
           {
             "name": "format",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "enum": ["json"] },
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            },
             "description": "Must be set to 'json'"
           }
         ],
@@ -114,7 +145,9 @@
                   "properties": {
                     "blocks": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Block" }
+                      "items": {
+                        "$ref": "#/components/schemas/Block"
+                      }
                     }
                   }
                 }
@@ -129,25 +162,34 @@
         "summary": "Get single address data",
         "description": "Returns information about a single Bitcoin address including transactions.",
         "operationId": "getRawAddress",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "bitcoin_address",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "The Bitcoin address"
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 },
+            "schema": {
+              "type": "integer",
+              "default": 50
+            },
             "description": "Number of transactions to return (default and max: 50)"
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Pagination offset"
           }
         ],
@@ -156,7 +198,9 @@
             "description": "Address data",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Address" }
+                "schema": {
+                  "$ref": "#/components/schemas/Address"
+                }
               }
             }
           }
@@ -168,25 +212,35 @@
         "summary": "Get multiple address data",
         "description": "Returns information about multiple Bitcoin addresses.",
         "operationId": "getMultiAddress",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "active",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Pipe-separated list of Bitcoin addresses (e.g. addr1|addr2)"
           },
           {
             "name": "n",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "maximum": 100 },
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 100
+            },
             "description": "Number of transactions per address (default: 50, max: 100)"
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Pagination offset"
           }
         ],
@@ -200,11 +254,15 @@
                   "properties": {
                     "addresses": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Address" }
+                      "items": {
+                        "$ref": "#/components/schemas/Address"
+                      }
                     },
                     "txs": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Transaction" }
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      }
                     }
                   }
                 }
@@ -219,25 +277,35 @@
         "summary": "Get unspent outputs for an address",
         "description": "Returns unspent transaction outputs for a Bitcoin address.",
         "operationId": "getUnspentOutputs",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "active",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Bitcoin address"
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 250, "maximum": 1000 },
+            "schema": {
+              "type": "integer",
+              "default": 250,
+              "maximum": 1000
+            },
             "description": "Number of outputs to return (default: 250, max: 1000)"
           },
           {
             "name": "confirmations",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Minimum confirmations filter"
           }
         ],
@@ -251,7 +319,9 @@
                   "properties": {
                     "unspent_outputs": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/UnspentOutput" }
+                      "items": {
+                        "$ref": "#/components/schemas/UnspentOutput"
+                      }
                     }
                   }
                 }
@@ -266,13 +336,17 @@
         "summary": "Get address balance",
         "description": "Returns the balance for one or more Bitcoin addresses.",
         "operationId": "getBalance",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "active",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Pipe-separated list of Bitcoin addresses"
           }
         ],
@@ -286,9 +360,18 @@
                   "additionalProperties": {
                     "type": "object",
                     "properties": {
-                      "final_balance": { "type": "integer", "description": "Balance in satoshi" },
-                      "n_tx": { "type": "integer", "description": "Number of transactions" },
-                      "total_received": { "type": "integer", "description": "Total received in satoshi" }
+                      "final_balance": {
+                        "type": "integer",
+                        "description": "Balance in satoshi"
+                      },
+                      "n_tx": {
+                        "type": "integer",
+                        "description": "Number of transactions"
+                      },
+                      "total_received": {
+                        "type": "integer",
+                        "description": "Total received in satoshi"
+                      }
                     }
                   }
                 }
@@ -303,7 +386,9 @@
         "summary": "Get latest block",
         "description": "Returns the latest block on the main chain.",
         "operationId": "getLatestBlock",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "responses": {
           "200": {
             "description": "Latest block data",
@@ -312,11 +397,24 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "hash": { "type": "string" },
-                    "time": { "type": "integer" },
-                    "block_index": { "type": "integer" },
-                    "height": { "type": "integer" },
-                    "txIndexes": { "type": "array", "items": { "type": "integer" } }
+                    "hash": {
+                      "type": "string"
+                    },
+                    "time": {
+                      "type": "integer"
+                    },
+                    "block_index": {
+                      "type": "integer"
+                    },
+                    "height": {
+                      "type": "integer"
+                    },
+                    "txIndexes": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer"
+                      }
+                    }
                   }
                 }
               }
@@ -330,13 +428,20 @@
         "summary": "Get unconfirmed transactions",
         "description": "Returns unconfirmed transactions.",
         "operationId": "getUnconfirmedTransactions",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "format",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "enum": ["json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            }
           }
         ],
         "responses": {
@@ -349,7 +454,9 @@
                   "properties": {
                     "txs": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Transaction" }
+                      "items": {
+                        "$ref": "#/components/schemas/Transaction"
+                      }
                     }
                   }
                 }
@@ -364,20 +471,29 @@
         "summary": "Get blocks by time or pool",
         "description": "Returns blocks for a specific day (time in milliseconds) or mining pool.",
         "operationId": "getBlocks",
-        "tags": ["Blockchain Data"],
+        "tags": [
+          "Blockchain Data"
+        ],
         "parameters": [
           {
             "name": "time_or_pool",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Timestamp in milliseconds or pool name"
           },
           {
             "name": "format",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "enum": ["json"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json"
+              ]
+            }
           }
         ],
         "responses": {
@@ -393,9 +509,15 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "height": { "type": "integer" },
-                          "hash": { "type": "string" },
-                          "time": { "type": "integer" }
+                          "height": {
+                            "type": "integer"
+                          },
+                          "hash": {
+                            "type": "string"
+                          },
+                          "time": {
+                            "type": "integer"
+                          }
                         }
                       }
                     }
@@ -412,7 +534,9 @@
         "summary": "Get exchange rates",
         "description": "Returns market prices from major exchanges in various currencies.",
         "operationId": "getTicker",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "responses": {
           "200": {
             "description": "Exchange rate data",
@@ -435,20 +559,26 @@
         "summary": "Convert currency to BTC",
         "description": "Converts a value in a given currency to BTC.",
         "operationId": "toBTC",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "currency",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Currency code (e.g. USD, EUR)"
           },
           {
             "name": "value",
             "in": "query",
             "required": true,
-            "schema": { "type": "number" },
+            "schema": {
+              "type": "number"
+            },
             "description": "The value to convert"
           }
         ],
@@ -457,7 +587,9 @@
             "description": "BTC value",
             "content": {
               "text/plain": {
-                "schema": { "type": "number" }
+                "schema": {
+                  "type": "number"
+                }
               }
             }
           }
@@ -469,24 +601,36 @@
         "summary": "Get chart data",
         "description": "Returns data for a specific chart type.",
         "operationId": "getChartData",
-        "tags": ["Charts & Statistics"],
+        "tags": [
+          "Charts & Statistics"
+        ],
         "parameters": [
           {
             "name": "chart_type",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "The chart type (e.g. total-bitcoins, market-price, hash-rate)"
           },
           {
             "name": "format",
             "in": "query",
-            "schema": { "type": "string", "enum": ["json", "csv"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "csv"
+              ]
+            }
           },
           {
             "name": "timespan",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Duration of chart (e.g. 1year, 6months, 30days)"
           }
         ],
@@ -503,8 +647,14 @@
                       "items": {
                         "type": "object",
                         "properties": {
-                          "x": { "type": "integer", "description": "Unix timestamp" },
-                          "y": { "type": "number", "description": "Value" }
+                          "x": {
+                            "type": "integer",
+                            "description": "Unix timestamp"
+                          },
+                          "y": {
+                            "type": "number",
+                            "description": "Value"
+                          }
                         }
                       }
                     }
@@ -520,277 +670,622 @@
       "get": {
         "summary": "Get current difficulty",
         "operationId": "getDifficulty",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Current difficulty", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Current difficulty",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get current difficulty"
       }
     },
     "/q/getblockcount": {
       "get": {
         "summary": "Get current block count",
         "operationId": "getBlockCount",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Block count", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Block count",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get current block count"
       }
     },
     "/q/latesthash": {
       "get": {
         "summary": "Get latest block hash",
         "operationId": "getLatestHash",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Latest hash", "content": { "text/plain": { "schema": { "type": "string" } } } }
-        }
+          "200": {
+            "description": "Latest hash",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get latest block hash"
       }
     },
     "/q/bcperblock": {
       "get": {
         "summary": "Get BTC reward per block",
         "operationId": "getBtcPerBlock",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "BTC per block", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "BTC per block",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get BTC reward per block"
       }
     },
     "/q/totalbc": {
       "get": {
         "summary": "Get total bitcoins in circulation",
         "operationId": "getTotalBtc",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Total BTC in satoshi", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Total BTC in satoshi",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get total bitcoins in circulation"
       }
     },
     "/q/probability": {
       "get": {
         "summary": "Get mining probability",
         "operationId": "getProbability",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Probability", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Probability",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get mining probability"
       }
     },
     "/q/hashestowin": {
       "get": {
         "summary": "Get hashes to win",
         "operationId": "getHashesToWin",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Hashes to win", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Hashes to win",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get hashes to win"
       }
     },
     "/q/nextretarget": {
       "get": {
         "summary": "Get next difficulty retarget block",
         "operationId": "getNextRetarget",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Next retarget block", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Next retarget block",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get next difficulty retarget block"
       }
     },
     "/q/avgtxsize/{blocks}": {
       "get": {
         "summary": "Get average transaction size",
         "operationId": "getAvgTxSize",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
           {
             "name": "blocks",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer", "default": 1000 },
+            "schema": {
+              "type": "integer",
+              "default": 1000
+            },
             "description": "Number of blocks to average (default: 1000)"
           }
         ],
         "responses": {
-          "200": { "description": "Average tx size in bytes", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Average tx size in bytes",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get average transaction size"
       }
     },
     "/q/avgtxvalue": {
       "get": {
         "summary": "Get average transaction value",
         "operationId": "getAvgTxValue",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Average transaction value", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Average transaction value",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get average transaction value"
       }
     },
     "/q/interval": {
       "get": {
         "summary": "Get average time between blocks",
         "operationId": "getInterval",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Interval in seconds", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Interval in seconds",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get average time between blocks"
       }
     },
     "/q/eta": {
       "get": {
         "summary": "Get estimated time to next block",
         "operationId": "getEta",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "ETA in seconds", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "ETA in seconds",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get estimated time to next block"
       }
     },
     "/q/avgtxnumber": {
       "get": {
         "summary": "Get average number of transactions per block",
         "operationId": "getAvgTxNumber",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Average transaction number", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Average transaction number",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get average number of transactions per block"
       }
     },
     "/q/getreceivedbyaddress/{address}": {
       "get": {
         "summary": "Get total received by address",
         "operationId": "getReceivedByAddress",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Total received in satoshi", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Total received in satoshi",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get total received by address"
       }
     },
     "/q/getsentbyaddress/{address}": {
       "get": {
         "summary": "Get total sent by address",
         "operationId": "getSentByAddress",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Total sent in satoshi", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Total sent in satoshi",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get total sent by address"
       }
     },
     "/q/addressbalance/{address}": {
       "get": {
         "summary": "Get address balance",
         "operationId": "getAddressBalance",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Balance in satoshi", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Balance in satoshi",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get address balance"
       }
     },
     "/q/addressfirstseen/{address}": {
       "get": {
         "summary": "Get timestamp when address was first seen",
         "operationId": "getAddressFirstSeen",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Unix timestamp", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Unix timestamp",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get timestamp when address was first seen"
       }
     },
     "/q/addresstohash/{address}": {
       "get": {
         "summary": "Convert address to hash160",
         "operationId": "addressToHash",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "address", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "address",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Hash160", "content": { "text/plain": { "schema": { "type": "string" } } } }
-        }
+          "200": {
+            "description": "Hash160",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "description": "Convert address to hash160"
       }
     },
     "/q/hashtoaddress/{hash}": {
       "get": {
         "summary": "Convert hash160 to address",
         "operationId": "hashToAddress",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "parameters": [
-          { "name": "hash", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "hash",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Bitcoin address", "content": { "text/plain": { "schema": { "type": "string" } } } }
-        }
+          "200": {
+            "description": "Bitcoin address",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "description": "Convert hash160 to address"
       }
     },
     "/q/unconfirmedcount": {
       "get": {
         "summary": "Get unconfirmed transaction count",
         "operationId": "getUnconfirmedCount",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Count of unconfirmed transactions", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Count of unconfirmed transactions",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get unconfirmed transaction count"
       }
     },
     "/q/24hrprice": {
       "get": {
         "summary": "Get 24-hour weighted price",
         "operationId": "get24HrPrice",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "24h weighted price", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "24h weighted price",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get 24-hour weighted price"
       }
     },
     "/q/marketcap": {
       "get": {
         "summary": "Get market capitalization",
         "operationId": "getMarketCap",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Market cap in USD", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Market cap in USD",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get market capitalization"
       }
     },
     "/q/24hrtransactioncount": {
       "get": {
         "summary": "Get 24-hour transaction count",
         "operationId": "get24HrTransactionCount",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Transaction count", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "Transaction count",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get 24-hour transaction count"
       }
     },
     "/q/24hrbtcsent": {
       "get": {
         "summary": "Get 24-hour BTC sent",
         "operationId": "get24HrBtcSent",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "BTC sent in satoshi", "content": { "text/plain": { "schema": { "type": "integer" } } } }
-        }
+          "200": {
+            "description": "BTC sent in satoshi",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get 24-hour BTC sent"
       }
     },
     "/q/hashrate": {
       "get": {
         "summary": "Get current hash rate",
         "operationId": "getHashRate",
-        "tags": ["Query API"],
+        "tags": [
+          "Query API"
+        ],
         "responses": {
-          "200": { "description": "Hash rate in GH/s", "content": { "text/plain": { "schema": { "type": "number" } } } }
-        }
+          "200": {
+            "description": "Hash rate in GH/s",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "number"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get current hash rate"
       }
     }
   },
@@ -799,104 +1294,233 @@
       "Block": {
         "type": "object",
         "properties": {
-          "hash": { "type": "string" },
-          "ver": { "type": "integer" },
-          "prev_block": { "type": "string" },
-          "mrkl_root": { "type": "string" },
-          "time": { "type": "integer" },
-          "bits": { "type": "integer" },
-          "nonce": { "type": "integer" },
-          "n_tx": { "type": "integer" },
-          "size": { "type": "integer" },
-          "block_index": { "type": "integer" },
-          "main_chain": { "type": "boolean" },
-          "height": { "type": "integer" },
-          "received_time": { "type": "integer" },
-          "relayed_by": { "type": "string" },
+          "hash": {
+            "type": "string"
+          },
+          "ver": {
+            "type": "integer"
+          },
+          "prev_block": {
+            "type": "string"
+          },
+          "mrkl_root": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "bits": {
+            "type": "integer"
+          },
+          "nonce": {
+            "type": "integer"
+          },
+          "n_tx": {
+            "type": "integer"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "block_index": {
+            "type": "integer"
+          },
+          "main_chain": {
+            "type": "boolean"
+          },
+          "height": {
+            "type": "integer"
+          },
+          "received_time": {
+            "type": "integer"
+          },
+          "relayed_by": {
+            "type": "string"
+          },
           "tx": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Transaction" }
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            }
           }
         }
       },
       "Transaction": {
         "type": "object",
         "properties": {
-          "hash": { "type": "string" },
-          "ver": { "type": "integer" },
-          "vin_sz": { "type": "integer" },
-          "vout_sz": { "type": "integer" },
-          "lock_time": { "type": "integer" },
-          "size": { "type": "integer" },
-          "relayed_by": { "type": "string" },
-          "block_height": { "type": "integer" },
-          "tx_index": { "type": "integer" },
+          "hash": {
+            "type": "string"
+          },
+          "ver": {
+            "type": "integer"
+          },
+          "vin_sz": {
+            "type": "integer"
+          },
+          "vout_sz": {
+            "type": "integer"
+          },
+          "lock_time": {
+            "type": "integer"
+          },
+          "size": {
+            "type": "integer"
+          },
+          "relayed_by": {
+            "type": "string"
+          },
+          "block_height": {
+            "type": "integer"
+          },
+          "tx_index": {
+            "type": "integer"
+          },
           "inputs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Input" }
+            "items": {
+              "$ref": "#/components/schemas/Input"
+            }
           },
           "out": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Output" }
+            "items": {
+              "$ref": "#/components/schemas/Output"
+            }
           }
         }
       },
       "Input": {
         "type": "object",
         "properties": {
-          "prev_out": { "$ref": "#/components/schemas/Output" },
-          "script": { "type": "string" }
+          "prev_out": {
+            "$ref": "#/components/schemas/Output"
+          },
+          "script": {
+            "type": "string"
+          }
         }
       },
       "Output": {
         "type": "object",
         "properties": {
-          "value": { "type": "integer", "description": "Value in satoshi" },
-          "script": { "type": "string" },
-          "addr": { "type": "string" },
-          "n": { "type": "integer" },
-          "tx_index": { "type": "integer" },
-          "type": { "type": "integer" },
-          "spent": { "type": "boolean" }
+          "value": {
+            "type": "integer",
+            "description": "Value in satoshi"
+          },
+          "script": {
+            "type": "string"
+          },
+          "addr": {
+            "type": "string"
+          },
+          "n": {
+            "type": "integer"
+          },
+          "tx_index": {
+            "type": "integer"
+          },
+          "type": {
+            "type": "integer"
+          },
+          "spent": {
+            "type": "boolean"
+          }
         }
       },
       "Address": {
         "type": "object",
         "properties": {
-          "hash160": { "type": "string" },
-          "address": { "type": "string" },
-          "n_tx": { "type": "integer" },
-          "n_unredeemed": { "type": "integer" },
-          "total_received": { "type": "integer" },
-          "total_sent": { "type": "integer" },
-          "final_balance": { "type": "integer" },
+          "hash160": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "n_tx": {
+            "type": "integer"
+          },
+          "n_unredeemed": {
+            "type": "integer"
+          },
+          "total_received": {
+            "type": "integer"
+          },
+          "total_sent": {
+            "type": "integer"
+          },
+          "final_balance": {
+            "type": "integer"
+          },
           "txs": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Transaction" }
+            "items": {
+              "$ref": "#/components/schemas/Transaction"
+            }
           }
         }
       },
       "UnspentOutput": {
         "type": "object",
         "properties": {
-          "tx_age": { "type": "integer" },
-          "tx_hash": { "type": "string" },
-          "tx_index": { "type": "integer" },
-          "tx_output_n": { "type": "integer" },
-          "script": { "type": "string" },
-          "value": { "type": "integer", "description": "Value in satoshi" }
+          "tx_age": {
+            "type": "integer"
+          },
+          "tx_hash": {
+            "type": "string"
+          },
+          "tx_index": {
+            "type": "integer"
+          },
+          "tx_output_n": {
+            "type": "integer"
+          },
+          "script": {
+            "type": "string"
+          },
+          "value": {
+            "type": "integer",
+            "description": "Value in satoshi"
+          }
         }
       },
       "CurrencyTicker": {
         "type": "object",
         "properties": {
-          "15m": { "type": "number", "description": "15 minute delayed price" },
-          "last": { "type": "number", "description": "Most recent price" },
-          "buy": { "type": "number", "description": "Buy price" },
-          "sell": { "type": "number", "description": "Sell price" },
-          "symbol": { "type": "string", "description": "Currency symbol" }
+          "15m": {
+            "type": "number",
+            "description": "15 minute delayed price"
+          },
+          "last": {
+            "type": "number",
+            "description": "Most recent price"
+          },
+          "buy": {
+            "type": "number",
+            "description": "Buy price"
+          },
+          "sell": {
+            "type": "number",
+            "description": "Sell price"
+          },
+          "symbol": {
+            "type": "string",
+            "description": "Currency symbol"
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Blockchain Data"
+    },
+    {
+      "name": "Charts & Statistics"
+    },
+    {
+      "name": "Exchange Rates"
+    },
+    {
+      "name": "Query API"
+    }
+  ]
 }

--- a/apis/openapi/bloomgrowth.com/bloom-growth-api/1.0.0/openapi.json
+++ b/apis/openapi/bloomgrowth.com/bloom-growth-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bloom Growth API",
     "version": "1.0.0",
     "description": "Bloom Growth (formerly Traction Tools) API for managing L10 meetings, rocks, issues, todos, headlines, measurables, and scorecards.",
-    "x-jentic-source-url": "https://traction.tools/swagger/ui/index"
+    "x-jentic-source-url": "https://traction.tools/swagger/ui/index",
+    "contact": {}
   },
   "servers": [
     {
@@ -60,7 +61,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create L10 meeting"
       }
     },
     "/api/v1/L10/{MEETING_ID}": {
@@ -111,7 +113,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get meeting details"
       },
       "put": {
         "operationId": "updateMeeting",
@@ -175,7 +178,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update meeting"
       },
       "delete": {
         "operationId": "deleteMeeting",
@@ -217,7 +221,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete meeting"
       }
     },
     "/api/v1/L10/list": {
@@ -269,7 +274,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all meetings"
       }
     },
     "/api/v1/L10/{MEETING_ID}/todos": {
@@ -330,7 +336,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add todo to meeting"
       }
     },
     "/api/v1/l10/{MEETING_ID}/todos": {
@@ -392,7 +399,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List meeting todos"
       }
     },
     "/api/v1/L10/{MEETING_ID}/issues": {
@@ -453,7 +461,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add issue to meeting"
       }
     },
     "/api/v1/l10/{MEETING_ID}/issues": {
@@ -515,7 +524,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List meeting issues"
       }
     },
     "/api/v1/issues/create": {
@@ -566,7 +576,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create issue"
       }
     },
     "/api/v1/issues/{ISSUE_ID}": {
@@ -617,7 +628,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get issue"
       },
       "put": {
         "operationId": "updateIssue",
@@ -676,7 +688,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update issue"
       }
     },
     "/api/v1/issues/{ISSUE_ID}/complete": {
@@ -727,7 +740,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Complete issue"
       }
     },
     "/api/v1/rocks/create": {
@@ -778,7 +792,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create rock"
       }
     },
     "/api/v1/rocks/{ROCK_ID}": {
@@ -829,7 +844,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get rock"
       },
       "put": {
         "operationId": "updateRock",
@@ -888,7 +904,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update rock"
       },
       "delete": {
         "operationId": "deleteRock",
@@ -930,7 +947,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete rock"
       }
     },
     "/api/v1/rocks/user/mine": {
@@ -982,7 +1000,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get my rocks"
       }
     },
     "/api/v1/measurables/create": {
@@ -1033,7 +1052,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create measurable"
       }
     },
     "/api/v1/measurables/{MEASURABLE_ID}": {
@@ -1084,7 +1104,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get measurable"
       },
       "put": {
         "operationId": "updateMeasurable",
@@ -1143,7 +1164,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update measurable"
       }
     },
     "/api/v1/measurables/user/mine": {
@@ -1195,7 +1217,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get my measurables"
       }
     },
     "/api/v1/headline/{HEADLINE_ID}": {
@@ -1246,7 +1269,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get headline"
       },
       "put": {
         "operationId": "updateHeadline",
@@ -1310,7 +1334,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update headline"
       },
       "delete": {
         "operationId": "deleteHeadline",
@@ -1352,7 +1377,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete headline"
       }
     },
     "/api/v1/scorecard/user/mine": {
@@ -1393,7 +1419,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get my scorecard"
       }
     },
     "/api/v1/scorecard/meeting/{MEETING_ID}": {
@@ -1444,7 +1471,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get meeting scorecard"
       }
     },
     "/api/v1/search/all": {
@@ -1506,7 +1534,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Global search"
       }
     }
   },
@@ -1738,6 +1767,32 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Headlines"
+    },
+    {
+      "name": "Issues"
+    },
+    {
+      "name": "Measurables"
+    },
+    {
+      "name": "Meetings"
+    },
+    {
+      "name": "Rocks"
+    },
+    {
+      "name": "Scorecards"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Todos"
     }
   ]
 }

--- a/apis/openapi/blueink.com/blueink-api/2.0.0/openapi.json
+++ b/apis/openapi/blueink.com/blueink-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Blueink eSignature API",
     "version": "2.0.0",
     "description": "Blueink eSignature REST API. Send documents for signing, track signing progress, and manage signed documents.",
-    "x-jentic-source-url": "https://developer.blueink.com/docs/esignature-api/"
+    "x-jentic-source-url": "https://developer.blueink.com/docs/esignature-api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a bundle"
       },
       "get": {
         "operationId": "listBundles",
@@ -101,7 +103,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List bundles"
       }
     },
     "/bundles/{bundle_id}": {
@@ -145,7 +148,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get bundle"
       },
       "delete": {
         "operationId": "cancelBundle",
@@ -187,7 +191,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel bundle"
       }
     },
     "/packets/{packet_id}": {
@@ -231,7 +236,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get packet"
       }
     },
     "/packets/{packet_id}/remind": {
@@ -275,7 +281,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Send reminder"
       }
     },
     "/templates": {
@@ -309,7 +316,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List templates"
       }
     },
     "/templates/{template_id}": {
@@ -353,7 +361,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get template"
       }
     },
     "/webhooks": {
@@ -387,7 +396,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List webhooks"
       },
       "post": {
         "operationId": "createWebhook",
@@ -429,7 +439,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create webhook"
       }
     },
     "/webhooks/{webhook_id}": {
@@ -473,7 +484,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get webhook"
       },
       "delete": {
         "operationId": "deleteWebhook",
@@ -515,7 +527,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete webhook"
       }
     }
   },
@@ -547,6 +560,20 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Bundles"
+    },
+    {
+      "name": "Packets"
+    },
+    {
+      "name": "Templates"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/bluemix.net/ibm-containers-api/3.0.0/openapi.json
+++ b/apis/openapi/bluemix.net/ibm-containers-api/3.0.0/openapi.json
@@ -27,7 +27,8 @@
     ],
     "x-providerName": "bluemix.net",
     "x-serviceName": "containers",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bluemix.net/containers/3.0.0/openapi.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bluemix.net/containers/3.0.0/openapi.yaml",
+    "contact": {}
   },
   "paths": {
     "/build": {
@@ -118,7 +119,8 @@
         "summary": "Build a Docker image from a Dockerfile",
         "tags": [
           "Images"
-        ]
+        ],
+        "operationId": "post-build"
       }
     },
     "/containers/create": {
@@ -191,7 +193,8 @@
         "summary": "Create and start a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-create"
       }
     },
     "/containers/floating-ips": {
@@ -250,7 +253,8 @@
         "summary": "List available public IP addresses in a space",
         "tags": [
           "Public IP addresses"
-        ]
+        ],
+        "operationId": "get-containers-floating-ips"
       }
     },
     "/containers/floating-ips/request": {
@@ -304,7 +308,8 @@
         "summary": "Request a public IP address for a space",
         "tags": [
           "Public IP addresses"
-        ]
+        ],
+        "operationId": "post-containers-floating-ips-request"
       }
     },
     "/containers/floating-ips/{ip}/release": {
@@ -356,7 +361,8 @@
         "summary": "Release public IP address",
         "tags": [
           "Public IP addresses"
-        ]
+        ],
+        "operationId": "post-containers-floating-ips-by-ip-release"
       }
     },
     "/containers/groups": {
@@ -406,7 +412,8 @@
         "summary": "List all container groups in a space",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "get-containers-groups"
       },
       "post": {
         "description": "This endpoint creates and starts a new container group in your space. A container group consists of two or more single containers that are all created from the same container image and as a consequence are configured in the same way. Container groups offer different options at no cost to make your app highly available, such as in-built load balancing, auto-recovery of unhealthy container instances, and auto-scaling of container instances based on CPU and memory usage.\n\nTo create a container group with IBM Containers, you must at least define a container group name and the image that the container group is based on. Required attributes:\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n- Name: The container group name must start with a letter and then can include uppercase letters, lowercase letters, numbers, periods (.), underscores (_), or hyphens (-). \n- Image: You must include the full path to the image in your private Bluemix registry in the format:`registry.ng.bluemix.net/<namespace>/<image>`.",
@@ -468,7 +475,8 @@
         "summary": "Create and start a container group.",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "post-containers-groups"
       }
     },
     "/containers/groups/{name_or_id}": {
@@ -532,7 +540,8 @@
         "summary": "Stop and delete all container instances in a container group.",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "delete-containers-groups-by-name-or-id"
       },
       "get": {
         "description": "This endpoint retrieves detailed information about a container group with a given name (corresponding IBM Containers command: `cf ic group inspect GROUP`).",
@@ -589,7 +598,8 @@
         "summary": "Inspect a container group.",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "get-containers-groups-by-name-or-id"
       },
       "patch": {
         "description": "Update the number of container instances that run in a container group (corresponding IBM Containers command: `cf ic group update <option> <group>`). \n\nNote: You can run only one update at a time.  \n\n The desired number is the number of container instances that you require. It must be within the current limits of Max and Min. To increase the number of desired container instances above the Max value, you must first execute an update on the Max value. Once this update is completed, you can increase the desired number of container instances. ",
@@ -653,7 +663,8 @@
         "summary": "Update a container group.",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "patch-containers-groups-by-name-or-id"
       }
     },
     "/containers/groups/{name_or_id}/maproute": {
@@ -726,7 +737,8 @@
         "summary": "Map a public route to a container group.",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "post-containers-groups-by-name-or-id-maproute"
       }
     },
     "/containers/groups/{name_or_id}/unmaproute": {
@@ -799,7 +811,8 @@
         "summary": "Unmap a public route from a container group",
         "tags": [
           "Container Groups"
-        ]
+        ],
+        "operationId": "post-containers-groups-by-name-or-id-unmaproute"
       }
     },
     "/containers/json": {
@@ -867,7 +880,8 @@
         "summary": "List single containers in a space.",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "get-containers-json"
       }
     },
     "/containers/messages": {
@@ -921,7 +935,8 @@
         "summary": "List messages for the user",
         "tags": [
           "API info"
-        ]
+        ],
+        "operationId": "get-containers-messages"
       }
     },
     "/containers/quota": {
@@ -968,7 +983,8 @@
         "summary": "Retrieve organization and space specific quota",
         "tags": [
           "Quota"
-        ]
+        ],
+        "operationId": "get-containers-quota"
       },
       "put": {
         "description": "This endpoint updates the quota that is allocated to a Bluemix space. \n\n **Note**: Only paid accounts are eligbile to update the space quota. If you are using a free-trial account, upgrade to a paid account first.",
@@ -1020,7 +1036,8 @@
         "summary": "Update space quota",
         "tags": [
           "Quota"
-        ]
+        ],
+        "operationId": "put-containers-quota"
       }
     },
     "/containers/usage": {
@@ -1067,7 +1084,8 @@
         "summary": "List container sizes and quota limits",
         "tags": [
           "Quota"
-        ]
+        ],
+        "operationId": "get-containers-usage"
       }
     },
     "/containers/version": {
@@ -1091,7 +1109,8 @@
         "summary": "List latest API version",
         "tags": [
           "API info"
-        ]
+        ],
+        "operationId": "get-containers-version"
       }
     },
     "/containers/{id}/status": {
@@ -1150,7 +1169,8 @@
         "summary": "List the current state of a container.",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "get-containers-by-id-status"
       }
     },
     "/containers/{name_or_id}": {
@@ -1211,7 +1231,8 @@
         "summary": "Remove a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "delete-containers-by-name-or-id"
       }
     },
     "/containers/{name_or_id}/floating-ips/{ip}/bind": {
@@ -1278,7 +1299,8 @@
         "summary": "Bind a public IP address to a single container",
         "tags": [
           "Public IP addresses"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-floating-ips-by-ip-bind"
       }
     },
     "/containers/{name_or_id}/floating-ips/{ip}/unbind": {
@@ -1342,7 +1364,8 @@
         "summary": "Unbind a public IP address from a container",
         "tags": [
           "Public IP addresses"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-floating-ips-by-ip-unbind"
       }
     },
     "/containers/{name_or_id}/json": {
@@ -1401,7 +1424,8 @@
         "summary": "Inspect a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "get-containers-by-name-or-id-json"
       }
     },
     "/containers/{name_or_id}/pause": {
@@ -1453,7 +1477,8 @@
         "summary": "Pause a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-pause"
       }
     },
     "/containers/{name_or_id}/rename": {
@@ -1517,7 +1542,8 @@
         "summary": "Rename a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-rename"
       }
     },
     "/containers/{name_or_id}/restart": {
@@ -1581,7 +1607,8 @@
         "summary": "Restart a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-restart"
       }
     },
     "/containers/{name_or_id}/start": {
@@ -1636,7 +1663,8 @@
         "summary": "Start a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-start"
       }
     },
     "/containers/{name_or_id}/stop": {
@@ -1700,7 +1728,8 @@
         "summary": "Stop a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-stop"
       }
     },
     "/containers/{name_or_id}/unpause": {
@@ -1752,7 +1781,8 @@
         "summary": "Unpause a single container",
         "tags": [
           "Single containers"
-        ]
+        ],
+        "operationId": "post-containers-by-name-or-id-unpause"
       }
     },
     "/images/json": {
@@ -1799,7 +1829,8 @@
         "summary": "List all Docker images that are available in your private Bluemix registry.",
         "tags": [
           "Images"
-        ]
+        ],
+        "operationId": "get-images-json"
       }
     },
     "/images/{id}": {
@@ -1851,7 +1882,8 @@
         "summary": "Remove a Docker image.",
         "tags": [
           "Images"
-        ]
+        ],
+        "operationId": "delete-images-by-id"
       }
     },
     "/images/{name_or_id}/json": {
@@ -1910,7 +1942,8 @@
         "summary": "Inspect a Docker image in private Bluemix registry",
         "tags": [
           "Images"
-        ]
+        ],
+        "operationId": "get-images-by-name-or-id-json"
       }
     },
     "/registry/namespaces": {
@@ -1960,7 +1993,8 @@
         "summary": "Retrieve the namespace of an organization.",
         "tags": [
           "Private Docker images registry"
-        ]
+        ],
+        "operationId": "get-registry-namespaces"
       }
     },
     "/registry/namespaces/{namespace}": {
@@ -2019,7 +2053,8 @@
         "summary": "Check the availability of a namespace",
         "tags": [
           "Private Docker images registry"
-        ]
+        ],
+        "operationId": "get-registry-namespaces-by-namespace"
       },
       "put": {
         "description": "Set up your own Docker images registry in Bluemix by defining a namespace for your organization (corresponding IBM Containers command: `cf ic namespace set <namespace>`). The namespace is used to generate a unique URL to your private Bluemix registry. In your private registry you store all Docker images that you want to share across your organization. To create a container from an image, you must first push the image to your registry. \n\n The namespace cannot be changed after is has been set. Consider the following rules to choose a namespace for your organization: \n\n- Every organization can have one namespace at a time only \n- The namespace must be unique in Bluemix. \n- The namespace can be 4-30 characters long. \n- The namespace must start with at least one letter or number. \n- The namespace can only contain lowercase letters, numbers or underscores (_).",
@@ -2079,7 +2114,8 @@
         "summary": "Set a namespace for your private Bluemix registry.",
         "tags": [
           "Private Docker images registry"
-        ]
+        ],
+        "operationId": "put-registry-namespaces-by-namespace"
       }
     },
     "/tlskey": {
@@ -2126,7 +2162,8 @@
         "summary": "Retrieve the TLS Certificate",
         "tags": [
           "Authentication"
-        ]
+        ],
+        "operationId": "get-tlskey"
       }
     },
     "/tlskey/refresh": {
@@ -2173,7 +2210,8 @@
         "summary": "Refresh the TLS Certificate",
         "tags": [
           "Authentication"
-        ]
+        ],
+        "operationId": "put-tlskey-refresh"
       }
     },
     "/volumes/create": {
@@ -2244,7 +2282,8 @@
         "summary": "Create a volume in a space",
         "tags": [
           "Volumes"
-        ]
+        ],
+        "operationId": "post-volumes-create"
       }
     },
     "/volumes/fs/create": {
@@ -2301,7 +2340,8 @@
         "summary": "Create a file share in a space",
         "tags": [
           "File shares"
-        ]
+        ],
+        "operationId": "post-volumes-fs-create"
       }
     },
     "/volumes/fs/flavors/json": {
@@ -2351,7 +2391,8 @@
         "summary": "List available file share sizes",
         "tags": [
           "File shares"
-        ]
+        ],
+        "operationId": "get-volumes-fs-flavors-json"
       }
     },
     "/volumes/fs/json": {
@@ -2401,7 +2442,8 @@
         "summary": "List available file shares in a space",
         "tags": [
           "File shares"
-        ]
+        ],
+        "operationId": "get-volumes-fs-json"
       }
     },
     "/volumes/fs/{name}": {
@@ -2456,7 +2498,8 @@
         "summary": "Delete a file share",
         "tags": [
           "File shares"
-        ]
+        ],
+        "operationId": "delete-volumes-fs-by-name"
       }
     },
     "/volumes/fs/{name}/json": {
@@ -2518,7 +2561,8 @@
         "summary": "Inspect a file share",
         "tags": [
           "File shares"
-        ]
+        ],
+        "operationId": "get-volumes-fs-by-name-json"
       }
     },
     "/volumes/json": {
@@ -2568,7 +2612,8 @@
         "summary": "List all volumes for a space",
         "tags": [
           "Volumes"
-        ]
+        ],
+        "operationId": "get-volumes-json"
       }
     },
     "/volumes/{name}": {
@@ -2620,7 +2665,8 @@
         "summary": "Delete a volume",
         "tags": [
           "Volumes"
-        ]
+        ],
+        "operationId": "delete-volumes-by-name"
       },
       "post": {
         "description": "This endpoint provisions an existing volume that was created in one space to another space within the same organization. Single containers and container groups in each space can read and write to the shared volume. The volume remains owned by the original space it was created in, including management and billing. For example, the volume can be deleted from the original space only.",
@@ -2691,7 +2737,8 @@
         "summary": "Share a volume with another space",
         "tags": [
           "Volumes"
-        ]
+        ],
+        "operationId": "post-volumes-by-name"
       }
     },
     "/volumes/{name}/json": {
@@ -2750,7 +2797,8 @@
         "summary": "Retrieve detailed information about a volume. ",
         "tags": [
           "Volumes"
-        ]
+        ],
+        "operationId": "get-volumes-by-name-json"
       }
     }
   },
@@ -4363,5 +4411,37 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "API info"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Container Groups"
+    },
+    {
+      "name": "File shares"
+    },
+    {
+      "name": "Images"
+    },
+    {
+      "name": "Private Docker images registry"
+    },
+    {
+      "name": "Public IP addresses"
+    },
+    {
+      "name": "Quota"
+    },
+    {
+      "name": "Single containers"
+    },
+    {
+      "name": "Volumes"
+    }
+  ]
 }

--- a/apis/openapi/bluesnap.com/bluesnap-payment-api/8976.0.0/openapi.json
+++ b/apis/openapi/bluesnap.com/bluesnap-payment-api/8976.0.0/openapi.json
@@ -4,183 +4,1212 @@
     "title": "BlueSnap Payment API",
     "version": "8976.0.0",
     "description": "BlueSnap Payment API for processing card transactions, managing subscriptions, vaulted shoppers, vendors, and refunds.",
-    "x-jentic-source-url": "https://developers.bluesnap.com/v8976-JSON/reference/bluesnap-payment-api-json"
+    "x-jentic-source-url": "https://developers.bluesnap.com/v8976-JSON/reference/bluesnap-payment-api-json",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://ws.bluesnap.com", "description": "Production" },
-    { "url": "https://sandbox.bluesnap.com", "description": "Sandbox" }
+    {
+      "url": "https://ws.bluesnap.com",
+      "description": "Production"
+    },
+    {
+      "url": "https://sandbox.bluesnap.com",
+      "description": "Sandbox"
+    }
   ],
   "paths": {
     "/services/2/transactions": {
       "post": {
-        "operationId": "createTransaction", "summary": "Auth Capture or Auth Only", "description": "Process a card transaction (Auth Capture or Auth Only).", "tags": ["Transactions"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TransactionInput" } } } },
-        "responses": { "200": { "description": "Transaction processed", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Transaction" } } } }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createTransaction",
+        "summary": "Auth Capture or Auth Only",
+        "description": "Process a card transaction (Auth Capture or Auth Only).",
+        "tags": [
+          "Transactions"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transaction processed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ]
       }
     },
     "/services/2/transactions/{transactionId}": {
       "put": {
-        "operationId": "captureOrReverseTransaction", "summary": "Capture or reverse a transaction", "tags": ["Transactions"],
-        "parameters": [{ "name": "transactionId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/TransactionUpdate" } } } },
-        "responses": { "200": { "description": "Transaction updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "captureOrReverseTransaction",
+        "summary": "Capture or reverse a transaction",
+        "tags": [
+          "Transactions"
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TransactionUpdate"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Transaction updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Capture or reverse a transaction"
       },
       "get": {
-        "operationId": "getTransaction", "summary": "Retrieve a transaction", "tags": ["Transactions"],
-        "parameters": [{ "name": "transactionId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "Transaction details", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Transaction" } } } }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "getTransaction",
+        "summary": "Retrieve a transaction",
+        "tags": [
+          "Transactions"
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Transaction details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Transaction"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve a transaction"
       }
     },
     "/services/2/transactions/ecp": {
       "post": {
-        "operationId": "createEcpTransaction", "summary": "Create ECP transaction", "tags": ["Alternate Payments"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "ECP transaction created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createEcpTransaction",
+        "summary": "Create ECP transaction",
+        "tags": [
+          "Alternate Payments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "ECP transaction created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create ECP transaction"
       }
     },
     "/services/2/transactions/ecp/{transactionId}": {
       "get": {
-        "operationId": "getEcpTransaction", "summary": "Retrieve ECP transaction", "tags": ["Alternate Payments"],
-        "parameters": [{ "name": "transactionId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "ECP transaction details" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "getEcpTransaction",
+        "summary": "Retrieve ECP transaction",
+        "tags": [
+          "Alternate Payments"
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "ECP transaction details"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve ECP transaction"
       }
     },
     "/services/2/transactions/paypal": {
       "post": {
-        "operationId": "createPaypalTransaction", "summary": "Create PayPal transaction", "tags": ["Alternate Payments"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "PayPal transaction created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createPaypalTransaction",
+        "summary": "Create PayPal transaction",
+        "tags": [
+          "Alternate Payments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "PayPal transaction created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create PayPal transaction"
       }
     },
     "/services/2/recurring/plans": {
       "post": {
-        "operationId": "createPlan", "summary": "Create subscription plan", "tags": ["Subscriptions"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PlanInput" } } } },
-        "responses": { "200": { "description": "Plan created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createPlan",
+        "summary": "Create subscription plan",
+        "tags": [
+          "Subscriptions"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Plan created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create subscription plan"
       },
       "get": {
-        "operationId": "listPlans", "summary": "Retrieve all plans", "tags": ["Subscriptions"],
-        "responses": { "200": { "description": "Plans listed" }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "listPlans",
+        "summary": "Retrieve all plans",
+        "tags": [
+          "Subscriptions"
+        ],
+        "responses": {
+          "200": {
+            "description": "Plans listed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve all plans"
       }
     },
     "/services/2/recurring/plans/{planId}": {
       "put": {
-        "operationId": "updatePlan", "summary": "Update plan", "tags": ["Subscriptions"],
-        "parameters": [{ "name": "planId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PlanInput" } } } },
-        "responses": { "200": { "description": "Plan updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "updatePlan",
+        "summary": "Update plan",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "planId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanInput"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Plan updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Update plan"
       },
       "get": {
-        "operationId": "getPlan", "summary": "Retrieve a plan", "tags": ["Subscriptions"],
-        "parameters": [{ "name": "planId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "Plan details" }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "getPlan",
+        "summary": "Retrieve a plan",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "planId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Plan details"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve a plan"
       }
     },
     "/services/2/recurring/subscriptions": {
       "post": {
-        "operationId": "createSubscription", "summary": "Create subscription", "tags": ["Subscriptions"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Subscription created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createSubscription",
+        "summary": "Create subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Subscription created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create subscription"
       }
     },
     "/services/2/recurring/subscriptions/{subscriptionId}": {
       "put": {
-        "operationId": "updateSubscription", "summary": "Update subscription", "tags": ["Subscriptions"],
-        "parameters": [{ "name": "subscriptionId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Subscription updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "updateSubscription",
+        "summary": "Update subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "subscriptionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Subscription updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Update subscription"
       }
     },
     "/services/2/vaulted-shoppers": {
       "post": {
-        "operationId": "createVaultedShopper", "summary": "Create vaulted shopper", "tags": ["Vaulted Shoppers"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Vaulted shopper created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createVaultedShopper",
+        "summary": "Create vaulted shopper",
+        "tags": [
+          "Vaulted Shoppers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Vaulted shopper created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create vaulted shopper"
       }
     },
     "/services/2/vaulted-shoppers/{vaultedShopperId}": {
       "get": {
-        "operationId": "getVaultedShopper", "summary": "Retrieve vaulted shopper", "tags": ["Vaulted Shoppers"],
-        "parameters": [{ "name": "vaultedShopperId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "Vaulted shopper details" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "getVaultedShopper",
+        "summary": "Retrieve vaulted shopper",
+        "tags": [
+          "Vaulted Shoppers"
+        ],
+        "parameters": [
+          {
+            "name": "vaultedShopperId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vaulted shopper details"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve vaulted shopper"
       },
       "put": {
-        "operationId": "updateVaultedShopper", "summary": "Update vaulted shopper", "tags": ["Vaulted Shoppers"],
-        "parameters": [{ "name": "vaultedShopperId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Vaulted shopper updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "updateVaultedShopper",
+        "summary": "Update vaulted shopper",
+        "tags": [
+          "Vaulted Shoppers"
+        ],
+        "parameters": [
+          {
+            "name": "vaultedShopperId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Vaulted shopper updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Update vaulted shopper"
       },
       "delete": {
-        "operationId": "deleteVaultedShopper", "summary": "Delete vaulted shopper", "tags": ["Vaulted Shoppers"],
-        "parameters": [{ "name": "vaultedShopperId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "Vaulted shopper deleted" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "deleteVaultedShopper",
+        "summary": "Delete vaulted shopper",
+        "tags": [
+          "Vaulted Shoppers"
+        ],
+        "parameters": [
+          {
+            "name": "vaultedShopperId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vaulted shopper deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Delete vaulted shopper"
       }
     },
     "/services/2/transactions/{transactionId}/refund": {
       "post": {
-        "operationId": "createRefund", "summary": "Refund a transaction", "tags": ["Refunds"],
-        "parameters": [{ "name": "transactionId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "amount": { "type": "number" }, "reason": { "type": "string" } } } } } },
-        "responses": { "200": { "description": "Refund processed" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createRefund",
+        "summary": "Refund a transaction",
+        "tags": [
+          "Refunds"
+        ],
+        "parameters": [
+          {
+            "name": "transactionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "number"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Refund processed"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Refund a transaction"
       }
     },
     "/services/2/vendors": {
       "post": {
-        "operationId": "createVendor", "summary": "Create vendor", "tags": ["Marketplace"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Vendor created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "createVendor",
+        "summary": "Create vendor",
+        "tags": [
+          "Marketplace"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Vendor created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Create vendor"
       },
       "get": {
-        "operationId": "listVendors", "summary": "List all vendors", "tags": ["Marketplace"],
-        "responses": { "200": { "description": "Vendors listed" }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "listVendors",
+        "summary": "List all vendors",
+        "tags": [
+          "Marketplace"
+        ],
+        "responses": {
+          "200": {
+            "description": "Vendors listed"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "List all vendors"
       }
     },
     "/services/2/vendors/{vendorId}": {
       "get": {
-        "operationId": "getVendor", "summary": "Retrieve vendor", "tags": ["Marketplace"],
-        "parameters": [{ "name": "vendorId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "responses": { "200": { "description": "Vendor details" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "getVendor",
+        "summary": "Retrieve vendor",
+        "tags": [
+          "Marketplace"
+        ],
+        "parameters": [
+          {
+            "name": "vendorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Vendor details"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Retrieve vendor"
       },
       "put": {
-        "operationId": "updateVendor", "summary": "Update vendor", "tags": ["Marketplace"],
-        "parameters": [{ "name": "vendorId", "in": "path", "required": true, "schema": { "type": "string" } }],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
-        "responses": { "200": { "description": "Vendor updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } },
-        "security": [{ "basicAuth": [] }]
+        "operationId": "updateVendor",
+        "summary": "Update vendor",
+        "tags": [
+          "Marketplace"
+        ],
+        "parameters": [
+          {
+            "name": "vendorId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Vendor updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "basicAuth": []
+          }
+        ],
+        "description": "Update vendor"
       }
     }
   },
   "components": {
     "schemas": {
-      "Transaction": { "type": "object", "properties": { "transactionId": { "type": "string" }, "amount": { "type": "number" }, "currency": { "type": "string" }, "status": { "type": "string" } } },
-      "TransactionInput": { "type": "object", "properties": { "amount": { "type": "number" }, "currency": { "type": "string" }, "cardTransactionType": { "type": "string", "enum": ["AUTH_CAPTURE", "AUTH_ONLY"] } } },
-      "TransactionUpdate": { "type": "object", "properties": { "cardTransactionType": { "type": "string", "enum": ["CAPTURE", "AUTH_REVERSAL"] }, "amount": { "type": "number" } } },
-      "PlanInput": { "type": "object", "properties": { "name": { "type": "string" }, "chargeFrequency": { "type": "string" }, "recurringChargeAmount": { "type": "number" }, "currency": { "type": "string" } } },
-      "ErrorResponse": { "type": "object", "properties": { "message": { "type": "array", "items": { "type": "object", "properties": { "errorName": { "type": "string" }, "code": { "type": "string" }, "description": { "type": "string" } } } } } }
+      "Transaction": {
+        "type": "object",
+        "properties": {
+          "transactionId": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "TransactionInput": {
+        "type": "object",
+        "properties": {
+          "amount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "cardTransactionType": {
+            "type": "string",
+            "enum": [
+              "AUTH_CAPTURE",
+              "AUTH_ONLY"
+            ]
+          }
+        }
+      },
+      "TransactionUpdate": {
+        "type": "object",
+        "properties": {
+          "cardTransactionType": {
+            "type": "string",
+            "enum": [
+              "CAPTURE",
+              "AUTH_REVERSAL"
+            ]
+          },
+          "amount": {
+            "type": "number"
+          }
+        }
+      },
+      "PlanInput": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "chargeFrequency": {
+            "type": "string"
+          },
+          "recurringChargeAmount": {
+            "type": "number"
+          },
+          "currency": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "errorName": {
+                  "type": "string"
+                },
+                "code": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "basicAuth": { "type": "http", "scheme": "basic", "description": "Basic authentication with API credentials" }
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic",
+        "description": "Basic authentication with API credentials"
+      }
     }
   },
-  "security": [{ "basicAuth": [] }]
+  "security": [
+    {
+      "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Alternate Payments"
+    },
+    {
+      "name": "Marketplace"
+    },
+    {
+      "name": "Refunds"
+    },
+    {
+      "name": "Subscriptions"
+    },
+    {
+      "name": "Transactions"
+    },
+    {
+      "name": "Vaulted Shoppers"
+    }
+  ]
 }

--- a/apis/openapi/boast.io/boast-api/1.0.0/openapi.json
+++ b/apis/openapi/boast.io/boast-api/1.0.0/openapi.json
@@ -4,165 +4,679 @@
     "title": "Boast API",
     "version": "1.0.0",
     "description": "Boast API for managing accounts, contacts, forms, responses, sequences, and webhook subscriptions. Uses OAuth 2.0 authorization.",
-    "x-jentic-source-url": "https://boast-io.github.io/api-docs"
+    "x-jentic-source-url": "https://boast-io.github.io/api-docs",
+    "contact": {}
   },
-  "servers": [{"url": "http://api.boast.io/v1"}],
+  "servers": [
+    {
+      "url": "http://api.boast.io/v1"
+    }
+  ],
   "paths": {
     "/accounts": {
       "get": {
         "operationId": "listAccounts",
         "summary": "List all accounts",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "responses": {
-          "200": {"description": "Account list", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Account"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Account list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Account"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List all accounts"
       }
     },
     "/accounts/{id}": {
       "get": {
         "operationId": "getAccount",
         "summary": "Get a specific account",
-        "tags": ["Accounts"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "tags": [
+          "Accounts"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Account details", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Account"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Account details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Account"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get a specific account"
       }
     },
     "/accounts/{account_id}/contacts": {
       "get": {
         "operationId": "listContacts",
         "summary": "List all contacts",
-        "tags": ["Contacts"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Contact list"},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Contact list"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List all contacts"
       },
       "post": {
         "operationId": "createContact",
         "summary": "Create a contact",
-        "tags": ["Contacts"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ContactInput"}}}},
+        "tags": [
+          "Contacts"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ContactInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created"},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create a contact"
       }
     },
     "/accounts/{account_id}/forms": {
       "get": {
         "operationId": "listForms",
         "summary": "List all forms",
-        "tags": ["Forms"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "responses": {"200": {"description": "Form list"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Forms"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Form list"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "List all forms"
       }
     },
     "/accounts/{account_id}/responses": {
       "get": {
         "operationId": "listResponses",
         "summary": "List all responses",
-        "tags": ["Responses"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "responses": {"200": {"description": "Response list"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Responses"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Response list"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "List all responses"
       }
     },
     "/accounts/{account_id}/sequences": {
       "get": {
         "operationId": "listSequences",
         "summary": "List all sequences",
-        "tags": ["Sequences"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "responses": {"200": {"description": "Sequence list"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Sequences"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Sequence list"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "List all sequences"
       }
     },
     "/accounts/{account_id}/sequence_enrollments": {
       "get": {
         "operationId": "listSequenceEnrollments",
         "summary": "List all sequence enrollments",
-        "tags": ["Sequences"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "responses": {"200": {"description": "Enrollment list"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Sequences"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Enrollment list"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "List all sequence enrollments"
       },
       "post": {
         "operationId": "enrollContactInSequence",
         "summary": "Enroll contact in sequence",
-        "tags": ["Sequences"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["contact_id", "sequence_id"], "properties": {"contact_id": {"type": "string"}, "sequence_id": {"type": "string"}}}}}},
-        "responses": {"201": {"description": "Enrolled"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Sequences"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "contact_id",
+                  "sequence_id"
+                ],
+                "properties": {
+                  "contact_id": {
+                    "type": "string"
+                  },
+                  "sequence_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Enrolled"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Enroll contact in sequence"
       }
     },
     "/accounts/{account_id}/sequence_enrollments/{enrollment_id}": {
       "get": {
         "operationId": "getSequenceEnrollment",
         "summary": "Get a specific enrollment",
-        "tags": ["Sequences"],
-        "parameters": [
-          {"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}},
-          {"name": "enrollment_id", "in": "path", "required": true, "schema": {"type": "string"}}
+        "tags": [
+          "Sequences"
         ],
-        "responses": {"200": {"description": "Enrollment details"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "enrollment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Enrollment details"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Get a specific enrollment"
       },
       "delete": {
         "operationId": "removeSequenceEnrollment",
         "summary": "Remove sequence enrollment",
-        "tags": ["Sequences"],
-        "parameters": [
-          {"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}},
-          {"name": "enrollment_id", "in": "path", "required": true, "schema": {"type": "string"}}
+        "tags": [
+          "Sequences"
         ],
-        "responses": {"204": {"description": "Deleted"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "enrollment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Remove sequence enrollment"
       }
     },
     "/accounts/{account_id}/webhook_subscriptions": {
       "get": {
         "operationId": "listWebhookSubscriptions",
         "summary": "List webhook subscriptions",
-        "tags": ["Webhooks"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "responses": {"200": {"description": "Subscription list"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Subscription list"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "List webhook subscriptions"
       },
       "post": {
         "operationId": "createWebhookSubscription",
         "summary": "Create webhook subscription",
-        "tags": ["Webhooks"],
-        "parameters": [{"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "required": ["event_name", "target_url"], "properties": {"event_name": {"type": "string"}, "target_url": {"type": "string"}, "filters": {"type": "object"}}}}}},
-        "responses": {"201": {"description": "Created"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "event_name",
+                  "target_url"
+                ],
+                "properties": {
+                  "event_name": {
+                    "type": "string"
+                  },
+                  "target_url": {
+                    "type": "string"
+                  },
+                  "filters": {
+                    "type": "object"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Create webhook subscription"
       }
     },
     "/accounts/{account_id}/webhook_subscriptions/{webhook_subscription_id}": {
       "delete": {
         "operationId": "deleteWebhookSubscription",
         "summary": "Delete webhook subscription",
-        "tags": ["Webhooks"],
-        "parameters": [
-          {"name": "account_id", "in": "path", "required": true, "schema": {"type": "string"}},
-          {"name": "webhook_subscription_id", "in": "path", "required": true, "schema": {"type": "string"}}
+        "tags": [
+          "Webhooks"
         ],
-        "responses": {"204": {"description": "Deleted"}, "400": {"description": "Bad request"}, "401": {"description": "Unauthorized"}}
+        "parameters": [
+          {
+            "name": "account_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "webhook_subscription_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "description": "Delete webhook subscription"
       }
     }
   },
   "components": {
     "schemas": {
-      "Account": {"type": "object", "properties": {"id": {"type": "string"}, "name": {"type": "string"}}},
-      "ContactInput": {"type": "object", "properties": {"email": {"type": "string"}, "mobile_phone": {"type": "string"}, "first_name": {"type": "string"}, "last_name": {"type": "string"}, "organization": {"type": "string"}, "job_title": {"type": "string"}, "time_zone": {"type": "string"}, "country_code": {"type": "string"}, "source": {"type": "string"}}},
-      "ErrorResponse": {"type": "object", "properties": {"error": {"type": "string"}, "message": {"type": "string"}}}
+      "Account": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "ContactInput": {
+        "type": "object",
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "mobile_phone": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "organization": {
+            "type": "string"
+          },
+          "job_title": {
+            "type": "string"
+          },
+          "time_zone": {
+            "type": "string"
+          },
+          "country_code": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "oauth2": {"type": "oauth2", "flows": {"authorizationCode": {"authorizationUrl": "https://app.boast.io/oauth/authorize", "tokenUrl": "https://app.boast.io/oauth/token", "scopes": {}}}}
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://app.boast.io/oauth/authorize",
+            "tokenUrl": "https://app.boast.io/oauth/token",
+            "scopes": {}
+          }
+        }
+      }
     }
   },
-  "security": [{"oauth2": []}]
+  "security": [
+    {
+      "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Forms"
+    },
+    {
+      "name": "Responses"
+    },
+    {
+      "name": "Sequences"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }

--- a/apis/openapi/bokio.se/bokio-api/1.0.0/openapi.json
+++ b/apis/openapi/bokio.se/bokio-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bokio API",
     "version": "1.0.0",
     "description": "Bokio is an accounting platform. The API provides management of journal entries, uploads, customers, invoices, items, chart of accounts, and connections.",
-    "x-jentic-source-url": "https://docs.bokio.se"
+    "x-jentic-source-url": "https://docs.bokio.se",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Obtain access token"
       }
     },
     "/authorization/authorize": {
@@ -144,7 +146,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Authorize the client"
       }
     },
     "/company-information": {
@@ -185,7 +188,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get company information"
       }
     },
     "/customers": {
@@ -236,7 +240,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a customer"
       },
       "get": {
         "operationId": "listCustomers",
@@ -278,7 +283,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get customers"
       }
     },
     "/customers/{customerId}": {
@@ -329,7 +335,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a customer"
       },
       "put": {
         "operationId": "updateCustomer",
@@ -381,7 +388,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a customer"
       },
       "delete": {
         "operationId": "deleteCustomer",
@@ -423,7 +431,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a customer"
       }
     },
     "/invoices": {
@@ -474,7 +483,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an invoice"
       },
       "get": {
         "operationId": "listInvoices",
@@ -516,7 +526,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get invoices"
       }
     },
     "/invoices/{invoiceId}": {
@@ -567,7 +578,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an invoice"
       },
       "put": {
         "operationId": "updateInvoice",
@@ -619,7 +631,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an invoice"
       }
     },
     "/invoices/{invoiceId}/publish": {
@@ -663,7 +676,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Publish an invoice"
       }
     },
     "/invoices/{invoiceId}/line-items": {
@@ -717,7 +731,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add line item to invoice"
       }
     },
     "/invoices/{invoiceId}/payments": {
@@ -771,7 +786,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create invoice payment"
       },
       "get": {
         "operationId": "listInvoicePayments",
@@ -813,7 +829,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List invoice payments"
       }
     },
     "/invoices/{invoiceId}/settlements": {
@@ -867,7 +884,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create invoice settlement"
       }
     },
     "/journal-entries": {
@@ -911,7 +929,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a journal entry"
       },
       "get": {
         "operationId": "listJournalEntries",
@@ -943,7 +962,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get journal entries"
       }
     },
     "/journal-entries/{journalId}": {
@@ -987,7 +1007,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a journal entry"
       }
     },
     "/journal-entries/{journalId}/reverse": {
@@ -1031,7 +1052,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Reverse a journal entry"
       }
     },
     "/uploads": {
@@ -1081,7 +1103,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add an upload"
       },
       "get": {
         "operationId": "listUploads",
@@ -1113,7 +1136,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get uploads"
       }
     },
     "/uploads/{uploadId}": {
@@ -1157,7 +1181,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an upload"
       }
     },
     "/uploads/{uploadId}/download": {
@@ -1201,7 +1226,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download upload file"
       }
     },
     "/items": {
@@ -1245,7 +1271,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an item"
       },
       "get": {
         "operationId": "listItems",
@@ -1277,7 +1304,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get items"
       }
     },
     "/items/{itemId}": {
@@ -1321,7 +1349,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an item"
       },
       "put": {
         "operationId": "updateItem",
@@ -1373,7 +1402,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an item"
       },
       "delete": {
         "operationId": "deleteItem",
@@ -1415,7 +1445,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete an item"
       }
     },
     "/chart-of-accounts": {
@@ -1449,7 +1480,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get chart of accounts"
       }
     },
     "/connections": {
@@ -1483,7 +1515,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get connections"
       }
     },
     "/connections/{connectionId}": {
@@ -1527,7 +1560,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get connection"
       },
       "delete": {
         "operationId": "deleteConnection",
@@ -1569,7 +1603,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete connection"
       }
     }
   },
@@ -1769,6 +1804,35 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Authorization"
+    },
+    {
+      "name": "Company"
+    },
+    {
+      "name": "Connections"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "Invoices"
+    },
+    {
+      "name": "Items"
+    },
+    {
+      "name": "Journal Entries"
+    },
+    {
+      "name": "Uploads"
     }
   ]
 }

--- a/apis/openapi/bokun.io/bokun-api/1.0.0/openapi.json
+++ b/apis/openapi/bokun.io/bokun-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bokun API",
     "version": "1.0.0",
     "description": "Bokun travel and tourism platform API for managing experiences, bookings, availability, and products.",
-    "x-jentic-source-url": "https://bokun.dev/"
+    "x-jentic-source-url": "https://bokun.dev/",
+    "contact": {}
   },
   "servers": [
     {
@@ -79,7 +80,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search activities"
       }
     },
     "/activity.json/{activityId}": {
@@ -130,7 +132,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get activity details"
       }
     },
     "/activity.json/{activityId}/availabilities": {
@@ -208,7 +211,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get activity availability"
       }
     },
     "/booking.json": {
@@ -259,7 +263,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create booking"
       },
       "get": {
         "operationId": "listBookings",
@@ -309,7 +314,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List bookings"
       }
     },
     "/booking.json/{bookingId}": {
@@ -360,7 +366,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get booking"
       }
     },
     "/booking.json/{bookingId}/confirm": {
@@ -411,7 +418,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Confirm booking"
       }
     },
     "/booking.json/{bookingId}/cancel": {
@@ -462,7 +470,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel booking"
       }
     },
     "/vendor.json": {
@@ -503,7 +512,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get vendor info"
       }
     }
   },
@@ -615,6 +625,17 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Activities"
+    },
+    {
+      "name": "Bookings"
+    },
+    {
+      "name": "Vendor"
     }
   ]
 }

--- a/apis/openapi/bolna.ai/bolna-api/1.0.0/openapi.json
+++ b/apis/openapi/bolna.ai/bolna-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bolna API",
     "version": "1.0.0",
     "description": "Bolna Voice AI platform API. Create and manage voice AI agents, batch calls, phone numbers, knowledge bases, SIP trunks, and sub-accounts.",
-    "x-jentic-source-url": "https://bolna.ai/apis"
+    "x-jentic-source-url": "https://bolna.ai/apis",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create agent"
       }
     },
     "/agent/v2/get": {
@@ -87,7 +89,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get agent"
       }
     },
     "/agent/v2/get_all": {
@@ -121,7 +124,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List agents"
       }
     },
     "/agent/v2/patch_update": {
@@ -165,7 +169,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Patch update agent"
       }
     },
     "/agent/v2/update": {
@@ -209,7 +214,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update agent"
       }
     },
     "/agent/v2/delete": {
@@ -243,7 +249,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete agent"
       }
     },
     "/agent/v2/get_agent_execution": {
@@ -277,7 +284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get agent execution"
       }
     },
     "/agent/v2/get_all_agent_executions": {
@@ -311,7 +319,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List agent executions"
       }
     },
     "/agent/v2/stop": {
@@ -355,7 +364,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Stop queued calls"
       }
     },
     "/batches/create": {
@@ -399,7 +409,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create batch"
       }
     },
     "/batches/get_batch": {
@@ -433,7 +444,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get batch"
       }
     },
     "/batches/get_batches": {
@@ -467,7 +479,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List batches"
       }
     },
     "/batches/delete": {
@@ -501,7 +514,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete batch"
       }
     },
     "/batches/schedule": {
@@ -545,7 +559,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Schedule batch"
       }
     },
     "/batches/stop": {
@@ -589,7 +604,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Stop batch"
       }
     },
     "/batches/executions": {
@@ -623,7 +639,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List batch executions"
       }
     },
     "/calls/make": {
@@ -667,7 +684,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Make call"
       }
     },
     "/calls/stop_call": {
@@ -711,7 +729,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Stop call"
       }
     },
     "/executions/get_execution": {
@@ -745,7 +764,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get execution"
       }
     },
     "/executions/get_executions": {
@@ -779,7 +799,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List executions"
       }
     },
     "/executions/get_execution_raw_logs": {
@@ -813,7 +834,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get execution raw logs"
       }
     },
     "/executions/get_batch_executions": {
@@ -847,7 +869,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get batch executions"
       }
     },
     "/extractions/get": {
@@ -881,7 +904,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get extraction template"
       }
     },
     "/extractions/list": {
@@ -915,7 +939,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List extraction templates"
       }
     },
     "/inbound/agent": {
@@ -959,7 +984,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Configure inbound agent"
       }
     },
     "/inbound/unlink": {
@@ -993,7 +1019,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Unlink inbound agent"
       }
     },
     "/knowledgebase/create": {
@@ -1037,7 +1064,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create knowledge base"
       }
     },
     "/knowledgebase/get_knowledgebase": {
@@ -1071,7 +1099,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get knowledge base"
       }
     },
     "/knowledgebase/get_knowledgebases": {
@@ -1105,7 +1134,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List knowledge bases"
       }
     },
     "/knowledgebase/delete": {
@@ -1139,7 +1169,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete knowledge base"
       }
     },
     "/phone-numbers/buy": {
@@ -1183,7 +1214,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Buy phone number"
       }
     },
     "/phone-numbers/get_all": {
@@ -1217,7 +1249,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List phone numbers"
       }
     },
     "/phone-numbers/delete": {
@@ -1251,7 +1284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete phone number"
       }
     },
     "/phone-numbers/search": {
@@ -1285,7 +1319,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search available numbers"
       }
     },
     "/providers/add": {
@@ -1329,7 +1364,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add provider"
       }
     },
     "/providers/get": {
@@ -1363,7 +1399,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List providers"
       }
     },
     "/providers/remove": {
@@ -1397,7 +1434,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove provider"
       }
     },
     "/sip-trunks/create": {
@@ -1441,7 +1479,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create SIP trunk"
       }
     },
     "/sip-trunks/get": {
@@ -1475,7 +1514,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get SIP trunk"
       }
     },
     "/sip-trunks/get_all": {
@@ -1509,7 +1549,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List SIP trunks"
       }
     },
     "/sip-trunks/update": {
@@ -1553,7 +1594,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update SIP trunk"
       }
     },
     "/sip-trunks/delete": {
@@ -1587,7 +1629,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete SIP trunk"
       }
     },
     "/sip-trunks/add_number": {
@@ -1631,7 +1674,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add number to SIP trunk"
       }
     },
     "/sip-trunks/remove_number": {
@@ -1665,7 +1709,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove number from SIP trunk"
       }
     },
     "/sip-trunks/list_numbers": {
@@ -1699,7 +1744,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List SIP trunk numbers"
       }
     },
     "/sub-accounts/create": {
@@ -1743,7 +1789,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create sub-account"
       }
     },
     "/sub-accounts/get_all": {
@@ -1777,7 +1824,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List sub-accounts"
       }
     },
     "/sub-accounts/usage": {
@@ -1811,7 +1859,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get sub-account usage"
       }
     },
     "/sub-accounts/all_usage": {
@@ -1845,7 +1894,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all usage"
       }
     },
     "/sub-accounts/patch_update": {
@@ -1889,7 +1939,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update sub-account"
       }
     },
     "/sub-accounts/delete": {
@@ -1923,7 +1974,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete sub-account"
       }
     },
     "/user/info": {
@@ -1957,7 +2009,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user info"
       }
     },
     "/user/add_model": {
@@ -2001,7 +2054,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add custom model"
       }
     },
     "/violations/list": {
@@ -2035,7 +2089,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List violations"
       }
     },
     "/violations/submit": {
@@ -2079,7 +2134,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Submit violation"
       }
     },
     "/voice/get_all": {
@@ -2113,7 +2169,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List voices"
       }
     }
   },
@@ -2144,6 +2201,50 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Agents"
+    },
+    {
+      "name": "Batches"
+    },
+    {
+      "name": "Calls"
+    },
+    {
+      "name": "Executions"
+    },
+    {
+      "name": "Extractions"
+    },
+    {
+      "name": "Inbound"
+    },
+    {
+      "name": "Knowledge Base"
+    },
+    {
+      "name": "Phone Numbers"
+    },
+    {
+      "name": "Providers"
+    },
+    {
+      "name": "SIP Trunks"
+    },
+    {
+      "name": "Sub-Accounts"
+    },
+    {
+      "name": "User"
+    },
+    {
+      "name": "Violations"
+    },
+    {
+      "name": "Voice"
     }
   ]
 }

--- a/apis/openapi/bond.tech/bond-api/0.1.0/openapi.json
+++ b/apis/openapi/bond.tech/bond-api/0.1.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bond API",
     "version": "0.1.0",
     "description": "Bond financial infrastructure API for card issuance, account management, KYC/KYB verification, and payments.",
-    "x-jentic-source-url": "https://docs.bond.tech/reference/intro"
+    "x-jentic-source-url": "https://docs.bond.tech/reference/intro",
+    "contact": {}
   },
   "servers": [
     {
@@ -2032,6 +2033,41 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Businesses"
+    },
+    {
+      "name": "Cards"
+    },
+    {
+      "name": "Credit"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "KYB"
+    },
+    {
+      "name": "KYC"
+    },
+    {
+      "name": "Statements"
+    },
+    {
+      "name": "Transactions"
+    },
+    {
+      "name": "Transfers"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/bondradar.com/bondradar/1.0.0/openapi.json
+++ b/apis/openapi/bondradar.com/bondradar/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BondRadar API",
     "version": "1.0.0",
     "description": "Fixed income bond data API",
-    "x-jentic-source-url": "https://developer.bondradar.com/support/"
+    "x-jentic-source-url": "https://developer.bondradar.com/support/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/bondradar.com/bondradar/1.0.0/openapi.json
+++ b/apis/openapi/bondradar.com/bondradar/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/bonusly.com/bonusly-api/1.0.0/openapi.json
+++ b/apis/openapi/bonusly.com/bonusly-api/1.0.0/openapi.json
@@ -1236,13 +1236,6 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "API key passed as Bearer token in Authorization header"
-      }
-    },
     "schemas": {
       "SuccessResponse": {
         "type": "object",
@@ -1253,19 +1246,6 @@
           },
           "result": {
             "description": "Response data (varies by endpoint)"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "example": false
-          },
-          "message": {
-            "type": "string",
-            "description": "Error description"
           }
         }
       },
@@ -1615,5 +1595,25 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Achievements"
+    },
+    {
+      "name": "Analytics"
+    },
+    {
+      "name": "Bonuses"
+    },
+    {
+      "name": "Redemptions"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }

--- a/apis/openapi/bonusly.com/bonusly-api/1.0.0/openapi.json
+++ b/apis/openapi/bonusly.com/bonusly-api/1.0.0/openapi.json
@@ -1594,6 +1594,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   },
   "tags": [

--- a/apis/openapi/booking.com/booking/1.0.0/openapi.json
+++ b/apis/openapi/booking.com/booking/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Booking.com API",
     "version": "1.0.0",
     "description": "APIs for hotel and accommodation bookings, property management, and travel services",
-    "x-jentic-source-url": "https://developers.booking.com/"
+    "x-jentic-source-url": "https://developers.booking.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -328,5 +329,16 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Availability"
+    },
+    {
+      "name": "Bookings"
+    },
+    {
+      "name": "Hotels"
+    }
+  ]
 }

--- a/apis/openapi/bookingsync.com/bookingsync-api/3.0.0/openapi.json
+++ b/apis/openapi/bookingsync.com/bookingsync-api/3.0.0/openapi.json
@@ -45,7 +45,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Accounts"
       }
     },
     "/rentals": {
@@ -74,7 +75,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Rentals"
       },
       "post": {
         "summary": "Create Rental",
@@ -113,7 +115,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Rental"
       }
     },
     "/rentals/{id}": {
@@ -149,7 +152,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Rental"
       },
       "put": {
         "summary": "Update Rental",
@@ -198,7 +202,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update Rental"
       }
     },
     "/bookings": {
@@ -227,7 +232,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Bookings"
       },
       "post": {
         "summary": "Create Booking",
@@ -266,7 +272,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Booking"
       }
     },
     "/bookings/{id}": {
@@ -302,7 +309,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Booking"
       }
     },
     "/rates": {
@@ -331,7 +339,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Rates"
       }
     },
     "/availability": {
@@ -355,7 +364,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Availability"
       }
     }
   },

--- a/apis/openapi/boschrexroth.github.io/rest-api/1.15.2/openapi.json
+++ b/apis/openapi/boschrexroth.github.io/rest-api/1.15.2/openapi.json
@@ -3374,6 +3374,17 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "UsernamePassword": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "UsernamePassword"
+      },
+      "Bearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   }
 }

--- a/apis/openapi/boschrexroth.github.io/rest-api/1.15.2/openapi.json
+++ b/apis/openapi/boschrexroth.github.io/rest-api/1.15.2/openapi.json
@@ -1691,93 +1691,6 @@
         }
       }
     },
-    "parameters": {
-      "fileName": {
-        "description": "Name of the file",
-        "explode": false,
-        "in": "path",
-        "name": "fileName",
-        "required": true,
-        "schema": {
-          "type": "string"
-        },
-        "style": "simple"
-      },
-      "taskId": {
-        "description": "task id",
-        "explode": false,
-        "in": "path",
-        "name": "taskId",
-        "required": true,
-        "schema": {
-          "example": "123",
-          "type": "string"
-        },
-        "style": "simple"
-      }
-    },
-    "responses": {
-      "Conflict": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "The request conflicts with the current state of the resource"
-      },
-      "Unauthorized": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "Not authorized to access this resource"
-      },
-      "Forbidden": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "Access forbidden for this resource"
-      },
-      "BadRequest": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "The request is incomplete or malformed"
-      },
-      "InternalServerError": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "Something unexpected happened on the server"
-      },
-      "NotFound": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/Problem"
-            }
-          }
-        },
-        "description": "The resource was not found"
-      }
-    },
     "schemas": {
       "SystemInfo": {
         "description": "System info dataobject",
@@ -3084,34 +2997,6 @@
         },
         "type": "object"
       },
-      "Storage": {
-        "description": "List of storages",
-        "example": [
-          {
-            "type": "nvme",
-            "writeSupport": "sporadic",
-            "size": 4096000000,
-            "removable": false,
-            "role": "system"
-          },
-          {
-            "type": "sdhc",
-            "size": 32000000000,
-            "writeSupport": "continuous",
-            "removable": false
-          },
-          {
-            "type": "usb",
-            "writeSupport": "continuous",
-            "size": 32000000000,
-            "removable": true
-          }
-        ],
-        "items": {
-          "$ref": "#/components/schemas/StorageItem"
-        },
-        "type": "array"
-      },
       "StorageItem": {
         "description": "Storage characteristics",
         "properties": {
@@ -3488,25 +3373,6 @@
             "$ref": "#/components/schemas/OneOfNtpResult"
           }
         }
-      }
-    },
-    "securitySchemes": {
-      "UsernamePassword": {
-        "description": "Enter username and password",
-        "flows": {
-          "password": {
-            "scopes": {
-              "dummy": "Dummy scope (scopes not used)"
-            },
-            "tokenUrl": "/identity-manager/api/v2/auth/token"
-          }
-        },
-        "type": "oauth2"
-      },
-      "Bearer": {
-        "description": "Alternatively&colon; Enter bearer token (without prefix 'Bearer')",
-        "scheme": "bearer",
-        "type": "http"
       }
     }
   }

--- a/apis/openapi/botcake.io/botcake-1/1.0.0/openapi.json
+++ b/apis/openapi/botcake.io/botcake-1/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Botcake API",
     "version": "1.0.0",
     "description": "Botcake chatbot and customer engagement platform API. Manage conversations, customers, bots, and analytics.",
-    "x-jentic-source-url": "https://docs.botcake.io/api-reference"
+    "x-jentic-source-url": "https://docs.botcake.io/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -42,7 +43,9 @@
   "paths": {
     "/customers": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "List customers",
         "operationId": "listCustomers",
         "parameters": [
@@ -93,10 +96,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List customers"
       },
       "post": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Create customer",
         "operationId": "createCustomer",
         "requestBody": {
@@ -123,12 +129,15 @@
           "400": {
             "$ref": "#/components/responses/BadRequestError"
           }
-        }
+        },
+        "description": "Create customer"
       }
     },
     "/customers/{customerId}": {
       "get": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Get customer details",
         "operationId": "getCustomer",
         "parameters": [
@@ -150,10 +159,13 @@
           "404": {
             "$ref": "#/components/responses/NotFoundError"
           }
-        }
+        },
+        "description": "Get customer details"
       },
       "put": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Update customer",
         "operationId": "updateCustomer",
         "parameters": [
@@ -182,10 +194,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Update customer"
       },
       "delete": {
-        "tags": ["Customers"],
+        "tags": [
+          "Customers"
+        ],
         "summary": "Delete customer",
         "operationId": "deleteCustomer",
         "parameters": [
@@ -197,12 +212,15 @@
           "204": {
             "description": "Customer deleted"
           }
-        }
+        },
+        "description": "Delete customer"
       }
     },
     "/conversations": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "List conversations",
         "operationId": "listConversations",
         "parameters": [
@@ -211,7 +229,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["open", "closed", "pending"]
+              "enum": [
+                "open",
+                "closed",
+                "pending"
+              ]
             }
           },
           {
@@ -252,10 +274,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List conversations"
       },
       "post": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Create conversation",
         "operationId": "createConversation",
         "requestBody": {
@@ -264,14 +289,21 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["customer_id"],
+                "required": [
+                  "customer_id"
+                ],
                 "properties": {
                   "customer_id": {
                     "type": "string"
                   },
                   "channel": {
                     "type": "string",
-                    "enum": ["web", "facebook", "whatsapp", "telegram"]
+                    "enum": [
+                      "web",
+                      "facebook",
+                      "whatsapp",
+                      "telegram"
+                    ]
                   },
                   "metadata": {
                     "type": "object"
@@ -292,12 +324,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create conversation"
       }
     },
     "/conversations/{conversationId}": {
       "get": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Get conversation details",
         "operationId": "getConversation",
         "parameters": [
@@ -321,10 +356,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get conversation details"
       },
       "patch": {
-        "tags": ["Conversations"],
+        "tags": [
+          "Conversations"
+        ],
         "summary": "Update conversation status",
         "operationId": "updateConversation",
         "parameters": [
@@ -346,7 +384,11 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": ["open", "closed", "pending"]
+                    "enum": [
+                      "open",
+                      "closed",
+                      "pending"
+                    ]
                   },
                   "assigned_to": {
                     "type": "string"
@@ -360,12 +402,15 @@
           "200": {
             "description": "Conversation updated"
           }
-        }
+        },
+        "description": "Update conversation status"
       }
     },
     "/conversations/{conversationId}/messages": {
       "get": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "summary": "Get conversation messages",
         "operationId": "getMessages",
         "parameters": [
@@ -400,10 +445,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get conversation messages"
       },
       "post": {
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "summary": "Send message",
         "operationId": "sendMessage",
         "parameters": [
@@ -437,12 +485,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Send message"
       }
     },
     "/bots": {
       "get": {
-        "tags": ["Bots"],
+        "tags": [
+          "Bots"
+        ],
         "summary": "List bots",
         "operationId": "listBots",
         "responses": {
@@ -459,10 +510,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List bots"
       },
       "post": {
-        "tags": ["Bots"],
+        "tags": [
+          "Bots"
+        ],
         "summary": "Create bot",
         "operationId": "createBot",
         "requestBody": {
@@ -471,7 +525,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -499,12 +555,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create bot"
       }
     },
     "/bots/{botId}": {
       "get": {
-        "tags": ["Bots"],
+        "tags": [
+          "Bots"
+        ],
         "summary": "Get bot details",
         "operationId": "getBot",
         "parameters": [
@@ -528,10 +587,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get bot details"
       },
       "put": {
-        "tags": ["Bots"],
+        "tags": [
+          "Bots"
+        ],
         "summary": "Update bot",
         "operationId": "updateBot",
         "parameters": [
@@ -569,10 +631,13 @@
           "200": {
             "description": "Bot updated"
           }
-        }
+        },
+        "description": "Update bot"
       },
       "delete": {
-        "tags": ["Bots"],
+        "tags": [
+          "Bots"
+        ],
         "summary": "Delete bot",
         "operationId": "deleteBot",
         "parameters": [
@@ -589,12 +654,15 @@
           "204": {
             "description": "Bot deleted"
           }
-        }
+        },
+        "description": "Delete bot"
       }
     },
     "/analytics/conversations": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "summary": "Get conversation analytics",
         "operationId": "getConversationAnalytics",
         "parameters": [
@@ -649,12 +717,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get conversation analytics"
       }
     },
     "/analytics/messages": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "summary": "Get message analytics",
         "operationId": "getMessageAnalytics",
         "parameters": [
@@ -705,7 +776,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get message analytics"
       }
     }
   },
@@ -759,7 +831,9 @@
       },
       "CustomerInput": {
         "type": "object",
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "properties": {
           "email": {
             "type": "string",
@@ -787,7 +861,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["open", "closed", "pending"]
+            "enum": [
+              "open",
+              "closed",
+              "pending"
+            ]
           },
           "channel": {
             "type": "string"
@@ -822,7 +900,11 @@
           },
           "sender_type": {
             "type": "string",
-            "enum": ["customer", "bot", "agent"]
+            "enum": [
+              "customer",
+              "bot",
+              "agent"
+            ]
           },
           "sender_id": {
             "type": "string"
@@ -850,14 +932,19 @@
       },
       "MessageInput": {
         "type": "object",
-        "required": ["content"],
+        "required": [
+          "content"
+        ],
         "properties": {
           "content": {
             "type": "string"
           },
           "sender_type": {
             "type": "string",
-            "enum": ["bot", "agent"]
+            "enum": [
+              "bot",
+              "agent"
+            ]
           },
           "attachments": {
             "type": "array",

--- a/apis/openapi/botschaft.local/fastapi/0.1.0/openapi.json
+++ b/apis/openapi/botschaft.local/fastapi/0.1.0/openapi.json
@@ -22,7 +22,9 @@
     "x-logo": {
       "url": "https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"
     },
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/botschaft.local/0.1.0/openapi.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/botschaft.local/0.1.0/openapi.yaml",
+    "contact": {},
+    "description": "FastAPI"
   },
   "paths": {
     "/config": {
@@ -61,7 +63,11 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Config"
+        "summary": "Config",
+        "tags": [
+          "config"
+        ],
+        "description": "Config"
       }
     },
     "/discord": {
@@ -128,7 +134,8 @@
         "summary": "Discord Get",
         "tags": [
           "discord"
-        ]
+        ],
+        "description": "Discord Get"
       },
       "post": {
         "operationId": "discord_post_discord_post",
@@ -176,7 +183,8 @@
         "summary": "Discord Post",
         "tags": [
           "discord"
-        ]
+        ],
+        "description": "Discord Post"
       }
     },
     "/slack": {
@@ -243,7 +251,8 @@
         "summary": "Slack Get",
         "tags": [
           "slack"
-        ]
+        ],
+        "description": "Slack Get"
       },
       "post": {
         "operationId": "slack_post_slack_post",
@@ -291,7 +300,8 @@
         "summary": "Slack Post",
         "tags": [
           "slack"
-        ]
+        ],
+        "description": "Slack Post"
       }
     },
     "/sns": {
@@ -349,7 +359,8 @@
         "summary": "Sns Get",
         "tags": [
           "sns"
-        ]
+        ],
+        "description": "Sns Get"
       },
       "post": {
         "operationId": "sns_post_sns_post",
@@ -397,7 +408,8 @@
         "summary": "Sns Post",
         "tags": [
           "sns"
-        ]
+        ],
+        "description": "Sns Post"
       }
     },
     "/topic/{topic_name}": {
@@ -461,7 +473,11 @@
             "description": "Validation Error"
           }
         },
-        "summary": "Topic"
+        "summary": "Topic",
+        "tags": [
+          "topic"
+        ],
+        "description": "Topic"
       }
     },
     "/twilio": {
@@ -528,7 +544,8 @@
         "summary": "Twilio Message Get",
         "tags": [
           "twilio"
-        ]
+        ],
+        "description": "Twilio Message Get"
       },
       "post": {
         "operationId": "twilio_message_post_twilio_post",
@@ -576,7 +593,8 @@
         "summary": "Twilio Message Post",
         "tags": [
           "twilio"
-        ]
+        ],
+        "description": "Twilio Message Post"
       }
     }
   },
@@ -718,5 +736,25 @@
         "type": "object"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "config"
+    },
+    {
+      "name": "discord"
+    },
+    {
+      "name": "slack"
+    },
+    {
+      "name": "sns"
+    },
+    {
+      "name": "topic"
+    },
+    {
+      "name": "twilio"
+    }
+  ]
 }

--- a/apis/openapi/bpaygroup.com.au/bpaygroup/1.0.0/openapi.json
+++ b/apis/openapi/bpaygroup.com.au/bpaygroup/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BPAY Group API",
     "version": "1.0.0",
     "description": "BPAY Group developer portal for Australian bill payment services",
-    "x-jentic-source-url": "https://developer.bpaygroup.com.au/"
+    "x-jentic-source-url": "https://developer.bpaygroup.com.au/",
+    "contact": {}
   },
   "servers": [
     {
@@ -188,5 +189,13 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Bills"
+    },
+    {
+      "name": "Payments"
+    }
+  ]
 }

--- a/apis/openapi/brainbi.net/brainbi-api/1.0.0/openapi.json
+++ b/apis/openapi/brainbi.net/brainbi-api/1.0.0/openapi.json
@@ -43,6 +43,9 @@
     },
     {
       "name": "SEO"
+    },
+    {
+      "name": "api"
     }
   ],
   "paths": {
@@ -130,7 +133,10 @@
             "description": ""
           }
         },
-        "summary": "Login and get bearer token"
+        "summary": "Login and get bearer token",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/logout": {
@@ -153,7 +159,10 @@
             "description": ""
           }
         },
-        "summary": "Logout"
+        "summary": "Logout",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/orders": {
@@ -358,7 +367,10 @@
             "description": ""
           }
         },
-        "summary": "Register"
+        "summary": "Register",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/register_woocommerce": {
@@ -480,7 +492,10 @@
             "description": ""
           }
         },
-        "summary": "Register and Create Store Connection for WooCommerce"
+        "summary": "Register and Create Store Connection for WooCommerce",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/rule": {

--- a/apis/openapi/brainbi.net/brainbi/1.0.0/openapi.json
+++ b/apis/openapi/brainbi.net/brainbi/1.0.0/openapi.json
@@ -44,6 +44,9 @@
     },
     {
       "name": "SEO"
+    },
+    {
+      "name": "api"
     }
   ],
   "paths": {
@@ -131,7 +134,10 @@
             "description": ""
           }
         },
-        "summary": "Login and get bearer token"
+        "summary": "Login and get bearer token",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/logout": {
@@ -154,7 +160,10 @@
             "description": ""
           }
         },
-        "summary": "Logout"
+        "summary": "Logout",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/orders": {
@@ -359,7 +368,10 @@
             "description": ""
           }
         },
-        "summary": "Register"
+        "summary": "Register",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/register_woocommerce": {
@@ -481,7 +493,10 @@
             "description": ""
           }
         },
-        "summary": "Register and Create Store Connection for WooCommerce"
+        "summary": "Register and Create Store Connection for WooCommerce",
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/rule": {

--- a/apis/openapi/braincert.com/virtual-classroom-api/2.0.0/openapi.json
+++ b/apis/openapi/braincert.com/virtual-classroom-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BrainCert Virtual Classroom API",
     "version": "2.0.0",
     "description": "API for managing virtual classroom sessions, scheduling, pricing, recordings, and reporting.",
-    "x-jentic-source-url": "https://www.braincert.com/docs/api/vc/"
+    "x-jentic-source-url": "https://www.braincert.com/docs/api/vc/",
+    "contact": {}
   },
   "servers": [
     {
@@ -70,7 +71,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Schedule a new live class"
       }
     },
     "/updateclass": {
@@ -131,7 +133,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Edit class"
       }
     },
     "/getclasslaunch": {
@@ -192,7 +195,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get class launch URL"
       }
     },
     "/listclass": {
@@ -243,7 +247,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List classes"
       }
     },
     "/removeclass": {
@@ -304,7 +309,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove class"
       }
     },
     "/cancelclass": {
@@ -365,7 +371,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel class"
       }
     },
     "/addpricing": {
@@ -426,7 +433,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add pricing scheme"
       }
     },
     "/listpricing": {
@@ -477,7 +485,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List pricing schemes"
       }
     },
     "/removepricing": {
@@ -538,7 +547,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove pricing scheme"
       }
     },
     "/classpayment": {
@@ -599,7 +609,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Process class payment"
       }
     },
     "/addclassdiscount": {
@@ -660,7 +671,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add class discount"
       }
     },
     "/listclassdiscount": {
@@ -711,7 +723,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List class discounts"
       }
     },
     "/removeclassdiscount": {
@@ -772,7 +785,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove class discount"
       }
     },
     "/applycoupon": {
@@ -833,7 +847,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Apply discount coupon"
       }
     },
     "/listrecordings": {
@@ -884,7 +899,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List class recordings"
       }
     },
     "/getrecordedvideo": {
@@ -945,7 +961,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get recorded class videos"
       }
     },
     "/removeclassrecording": {
@@ -1006,7 +1023,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove class recording"
       }
     },
     "/changerecordstatus": {
@@ -1067,7 +1085,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Change recording status"
       }
     },
     "/usagereports": {
@@ -1118,7 +1137,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get class usage report"
       }
     },
     "/availableattendees": {
@@ -1169,7 +1189,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get available attendees"
       }
     }
   },
@@ -1375,6 +1396,23 @@
   "security": [
     {
       "ApiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Classes"
+    },
+    {
+      "name": "Discounts"
+    },
+    {
+      "name": "Pricing"
+    },
+    {
+      "name": "Recordings"
+    },
+    {
+      "name": "Reports"
     }
   ]
 }

--- a/apis/openapi/bri.co.id/bri-api/1.0.0/openapi.json
+++ b/apis/openapi/bri.co.id/bri-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BRI API",
     "version": "1.0.0",
     "description": "BRI (Bank Rakyat Indonesia) API platform providing BRI Direct Debit, BRIZZI e-money, BRIVA payment processing, and Banking as a Service (BaaS) for account management.",
-    "x-jentic-source-url": "https://developers.bri.co.id/en"
+    "x-jentic-source-url": "https://developers.bri.co.id/en",
+    "contact": {}
   },
   "servers": [
     {
@@ -27,7 +28,9 @@
         "operationId": "processDirectDebitPayment",
         "summary": "Process direct debit payment",
         "description": "Integrates debit card payments into applications",
-        "tags": ["Direct Debit"],
+        "tags": [
+          "Direct Debit"
+        ],
         "parameters": [
           {
             "name": "BRI-Timestamp",
@@ -123,7 +126,9 @@
         "operationId": "processBrizziPayment",
         "summary": "Process BRIZZI e-money payment",
         "description": "E-money payment integration service",
-        "tags": ["BRIZZI"],
+        "tags": [
+          "BRIZZI"
+        ],
         "parameters": [
           {
             "name": "BRI-Timestamp",
@@ -213,7 +218,9 @@
         "operationId": "processBrivaPayment",
         "summary": "Process BRIVA payment",
         "description": "Unique code-based payment processing",
-        "tags": ["BRIVA"],
+        "tags": [
+          "BRIVA"
+        ],
         "parameters": [
           {
             "name": "BRI-Timestamp",
@@ -303,7 +310,9 @@
         "operationId": "createSavingsAccount",
         "summary": "Create savings account",
         "description": "Banking as a Service (BaaS) - Open a new savings account",
-        "tags": ["Banking as a Service"],
+        "tags": [
+          "Banking as a Service"
+        ],
         "parameters": [
           {
             "name": "BRI-Timestamp",
@@ -414,5 +423,19 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "BRIVA"
+    },
+    {
+      "name": "BRIZZI"
+    },
+    {
+      "name": "Banking as a Service"
+    },
+    {
+      "name": "Direct Debit"
+    }
+  ]
 }

--- a/apis/openapi/bridgedb.org/bridgedb-webservices/0.9.0/openapi.json
+++ b/apis/openapi/bridgedb.org/bridgedb-webservices/0.9.0/openapi.json
@@ -19,7 +19,9 @@
     "x-logo": {
       "url": "https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"
     },
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bridgedb.org/0.9.0/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/bridgedb.org/0.9.0/swagger.yaml",
+    "contact": {},
+    "description": "bridgedb webservices"
   },
   "consumes": [
     "text/html"
@@ -131,7 +133,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-attributesearch-by-query"
       }
     },
     "/{organism}/attributeSet": {
@@ -216,7 +219,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-attributeset"
       }
     },
     "/{organism}/attributes/{systemCode}/{identifier}": {
@@ -362,7 +366,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-attributes-by-systemcode-by-identifier"
       }
     },
     "/{organism}/isFreeSearchSupported": {
@@ -447,7 +452,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-isfreesearchsupported"
       }
     },
     "/{organism}/isMappingSupported/{sourceSystemCode}/{targetSystemCode}": {
@@ -623,7 +629,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-ismappingsupported-by-sourcesystemcode-by-targetsystemcode"
       }
     },
     "/{organism}/properties": {
@@ -708,7 +715,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-properties"
       }
     },
     "/{organism}/search/{query}": {
@@ -808,7 +816,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-search-by-query"
       }
     },
     "/{organism}/sourceDataSources": {
@@ -893,7 +902,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-sourcedatasources"
       }
     },
     "/{organism}/targetDataSources": {
@@ -978,7 +988,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-targetdatasources"
       }
     },
     "/{organism}/xrefExists/{systemCode}/{identifier}": {
@@ -1117,7 +1128,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-xrefexists-by-systemcode-by-identifier"
       }
     },
     "/{organism}/xrefs/{systemCode}/{identifier}": {
@@ -1301,7 +1313,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "get-by-organism-xrefs-by-systemcode-by-identifier"
       }
     },
     "/{organism}/xrefsBatch": {
@@ -1442,7 +1455,8 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "post-by-organism-xrefsbatch"
       }
     },
     "/{organism}/xrefsBatch/{systemCode}": {
@@ -1628,8 +1642,14 @@
         },
         "tags": [
           "Identifiers (Genes, proteins, metabolites, interactions)"
-        ]
+        ],
+        "operationId": "post-by-organism-xrefsbatch-by-systemcode"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Identifiers (Genes, proteins, metabolites, interactions)"
+    }
+  ]
 }

--- a/apis/openapi/brightcove.com/brightcove-platform-api/1.0.0/openapi.json
+++ b/apis/openapi/brightcove.com/brightcove-platform-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Brightcove Platform API",
     "version": "1.0.0",
     "description": "Brightcove video platform APIs for content management, analytics, dynamic ingest, playback, and OAuth.",
-    "x-jentic-source-url": "https://apis.support.brightcove.com/"
+    "x-jentic-source-url": "https://apis.support.brightcove.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -84,7 +85,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List videos"
       },
       "post": {
         "operationId": "createVideo",
@@ -143,7 +145,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create video"
       }
     },
     "/accounts/{account_id}/videos/{video_id}": {
@@ -202,7 +205,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get video"
       },
       "patch": {
         "operationId": "updateVideo",
@@ -269,7 +273,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update video"
       },
       "delete": {
         "operationId": "deleteVideo",
@@ -319,7 +324,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete video"
       }
     },
     "/accounts/{account_id}/playlists": {
@@ -370,7 +376,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List playlists"
       }
     },
     "/accounts/{account_id}/folders": {
@@ -421,7 +428,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List folders"
       }
     }
   },
@@ -514,6 +522,11 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "CMS"
     }
   ]
 }

--- a/apis/openapi/btcturk.com/btcturk-api/2.0.0/openapi.json
+++ b/apis/openapi/btcturk.com/btcturk-api/2.0.0/openapi.json
@@ -25,7 +25,9 @@
         "summary": "Get exchange info",
         "description": "Returns server time, timezone, and information about all trading pairs including filters and order methods.",
         "operationId": "getExchangeInfo",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "responses": {
           "200": {
             "description": "Exchange information",
@@ -34,10 +36,19 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "$ref": "#/components/schemas/ExchangeInfo" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/ExchangeInfo"
+                    }
                   }
                 }
               }
@@ -51,12 +62,16 @@
         "summary": "Get ticker data",
         "description": "Returns 24-hour price change statistics for a trading pair or all pairs.",
         "operationId": "getTicker",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "pairSymbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Trading pair symbol (e.g. BTCTRY, ETHTRY). Omit for all pairs."
           }
         ],
@@ -68,12 +83,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Ticker" }
+                      "items": {
+                        "$ref": "#/components/schemas/Ticker"
+                      }
                     }
                   }
                 }
@@ -88,12 +112,16 @@
         "summary": "Get ticker by currency",
         "description": "Returns ticker data filtered by quote currency.",
         "operationId": "getTickerByCurrency",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Quote currency symbol (e.g. USDT, TRY)"
           }
         ],
@@ -105,12 +133,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Ticker" }
+                      "items": {
+                        "$ref": "#/components/schemas/Ticker"
+                      }
                     }
                   }
                 }
@@ -125,19 +162,26 @@
         "summary": "Get order book",
         "description": "Returns the order book for a trading pair.",
         "operationId": "getOrderBook",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "pairSymbol",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Trading pair symbol (e.g. BTCTRY)"
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 25 },
+            "schema": {
+              "type": "integer",
+              "default": 25
+            },
             "description": "Maximum number of orders to return (default: 25)"
           }
         ],
@@ -149,10 +193,19 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "$ref": "#/components/schemas/OrderBook" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/OrderBook"
+                    }
                   }
                 }
               }
@@ -169,19 +222,26 @@
         "summary": "Get recent trades",
         "description": "Returns recent trades for a trading pair.",
         "operationId": "getTrades",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "pairSymbol",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Trading pair symbol (e.g. BTCTRY)"
           },
           {
             "name": "last",
             "in": "query",
-            "schema": { "type": "integer", "maximum": 50 },
+            "schema": {
+              "type": "integer",
+              "maximum": 50
+            },
             "description": "Number of recent trades to retrieve (max: 50)"
           }
         ],
@@ -193,12 +253,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Trade" }
+                      "items": {
+                        "$ref": "#/components/schemas/Trade"
+                      }
                     }
                   }
                 }
@@ -213,13 +282,17 @@
         "summary": "Get OHLC data",
         "description": "Returns OHLC (Open/High/Low/Close) candlestick data. Uses graph-api.btcturk.com server.",
         "operationId": "getOHLC",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "pair",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Trading pair symbol"
           }
         ],
@@ -228,7 +301,9 @@
             "description": "OHLC data",
             "content": {
               "application/json": {
-                "schema": { "type": "object" }
+                "schema": {
+                  "type": "object"
+                }
               }
             }
           }
@@ -240,34 +315,44 @@
         "summary": "Get kline data",
         "description": "Returns kline (candlestick) history data. Uses graph-api.btcturk.com server.",
         "operationId": "getKlineHistory",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "parameters": [
           {
             "name": "symbol",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Trading pair symbol"
           },
           {
             "name": "resolution",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Kline interval resolution"
           },
           {
             "name": "from",
             "in": "query",
             "required": true,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Start time in seconds"
           },
           {
             "name": "to",
             "in": "query",
             "required": true,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "End time in seconds"
           }
         ],
@@ -276,7 +361,9 @@
             "description": "Kline history data",
             "content": {
               "application/json": {
-                "schema": { "type": "object" }
+                "schema": {
+                  "type": "object"
+                }
               }
             }
           }
@@ -288,7 +375,9 @@
         "summary": "Get crypto exchanges",
         "description": "Returns a list of supported crypto exchanges.",
         "operationId": "getCryptoExchanges",
-        "tags": ["Public"],
+        "tags": [
+          "Public"
+        ],
         "responses": {
           "200": {
             "description": "Exchange list",
@@ -297,10 +386,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "type": "object" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               }
@@ -314,8 +415,14 @@
         "summary": "Get account balances",
         "description": "Returns the balances for all assets in the user's account.",
         "operationId": "getAccountBalances",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Account balances",
@@ -324,12 +431,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
                     "data": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Balance" }
+                      "items": {
+                        "$ref": "#/components/schemas/Balance"
+                      }
                     }
                   }
                 }
@@ -344,19 +460,33 @@
         "summary": "Get user trade transactions",
         "description": "Returns the user's trade transaction history.",
         "operationId": "getUserTradeTransactions",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "type",
             "in": "query",
-            "schema": { "type": "string", "enum": ["buy", "sell"] },
+            "schema": {
+              "type": "string",
+              "enum": [
+                "buy",
+                "sell"
+              ]
+            },
             "description": "Filter by transaction type"
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by trading pair symbol"
           }
         ],
@@ -368,10 +498,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "type": "object" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               }
@@ -385,8 +527,14 @@
         "summary": "Get user fiat transactions",
         "description": "Returns the user's fiat currency transaction history.",
         "operationId": "getUserFiatTransactions",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Fiat transactions",
@@ -395,10 +543,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "type": "object" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               }
@@ -412,8 +572,14 @@
         "summary": "Get user crypto transactions",
         "description": "Returns the user's cryptocurrency transaction history.",
         "operationId": "getUserCryptoTransactions",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Crypto transactions",
@@ -422,10 +588,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "type": "object" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               }
@@ -439,13 +617,21 @@
         "summary": "Get open orders",
         "description": "Returns the user's currently open orders.",
         "operationId": "getOpenOrders",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "pairSymbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by trading pair symbol"
           }
         ],
@@ -457,14 +643,31 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "asks": { "type": "array", "items": { "$ref": "#/components/schemas/Order" } },
-                        "bids": { "type": "array", "items": { "$ref": "#/components/schemas/Order" } }
+                        "asks": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Order"
+                          }
+                        },
+                        "bids": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/Order"
+                          }
+                        }
                       }
                     }
                   }
@@ -480,13 +683,21 @@
         "summary": "Get all orders",
         "description": "Returns all orders including closed ones.",
         "operationId": "getAllOrders",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "pairSymbol",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by trading pair symbol"
           }
         ],
@@ -498,10 +709,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "$ref": "#/components/schemas/Order" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Order"
+                      }
+                    }
                   }
                 }
               }
@@ -515,14 +738,22 @@
         "summary": "Get single order",
         "description": "Returns details of a specific order.",
         "operationId": "getOrder",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "orderId",
             "in": "path",
             "required": true,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Order ID"
           }
         ],
@@ -534,10 +765,19 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "$ref": "#/components/schemas/Order" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Order"
+                    }
                   }
                 }
               }
@@ -551,13 +791,21 @@
         "summary": "Submit an order",
         "description": "Submit a new buy or sell order.",
         "operationId": "submitOrder",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/OrderRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/OrderRequest"
+              }
             }
           }
         },
@@ -569,10 +817,18 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string" },
-                    "code": { "type": "integer" },
-                    "data": { "$ref": "#/components/schemas/Order" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "$ref": "#/components/schemas/Order"
+                    }
                   }
                 }
               }
@@ -584,14 +840,22 @@
         "summary": "Cancel an order",
         "description": "Cancel an open order by ID.",
         "operationId": "cancelOrder",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
             "required": true,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Order ID to cancel"
           }
         ],
@@ -603,9 +867,15 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string" },
-                    "code": { "type": "integer" }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string"
+                    },
+                    "code": {
+                      "type": "integer"
+                    }
                   }
                 }
               }
@@ -619,8 +889,14 @@
         "summary": "Get crypto deposit declarations",
         "description": "Returns crypto deposit declaration information.",
         "operationId": "getCryptoDepositDeclarations",
-        "tags": ["Private"],
-        "security": [{ "ApiKeyAuth": [] }],
+        "tags": [
+          "Private"
+        ],
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
         "responses": {
           "200": {
             "description": "Crypto deposit declarations",
@@ -629,10 +905,22 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "success": { "type": "boolean" },
-                    "message": { "type": "string", "nullable": true },
-                    "code": { "type": "integer" },
-                    "data": { "type": "array", "items": { "type": "object" } }
+                    "success": {
+                      "type": "boolean"
+                    },
+                    "message": {
+                      "type": "string",
+                      "nullable": true
+                    },
+                    "code": {
+                      "type": "integer"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
                   }
                 }
               }
@@ -655,64 +943,143 @@
       "ExchangeInfo": {
         "type": "object",
         "properties": {
-          "timeZone": { "type": "string" },
-          "serverTime": { "type": "integer" },
+          "timeZone": {
+            "type": "string"
+          },
+          "serverTime": {
+            "type": "integer"
+          },
           "symbols": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Symbol" }
+            "items": {
+              "$ref": "#/components/schemas/Symbol"
+            }
           }
         }
       },
       "Symbol": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "name": { "type": "string" },
-          "nameNormalized": { "type": "string" },
-          "status": { "type": "string" },
-          "numerator": { "type": "string" },
-          "denominator": { "type": "string" },
-          "numeratorScale": { "type": "integer" },
-          "denominatorScale": { "type": "integer" },
-          "hasFraction": { "type": "boolean" },
-          "filters": { "type": "array", "items": { "type": "object" } },
-          "orderMethods": { "type": "array", "items": { "type": "string" } },
-          "displayFormat": { "type": "string" },
-          "maximumLimitOrderPrice": { "type": "number" },
-          "minimumLimitOrderPrice": { "type": "number" },
-          "maximumOrderAmount": { "type": "number", "nullable": true }
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "nameNormalized": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "numerator": {
+            "type": "string"
+          },
+          "denominator": {
+            "type": "string"
+          },
+          "numeratorScale": {
+            "type": "integer"
+          },
+          "denominatorScale": {
+            "type": "integer"
+          },
+          "hasFraction": {
+            "type": "boolean"
+          },
+          "filters": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "orderMethods": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "displayFormat": {
+            "type": "string"
+          },
+          "maximumLimitOrderPrice": {
+            "type": "number"
+          },
+          "minimumLimitOrderPrice": {
+            "type": "number"
+          },
+          "maximumOrderAmount": {
+            "type": "number",
+            "nullable": true
+          }
         }
       },
       "Ticker": {
         "type": "object",
         "properties": {
-          "pair": { "type": "string" },
-          "pairNormalized": { "type": "string" },
-          "timestamp": { "type": "integer" },
-          "last": { "type": "number" },
-          "high": { "type": "number" },
-          "low": { "type": "number" },
-          "bid": { "type": "number" },
-          "ask": { "type": "number" },
-          "open": { "type": "number" },
-          "volume": { "type": "number" },
-          "average": { "type": "number" },
-          "daily": { "type": "number" },
-          "dailyPercent": { "type": "number" },
-          "denominatorSymbol": { "type": "string" },
-          "numeratorSymbol": { "type": "string" },
-          "order": { "type": "integer" }
+          "pair": {
+            "type": "string"
+          },
+          "pairNormalized": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "integer"
+          },
+          "last": {
+            "type": "number"
+          },
+          "high": {
+            "type": "number"
+          },
+          "low": {
+            "type": "number"
+          },
+          "bid": {
+            "type": "number"
+          },
+          "ask": {
+            "type": "number"
+          },
+          "open": {
+            "type": "number"
+          },
+          "volume": {
+            "type": "number"
+          },
+          "average": {
+            "type": "number"
+          },
+          "daily": {
+            "type": "number"
+          },
+          "dailyPercent": {
+            "type": "number"
+          },
+          "denominatorSymbol": {
+            "type": "string"
+          },
+          "numeratorSymbol": {
+            "type": "string"
+          },
+          "order": {
+            "type": "integer"
+          }
         }
       },
       "OrderBook": {
         "type": "object",
         "properties": {
-          "timestamp": { "type": "integer" },
+          "timestamp": {
+            "type": "integer"
+          },
           "bids": {
             "type": "array",
             "items": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "description": "Array of [price, amount] pairs"
           },
@@ -720,7 +1087,9 @@
             "type": "array",
             "items": {
               "type": "array",
-              "items": { "type": "string" }
+              "items": {
+                "type": "string"
+              }
             },
             "description": "Array of [price, amount] pairs"
           }
@@ -729,62 +1098,178 @@
       "Trade": {
         "type": "object",
         "properties": {
-          "pair": { "type": "string" },
-          "pairNormalized": { "type": "string" },
-          "numerator": { "type": "string" },
-          "denominator": { "type": "string" },
-          "date": { "type": "integer", "description": "Timestamp in milliseconds" },
-          "tid": { "type": "string" },
-          "price": { "type": "string" },
-          "amount": { "type": "string" }
+          "pair": {
+            "type": "string"
+          },
+          "pairNormalized": {
+            "type": "string"
+          },
+          "numerator": {
+            "type": "string"
+          },
+          "denominator": {
+            "type": "string"
+          },
+          "date": {
+            "type": "integer",
+            "description": "Timestamp in milliseconds"
+          },
+          "tid": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string"
+          }
         }
       },
       "Balance": {
         "type": "object",
         "properties": {
-          "asset": { "type": "string" },
-          "assetname": { "type": "string" },
-          "balance": { "type": "string" },
-          "locked": { "type": "string" },
-          "free": { "type": "string" },
-          "orderFund": { "type": "string" },
-          "requestFund": { "type": "string" },
-          "precision": { "type": "integer" },
-          "timestamp": { "type": "integer" }
+          "asset": {
+            "type": "string"
+          },
+          "assetname": {
+            "type": "string"
+          },
+          "balance": {
+            "type": "string"
+          },
+          "locked": {
+            "type": "string"
+          },
+          "free": {
+            "type": "string"
+          },
+          "orderFund": {
+            "type": "string"
+          },
+          "requestFund": {
+            "type": "string"
+          },
+          "precision": {
+            "type": "integer"
+          },
+          "timestamp": {
+            "type": "integer"
+          }
         }
       },
       "Order": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "price": { "type": "string" },
-          "amount": { "type": "string" },
-          "quantity": { "type": "string" },
-          "stopPrice": { "type": "string" },
-          "pairSymbol": { "type": "string" },
-          "pairSymbolNormalized": { "type": "string" },
-          "type": { "type": "string", "enum": ["buy", "sell"] },
-          "method": { "type": "string", "enum": ["limit", "market", "stoplimit", "stopmarket"] },
-          "orderClientId": { "type": "string" },
-          "time": { "type": "integer" },
-          "updateTime": { "type": "integer" },
-          "status": { "type": "string" },
-          "leftAmount": { "type": "string" }
+          "id": {
+            "type": "integer"
+          },
+          "price": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "string"
+          },
+          "quantity": {
+            "type": "string"
+          },
+          "stopPrice": {
+            "type": "string"
+          },
+          "pairSymbol": {
+            "type": "string"
+          },
+          "pairSymbolNormalized": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "method": {
+            "type": "string",
+            "enum": [
+              "limit",
+              "market",
+              "stoplimit",
+              "stopmarket"
+            ]
+          },
+          "orderClientId": {
+            "type": "string"
+          },
+          "time": {
+            "type": "integer"
+          },
+          "updateTime": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "leftAmount": {
+            "type": "string"
+          }
         }
       },
       "OrderRequest": {
         "type": "object",
-        "required": ["quantity", "price", "orderMethod", "orderType", "pairSymbol"],
+        "required": [
+          "quantity",
+          "price",
+          "orderMethod",
+          "orderType",
+          "pairSymbol"
+        ],
         "properties": {
-          "quantity": { "type": "number", "description": "Order quantity" },
-          "price": { "type": "number", "description": "Order price (ignored for market orders)" },
-          "stopPrice": { "type": "number", "description": "Stop price for stop orders" },
-          "newOrderClientId": { "type": "string", "description": "Client order ID (GUID format)" },
-          "orderMethod": { "type": "string", "enum": ["limit", "market", "stoplimit", "stopmarket"] },
-          "orderType": { "type": "string", "enum": ["buy", "sell"] },
-          "pairSymbol": { "type": "string", "description": "Trading pair (e.g. BTCTRY)" }
+          "quantity": {
+            "type": "number",
+            "description": "Order quantity"
+          },
+          "price": {
+            "type": "number",
+            "description": "Order price (ignored for market orders)"
+          },
+          "stopPrice": {
+            "type": "number",
+            "description": "Stop price for stop orders"
+          },
+          "newOrderClientId": {
+            "type": "string",
+            "description": "Client order ID (GUID format)"
+          },
+          "orderMethod": {
+            "type": "string",
+            "enum": [
+              "limit",
+              "market",
+              "stoplimit",
+              "stopmarket"
+            ]
+          },
+          "orderType": {
+            "type": "string",
+            "enum": [
+              "buy",
+              "sell"
+            ]
+          },
+          "pairSymbol": {
+            "type": "string",
+            "description": "Trading pair (e.g. BTCTRY)"
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Private"
+    },
+    {
+      "name": "Public"
+    }
+  ]
 }

--- a/apis/openapi/bubosales.com/buboai/1.0.0/openapi.json
+++ b/apis/openapi/bubosales.com/buboai/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bubo AI API",
     "version": "1.0.0",
     "description": "Bubo AI Sales API for intelligent sales automation and CRM",
-    "x-jentic-source-url": "https://app.bubosales.com/api-docs"
+    "x-jentic-source-url": "https://app.bubosales.com/api-docs",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,15 +19,29 @@
     }
   ],
   "tags": [
-    {"name": "Leads", "description": "Lead management"},
-    {"name": "Contacts", "description": "Contact operations"},
-    {"name": "Campaigns", "description": "Campaign management"},
-    {"name": "Analytics", "description": "Sales analytics"}
+    {
+      "name": "Leads",
+      "description": "Lead management"
+    },
+    {
+      "name": "Contacts",
+      "description": "Contact operations"
+    },
+    {
+      "name": "Campaigns",
+      "description": "Campaign management"
+    },
+    {
+      "name": "Analytics",
+      "description": "Sales analytics"
+    }
   ],
   "paths": {
     "/leads": {
       "get": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "List Leads",
         "description": "Retrieve all leads",
         "operationId": "listLeads",
@@ -34,17 +49,30 @@
           {
             "name": "status",
             "in": "query",
-            "schema": {"type": "string", "enum": ["new", "qualified", "contacted", "converted"]}
+            "schema": {
+              "type": "string",
+              "enum": [
+                "new",
+                "qualified",
+                "contacted",
+                "converted"
+              ]
+            }
           },
           {
             "name": "source",
             "in": "query",
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": {"type": "integer", "default": 50}
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           }
         ],
         "responses": {
@@ -57,9 +85,13 @@
                   "properties": {
                     "leads": {
                       "type": "array",
-                      "items": {"$ref": "#/components/schemas/Lead"}
+                      "items": {
+                        "$ref": "#/components/schemas/Lead"
+                      }
                     },
-                    "pagination": {"$ref": "#/components/schemas/Pagination"}
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
                   }
                 }
               }
@@ -68,7 +100,9 @@
         }
       },
       "post": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Create Lead",
         "description": "Create a new lead",
         "operationId": "createLead",
@@ -76,7 +110,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateLeadRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateLeadRequest"
+              }
             }
           }
         },
@@ -85,7 +121,9 @@
             "description": "Lead created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Lead"}
+                "schema": {
+                  "$ref": "#/components/schemas/Lead"
+                }
               }
             }
           }
@@ -94,7 +132,9 @@
     },
     "/leads/{leadId}": {
       "get": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Get Lead",
         "description": "Retrieve a specific lead",
         "operationId": "getLead",
@@ -103,7 +143,9 @@
             "name": "leadId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -111,14 +153,18 @@
             "description": "Lead details",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Lead"}
+                "schema": {
+                  "$ref": "#/components/schemas/Lead"
+                }
               }
             }
           }
         }
       },
       "patch": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Update Lead",
         "description": "Update lead information",
         "operationId": "updateLead",
@@ -127,14 +173,18 @@
             "name": "leadId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateLeadRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateLeadRequest"
+              }
             }
           }
         },
@@ -145,7 +195,9 @@
         }
       },
       "delete": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Delete Lead",
         "description": "Delete a lead",
         "operationId": "deleteLead",
@@ -154,7 +206,9 @@
             "name": "leadId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -166,7 +220,9 @@
     },
     "/contacts": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "List Contacts",
         "description": "Retrieve all contacts",
         "operationId": "listContacts",
@@ -174,7 +230,10 @@
           {
             "name": "limit",
             "in": "query",
-            "schema": {"type": "integer", "default": 50}
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           }
         ],
         "responses": {
@@ -184,7 +243,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {"$ref": "#/components/schemas/Contact"}
+                  "items": {
+                    "$ref": "#/components/schemas/Contact"
+                  }
                 }
               }
             }
@@ -192,7 +253,9 @@
         }
       },
       "post": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Create Contact",
         "description": "Create a new contact",
         "operationId": "createContact",
@@ -200,7 +263,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateContactRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateContactRequest"
+              }
             }
           }
         },
@@ -209,7 +274,9 @@
             "description": "Contact created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Contact"}
+                "schema": {
+                  "$ref": "#/components/schemas/Contact"
+                }
               }
             }
           }
@@ -218,7 +285,9 @@
     },
     "/contacts/{contactId}": {
       "get": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Get Contact",
         "description": "Retrieve a specific contact",
         "operationId": "getContact",
@@ -227,7 +296,9 @@
             "name": "contactId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -235,14 +306,18 @@
             "description": "Contact details",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Contact"}
+                "schema": {
+                  "$ref": "#/components/schemas/Contact"
+                }
               }
             }
           }
         }
       },
       "patch": {
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "summary": "Update Contact",
         "description": "Update contact information",
         "operationId": "updateContact",
@@ -251,14 +326,18 @@
             "name": "contactId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/UpdateContactRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/UpdateContactRequest"
+              }
             }
           }
         },
@@ -271,7 +350,9 @@
     },
     "/campaigns": {
       "get": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "List Campaigns",
         "description": "Retrieve all campaigns",
         "operationId": "listCampaigns",
@@ -282,7 +363,9 @@
               "application/json": {
                 "schema": {
                   "type": "array",
-                  "items": {"$ref": "#/components/schemas/Campaign"}
+                  "items": {
+                    "$ref": "#/components/schemas/Campaign"
+                  }
                 }
               }
             }
@@ -290,7 +373,9 @@
         }
       },
       "post": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "Create Campaign",
         "description": "Create a new campaign",
         "operationId": "createCampaign",
@@ -298,7 +383,9 @@
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/CreateCampaignRequest"}
+              "schema": {
+                "$ref": "#/components/schemas/CreateCampaignRequest"
+              }
             }
           }
         },
@@ -307,7 +394,9 @@
             "description": "Campaign created",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Campaign"}
+                "schema": {
+                  "$ref": "#/components/schemas/Campaign"
+                }
               }
             }
           }
@@ -316,7 +405,9 @@
     },
     "/campaigns/{campaignId}": {
       "get": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "Get Campaign",
         "description": "Retrieve a specific campaign",
         "operationId": "getCampaign",
@@ -325,7 +416,9 @@
             "name": "campaignId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -333,7 +426,9 @@
             "description": "Campaign details",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Campaign"}
+                "schema": {
+                  "$ref": "#/components/schemas/Campaign"
+                }
               }
             }
           }
@@ -342,7 +437,9 @@
     },
     "/campaigns/{campaignId}/start": {
       "post": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "Start Campaign",
         "description": "Start a campaign",
         "operationId": "startCampaign",
@@ -351,7 +448,9 @@
             "name": "campaignId",
             "in": "path",
             "required": true,
-            "schema": {"type": "string"}
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -363,7 +462,9 @@
     },
     "/analytics/dashboard": {
       "get": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "summary": "Get Dashboard Analytics",
         "description": "Retrieve sales dashboard analytics",
         "operationId": "getDashboardAnalytics",
@@ -371,12 +472,18 @@
           {
             "name": "start_date",
             "in": "query",
-            "schema": {"type": "string", "format": "date"}
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "end_date",
             "in": "query",
-            "schema": {"type": "string", "format": "date"}
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           }
         ],
         "responses": {
@@ -384,7 +491,9 @@
             "description": "Analytics data",
             "content": {
               "application/json": {
-                "schema": {"$ref": "#/components/schemas/Analytics"}
+                "schema": {
+                  "$ref": "#/components/schemas/Analytics"
+                }
               }
             }
           }
@@ -393,7 +502,9 @@
     },
     "/analytics/reports": {
       "post": {
-        "tags": ["Analytics"],
+        "tags": [
+          "Analytics"
+        ],
         "summary": "Generate Report",
         "description": "Generate a sales report",
         "operationId": "generateReport",
@@ -403,11 +514,26 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["report_type"],
+                "required": [
+                  "report_type"
+                ],
                 "properties": {
-                  "report_type": {"type": "string", "enum": ["leads", "conversions", "campaigns"]},
-                  "start_date": {"type": "string", "format": "date"},
-                  "end_date": {"type": "string", "format": "date"}
+                  "report_type": {
+                    "type": "string",
+                    "enum": [
+                      "leads",
+                      "conversions",
+                      "campaigns"
+                    ]
+                  },
+                  "start_date": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "end_date": {
+                    "type": "string",
+                    "format": "date"
+                  }
                 }
               }
             }
@@ -422,121 +548,232 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key"
-      }
-    },
     "schemas": {
       "Lead": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "status": {"type": "string"},
-          "source": {"type": "string"},
-          "score": {"type": "integer"},
-          "created_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          },
+          "score": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "CreateLeadRequest": {
         "type": "object",
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "phone": {"type": "string"},
-          "source": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string"
+          }
         }
       },
       "UpdateLeadRequest": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "status": {"type": "string"},
-          "score": {"type": "integer"}
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "score": {
+            "type": "integer"
+          }
         }
       },
       "Contact": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "phone": {"type": "string"},
-          "created_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "CreateContactRequest": {
         "type": "object",
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "phone": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
         }
       },
       "UpdateContactRequest": {
         "type": "object",
         "properties": {
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "phone": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
         }
       },
       "Campaign": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "status": {"type": "string", "enum": ["draft", "active", "paused", "completed"]},
-          "start_date": {"type": "string", "format": "date"},
-          "end_date": {"type": "string", "format": "date"},
-          "created_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "active",
+              "paused",
+              "completed"
+            ]
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "CreateCampaignRequest": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "start_date": {"type": "string", "format": "date"},
-          "target_leads": {"type": "array", "items": {"type": "string"}}
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "target_leads": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "Analytics": {
         "type": "object",
         "properties": {
-          "total_leads": {"type": "integer"},
-          "converted_leads": {"type": "integer"},
-          "conversion_rate": {"type": "number"},
-          "active_campaigns": {"type": "integer"},
-          "revenue": {"type": "number"}
+          "total_leads": {
+            "type": "integer"
+          },
+          "converted_leads": {
+            "type": "integer"
+          },
+          "conversion_rate": {
+            "type": "number"
+          },
+          "active_campaigns": {
+            "type": "integer"
+          },
+          "revenue": {
+            "type": "number"
+          }
         }
       },
       "Pagination": {
         "type": "object",
         "properties": {
-          "page": {"type": "integer"},
-          "per_page": {"type": "integer"},
-          "total": {"type": "integer"}
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {"type": "string"},
-          "message": {"type": "string"}
+          "page": {
+            "type": "integer"
+          },
+          "per_page": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
         }
       }
     }

--- a/apis/openapi/bubosales.com/buboai/1.0.0/openapi.json
+++ b/apis/openapi/bubosales.com/buboai/1.0.0/openapi.json
@@ -776,6 +776,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   }
 }

--- a/apis/openapi/buddypunch.com/buddy-punch-api/1.0.0/openapi.json
+++ b/apis/openapi/buddypunch.com/buddy-punch-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Buddy Punch API",
     "description": "Buddy Punch API enables integration for advanced data automation and custom reporting related to employee time tracking. Access requires Enterprise tier subscription and administrator approval.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://docs.buddypunch.com/en/articles/1266220-api-instructions"
+    "x-jentic-source-url": "https://docs.buddypunch.com/en/articles/1266220-api-instructions",
+    "contact": {}
   },
   "servers": [
     {
@@ -87,7 +88,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "api"
+        ]
       }
     },
     "/api/timesheets": {
@@ -134,8 +138,16 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "api"
+        ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "api"
+    }
+  ]
 }

--- a/apis/openapi/buffer.com/buffer-api/1.0/openapi.json
+++ b/apis/openapi/buffer.com/buffer-api/1.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Buffer API",
     "version": "1.0",
     "description": "Buffer social media scheduling API",
-    "x-jentic-source-url": "https://buffer.com/developers/api"
+    "x-jentic-source-url": "https://buffer.com/developers/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -114,7 +115,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user"
       }
     },
     "/1/profiles": {
@@ -156,7 +158,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List profiles"
       }
     },
     "/1/profiles/{id}": {
@@ -207,7 +210,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get profile"
       }
     },
     "/1/profiles/{id}/schedules": {
@@ -258,7 +262,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get posting schedules"
       }
     },
     "/1/profiles/{id}/schedules/update": {
@@ -309,7 +314,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update schedules"
       }
     },
     "/1/profiles/{id}/updates/pending": {
@@ -360,7 +366,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get pending updates"
       }
     },
     "/1/profiles/{id}/updates/sent": {
@@ -411,7 +418,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get sent updates"
       }
     },
     "/1/updates/create": {
@@ -453,7 +461,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create update"
       }
     },
     "/1/updates/{id}/update": {
@@ -504,7 +513,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update post"
       }
     },
     "/1/updates/{id}/destroy": {
@@ -555,7 +565,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete update"
       }
     },
     "/1/updates/{id}/share": {
@@ -606,7 +617,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Share update now"
       }
     },
     "/1/updates/{id}": {
@@ -657,8 +669,20 @@
               }
             }
           }
-        }
+        },
+        "description": "Get update"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Profiles"
+    },
+    {
+      "name": "Updates"
+    },
+    {
+      "name": "User"
+    }
+  ]
 }

--- a/apis/openapi/buildkite.com/buildkite-api/2.0.0/openapi.json
+++ b/apis/openapi/buildkite.com/buildkite-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Buildkite API",
     "version": "2.0.0",
     "description": "Buildkite provides CI/CD infrastructure. The REST API allows programmatic access to organizations, pipelines, builds, agents, artifacts, and more.",
-    "x-jentic-source-url": "https://buildkite.com/docs/apis/rest-api"
+    "x-jentic-source-url": "https://buildkite.com/docs/apis/rest-api",
+    "contact": {}
   },
   "servers": [
     {
@@ -43,7 +44,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List organizations"
       }
     },
     "/organizations/{org_slug}": {
@@ -87,7 +89,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get organization"
       }
     },
     "/organizations/{org_slug}/pipelines": {
@@ -145,7 +148,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List pipelines"
       },
       "post": {
         "operationId": "createPipeline",
@@ -197,7 +201,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create pipeline"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}": {
@@ -249,7 +254,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get pipeline"
       },
       "patch": {
         "operationId": "updatePipeline",
@@ -309,7 +315,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update pipeline"
       },
       "delete": {
         "operationId": "deletePipeline",
@@ -359,7 +366,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete pipeline"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds": {
@@ -439,7 +447,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List builds for pipeline"
       },
       "post": {
         "operationId": "createBuild",
@@ -499,7 +508,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create build"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}": {
@@ -559,7 +569,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get build"
       },
       "put": {
         "operationId": "rebuildBuild",
@@ -617,7 +628,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Rebuild"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}/cancel": {
@@ -677,7 +689,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel build"
       }
     },
     "/organizations/{org_slug}/builds": {
@@ -735,7 +748,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List builds for organization"
       }
     },
     "/builds": {
@@ -785,7 +799,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all builds"
       }
     },
     "/organizations/{org_slug}/agents": {
@@ -843,7 +858,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List agents"
       }
     },
     "/organizations/{org_slug}/agents/{agent_id}": {
@@ -895,7 +911,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get agent"
       },
       "put": {
         "operationId": "stopAgent",
@@ -945,7 +962,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Stop agent"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}/artifacts": {
@@ -1005,7 +1023,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List artifacts for build"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}/jobs/{job_id}/artifacts": {
@@ -1073,7 +1092,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List artifacts for job"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}/artifacts/{artifact_id}/download": {
@@ -1141,7 +1161,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download artifact"
       }
     },
     "/organizations/{org_slug}/pipelines/{pipeline_slug}/builds/{build_number}/annotations": {
@@ -1201,7 +1222,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List annotations"
       }
     },
     "/user": {
@@ -1235,7 +1257,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get current user"
       }
     },
     "/access-tokens": {
@@ -1269,7 +1292,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List access tokens"
       }
     },
     "/access-tokens/{token_uuid}": {
@@ -1313,7 +1337,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       },
       "delete": {
         "operationId": "revokeAccessToken",
@@ -1355,7 +1380,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Revoke access token"
       }
     },
     "/organizations/{org_slug}/emojis": {
@@ -1399,7 +1425,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List emojis"
       }
     },
     "/meta": {
@@ -1433,7 +1460,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get API metadata"
       }
     },
     "/organizations/{org_slug}/teams": {
@@ -1477,7 +1505,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List teams"
       },
       "post": {
         "operationId": "createTeam",
@@ -1529,7 +1558,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create team"
       }
     },
     "/organizations/{org_slug}/teams/{team_uuid}": {
@@ -1581,7 +1611,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get team"
       },
       "patch": {
         "operationId": "updateTeam",
@@ -1641,7 +1672,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update team"
       },
       "delete": {
         "operationId": "deleteTeam",
@@ -1691,7 +1723,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete team"
       }
     }
   },
@@ -1724,6 +1757,41 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Access Tokens"
+    },
+    {
+      "name": "Agents"
+    },
+    {
+      "name": "Annotations"
+    },
+    {
+      "name": "Artifacts"
+    },
+    {
+      "name": "Builds"
+    },
+    {
+      "name": "Emojis"
+    },
+    {
+      "name": "Meta"
+    },
+    {
+      "name": "Organizations"
+    },
+    {
+      "name": "Pipelines"
+    },
+    {
+      "name": "Teams"
+    },
+    {
+      "name": "User"
     }
   ]
 }

--- a/apis/openapi/builtfirst.com/builtfirst-api/1.0.0/openapi.json
+++ b/apis/openapi/builtfirst.com/builtfirst-api/1.0.0/openapi.json
@@ -732,5 +732,14 @@
         "description": "Delete document"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/builtfirst.com/builtfirst-api/1.0.0/openapi.json
+++ b/apis/openapi/builtfirst.com/builtfirst-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Builtfirst API",
     "version": "1.0.0",
     "description": "Construction project management and building operations API",
-    "x-jentic-source-url": "https://api-docs.builtfirst.com/"
+    "x-jentic-source-url": "https://api-docs.builtfirst.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -81,7 +82,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all projects"
       },
       "post": {
         "summary": "Create project",
@@ -111,7 +113,8 @@
           "201": {
             "description": "Project created"
           }
-        }
+        },
+        "description": "Create project"
       }
     },
     "/projects/{id}": {
@@ -142,7 +145,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get project by ID"
       },
       "put": {
         "summary": "Update project",
@@ -174,7 +178,8 @@
           "200": {
             "description": "Project updated"
           }
-        }
+        },
+        "description": "Update project"
       }
     },
     "/buildings": {
@@ -207,7 +212,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List buildings"
       },
       "post": {
         "summary": "Create building",
@@ -237,7 +243,8 @@
           "201": {
             "description": "Building created"
           }
-        }
+        },
+        "description": "Create building"
       }
     },
     "/buildings/{id}": {
@@ -268,7 +275,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get building by ID"
       }
     },
     "/units": {
@@ -301,7 +309,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List units"
       },
       "post": {
         "summary": "Create unit",
@@ -331,7 +340,8 @@
           "201": {
             "description": "Unit created"
           }
-        }
+        },
+        "description": "Create unit"
       }
     },
     "/units/{id}": {
@@ -362,7 +372,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get unit by ID"
       }
     },
     "/tasks": {
@@ -402,7 +413,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List tasks"
       },
       "post": {
         "summary": "Create task",
@@ -432,7 +444,8 @@
           "201": {
             "description": "Task created"
           }
-        }
+        },
+        "description": "Create task"
       }
     },
     "/tasks/{id}": {
@@ -463,7 +476,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get task by ID"
       },
       "put": {
         "summary": "Update task",
@@ -495,7 +509,8 @@
           "200": {
             "description": "Task updated"
           }
-        }
+        },
+        "description": "Update task"
       }
     },
     "/inspections": {
@@ -528,7 +543,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List inspections"
       },
       "post": {
         "summary": "Create inspection",
@@ -559,7 +575,8 @@
           "201": {
             "description": "Inspection created"
           }
-        }
+        },
+        "description": "Create inspection"
       }
     },
     "/inspections/{id}": {
@@ -590,7 +607,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get inspection by ID"
       }
     },
     "/documents": {
@@ -623,7 +641,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List documents"
       },
       "post": {
         "summary": "Upload document",
@@ -654,7 +673,8 @@
           "201": {
             "description": "Document uploaded"
           }
-        }
+        },
+        "description": "Upload document"
       }
     },
     "/documents/{id}": {
@@ -685,7 +705,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get document by ID"
       },
       "delete": {
         "summary": "Delete document",
@@ -707,30 +728,8 @@
           "204": {
             "description": "Document deleted"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key",
-        "description": "API key for authentication"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Delete document"
       }
     }
   }

--- a/apis/openapi/bulkgate.com/sms-api/1.0/openapi.json
+++ b/apis/openapi/bulkgate.com/sms-api/1.0/openapi.json
@@ -3,7 +3,8 @@
   "info": {
     "title": "BulkGate SMS API",
     "description": "BulkGate Transactional SMS API allows you to send transactional SMS messages to recipients worldwide. The API supports Unicode messages, scheduled delivery, duplicate checking, custom sender IDs, and template variables.",
-    "version": "1.0"
+    "version": "1.0",
+    "contact": {}
   },
   "servers": [
     {
@@ -57,7 +58,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "advanced"
+        ]
       }
     }
   },
@@ -204,5 +208,10 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "advanced"
+    }
+  ]
 }

--- a/apis/openapi/bullhorn.github.io/bullhorn-resume-parsing-api/1.0.0/openapi.json
+++ b/apis/openapi/bullhorn.github.io/bullhorn-resume-parsing-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Bullhorn Resume Parsing API",
     "version": "1.0.0",
     "description": "Bullhorn REST API for parsing resumes into candidate data, creating candidate entities, managing education and work history, and handling file attachments.",
-    "x-jentic-source-url": "https://bullhorn.github.io/Resume-Parsing/"
+    "x-jentic-source-url": "https://bullhorn.github.io/Resume-Parsing/",
+    "contact": {}
   },
   "servers": [
     {
@@ -139,7 +140,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a candidate"
       }
     },
     "/entity/Candidate/{candidateId}": {
@@ -184,7 +186,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a candidate"
       }
     },
     "/entity/CandidateEducation": {
@@ -221,7 +224,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create candidate education"
       }
     },
     "/entity/CandidateWorkHistory": {
@@ -258,7 +262,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create candidate work history"
       }
     },
     "/entity/Candidate/{candidateId}/primarySkills/{skillIds}": {
@@ -304,7 +309,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Add primary skills to candidate"
       }
     },
     "/options/Skill": {
@@ -334,7 +340,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List available skills"
       }
     },
     "/file/Candidate/{candidateId}/raw": {
@@ -408,7 +415,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Attach resume file to candidate"
       }
     },
     "/entityFiles/Candidate/{candidateId}": {
@@ -453,7 +461,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List candidate files"
       }
     }
   },
@@ -628,6 +637,26 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Candidates"
+    },
+    {
+      "name": "Education"
+    },
+    {
+      "name": "Files"
+    },
+    {
+      "name": "Resume"
+    },
+    {
+      "name": "Skills"
+    },
+    {
+      "name": "WorkHistory"
     }
   ]
 }

--- a/apis/openapi/burstyai.com/burstyai/1.0.0/openapi.json
+++ b/apis/openapi/burstyai.com/burstyai/1.0.0/openapi.json
@@ -3,7 +3,8 @@
   "info": {
     "title": "BurstyAI API",
     "description": "BurstyAI provides AI-powered workflow automation for SEO, content creation, lead research, and marketing operations. Each workflow supports single/bulk execution and scheduling.",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "contact": {}
   },
   "servers": [
     {
@@ -20,7 +21,9 @@
       "post": {
         "summary": "Run Topical Authority Single",
         "description": "Execute a single topical authority and blog planning workflow.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runTopicalAuthoritySingle",
         "requestBody": {
           "required": true,
@@ -51,7 +54,9 @@
       "post": {
         "summary": "Schedule Topical Authority Single",
         "description": "Schedule a single topical authority workflow execution.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "scheduleTopicalAuthoritySingle",
         "responses": {
           "200": {
@@ -64,7 +69,9 @@
       "post": {
         "summary": "Run Topical Authority Bulk",
         "description": "Execute topical authority workflow for multiple topics.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runTopicalAuthorityBulk",
         "responses": {
           "200": {
@@ -77,7 +84,9 @@
       "post": {
         "summary": "Schedule Topical Authority Bulk",
         "description": "Schedule bulk topical authority workflow execution.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "scheduleTopicalAuthorityBulk",
         "responses": {
           "200": {
@@ -90,7 +99,9 @@
       "post": {
         "summary": "Run LSI Keywords Single",
         "description": "Extract LSI keywords from top-ranking pages.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runLsiKeywordsSingle",
         "requestBody": {
           "required": true,
@@ -119,7 +130,9 @@
       "post": {
         "summary": "Schedule LSI Keywords Single",
         "description": "Schedule LSI keywords extraction.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "scheduleLsiKeywordsSingle",
         "responses": {
           "200": {
@@ -132,7 +145,9 @@
       "post": {
         "summary": "Run LSI Keywords Bulk",
         "description": "Extract LSI keywords from multiple pages.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runLsiKeywordsBulk",
         "responses": {
           "200": {
@@ -145,7 +160,9 @@
       "post": {
         "summary": "Schedule LSI Keywords Bulk",
         "description": "Schedule bulk LSI keywords extraction.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "scheduleLsiKeywordsBulk",
         "responses": {
           "200": {
@@ -158,7 +175,9 @@
       "post": {
         "summary": "Run Internal Link Extraction Single",
         "description": "Extract internal links from a website.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runInternalLinksSingle",
         "requestBody": {
           "required": true,
@@ -187,7 +206,9 @@
       "post": {
         "summary": "Schedule Internal Link Extraction Single",
         "description": "Schedule internal link extraction.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "scheduleInternalLinksSingle",
         "responses": {
           "200": {
@@ -200,7 +221,9 @@
       "post": {
         "summary": "Run Google URL Indexing Single",
         "description": "Submit URL to Google for indexing.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runGoogleIndexingSingle",
         "requestBody": {
           "required": true,
@@ -229,7 +252,9 @@
       "post": {
         "summary": "Run Google URL Indexing Bulk",
         "description": "Submit multiple URLs to Google for indexing.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runGoogleIndexingBulk",
         "responses": {
           "200": {
@@ -242,7 +267,9 @@
       "post": {
         "summary": "Run Keyword Search Intent Analysis Single",
         "description": "Analyze search intent for a keyword.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runKeywordIntentSingle",
         "requestBody": {
           "required": true,
@@ -270,7 +297,9 @@
       "post": {
         "summary": "Run Keyword Search Intent Analysis Bulk",
         "description": "Analyze search intent for multiple keywords.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runKeywordIntentBulk",
         "responses": {
           "200": {
@@ -283,7 +312,9 @@
       "post": {
         "summary": "Run AI Blog Writing Single",
         "description": "Generate an AI-written blog article.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runBlogWritingSingle",
         "requestBody": {
           "required": true,
@@ -317,7 +348,9 @@
       "post": {
         "summary": "Run AI Blog Writing Bulk",
         "description": "Generate multiple AI-written blog articles.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runBlogWritingBulk",
         "responses": {
           "200": {
@@ -330,7 +363,9 @@
       "post": {
         "summary": "Run Blog Title Generation Single",
         "description": "Generate blog titles for a topic.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runBlogTitleSingle",
         "requestBody": {
           "required": true,
@@ -358,7 +393,9 @@
       "post": {
         "summary": "Run YouTube to Blog Conversion Single",
         "description": "Convert YouTube video to blog post.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runYoutubeToBlogSingle",
         "requestBody": {
           "required": true,
@@ -387,7 +424,9 @@
       "post": {
         "summary": "Run AI Image Generation Single",
         "description": "Generate an AI image from a prompt.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runImageGenerationSingle",
         "requestBody": {
           "required": true,
@@ -415,7 +454,9 @@
       "post": {
         "summary": "Run WordPress Blog Integration Single",
         "description": "Publish content to WordPress blog.",
-        "tags": ["Content Creation"],
+        "tags": [
+          "Content Creation"
+        ],
         "operationId": "runWordpressIntegrationSingle",
         "requestBody": {
           "required": true,
@@ -447,7 +488,9 @@
       "post": {
         "summary": "Run Google Autocomplete Keywords Single",
         "description": "Get Google autocomplete keyword suggestions.",
-        "tags": ["Keyword Research"],
+        "tags": [
+          "Keyword Research"
+        ],
         "operationId": "runGoogleAutocompleteSingle",
         "requestBody": {
           "required": true,
@@ -475,7 +518,9 @@
       "post": {
         "summary": "Run Nested Google Keywords Single",
         "description": "Get nested keyword suggestions from Google.",
-        "tags": ["Keyword Research"],
+        "tags": [
+          "Keyword Research"
+        ],
         "operationId": "runNestedKeywordsSingle",
         "requestBody": {
           "required": true,
@@ -503,7 +548,9 @@
       "post": {
         "summary": "Run Google Ads Keyword Ideas Single",
         "description": "Get keyword ideas from Google Ads.",
-        "tags": ["Keyword Research"],
+        "tags": [
+          "Keyword Research"
+        ],
         "operationId": "runGoogleAdsKeywordsSingle",
         "requestBody": {
           "required": true,
@@ -531,7 +578,9 @@
       "post": {
         "summary": "Run Backlink Research Single",
         "description": "Research backlinks for a domain.",
-        "tags": ["SEO Workflows"],
+        "tags": [
+          "SEO Workflows"
+        ],
         "operationId": "runBacklinkResearchSingle",
         "requestBody": {
           "required": true,
@@ -559,7 +608,9 @@
       "post": {
         "summary": "Run Company Research Single",
         "description": "Research company information from website or LinkedIn.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runCompanyResearchSingle",
         "requestBody": {
           "required": true,
@@ -592,7 +643,9 @@
       "post": {
         "summary": "Run Company Research Bulk",
         "description": "Research multiple companies.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runCompanyResearchBulk",
         "responses": {
           "200": {
@@ -605,7 +658,9 @@
       "post": {
         "summary": "Run Lead Research Single",
         "description": "Research lead information from LinkedIn.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runLeadResearchSingle",
         "requestBody": {
           "required": true,
@@ -634,7 +689,9 @@
       "post": {
         "summary": "Run Lead Research Bulk",
         "description": "Research multiple leads from LinkedIn.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runLeadResearchBulk",
         "responses": {
           "200": {
@@ -647,7 +704,9 @@
       "post": {
         "summary": "Run Email Outreach Personalization Single",
         "description": "Personalize email outreach content.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runEmailPersonalizationSingle",
         "requestBody": {
           "required": true,
@@ -678,7 +737,9 @@
       "post": {
         "summary": "Run Email Outreach Personalization Bulk",
         "description": "Personalize email outreach for multiple recipients.",
-        "tags": ["Lead Research"],
+        "tags": [
+          "Lead Research"
+        ],
         "operationId": "runEmailPersonalizationBulk",
         "responses": {
           "200": {
@@ -691,7 +752,9 @@
       "get": {
         "summary": "Get File Download URL",
         "description": "Retrieve a download URL for a stored file.",
-        "tags": ["Utility"],
+        "tags": [
+          "Utility"
+        ],
         "operationId": "getStorageUrl",
         "parameters": [
           {
@@ -727,7 +790,9 @@
       "get": {
         "summary": "Get Workflow Job Result",
         "description": "Retrieve the result of a workflow execution job.",
-        "tags": ["Utility"],
+        "tags": [
+          "Utility"
+        ],
         "operationId": "getJobResult",
         "parameters": [
           {
@@ -759,5 +824,22 @@
         "description": "API key for authentication. Required for all endpoints."
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Content Creation"
+    },
+    {
+      "name": "Keyword Research"
+    },
+    {
+      "name": "Lead Research"
+    },
+    {
+      "name": "SEO Workflows"
+    },
+    {
+      "name": "Utility"
+    }
+  ]
 }

--- a/apis/openapi/businessfinland.fi/business-finland-api/1.0.0/openapi.json
+++ b/apis/openapi/businessfinland.fi/business-finland-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Business Finland API",
     "version": "1.0.0",
     "description": "Business Finland developer portal API for accessing Finnish business services, funding, and trade data.",
-    "x-jentic-source-url": "https://developer.businessfinland.fi/"
+    "x-jentic-source-url": "https://developer.businessfinland.fi/",
+    "contact": {}
   },
   "servers": [
     {
@@ -66,7 +67,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Services"
       }
     },
     "/services/{serviceId}": {
@@ -117,7 +119,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Service"
       }
     },
     "/funding": {
@@ -158,7 +161,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Funding Programs"
       }
     },
     "/companies": {
@@ -215,7 +219,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search Companies"
       }
     }
   },
@@ -326,6 +331,17 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Companies"
+    },
+    {
+      "name": "Funding"
+    },
+    {
+      "name": "Services"
     }
   ]
 }

--- a/apis/openapi/businesslogic.online/businesslogic-api/1.0.0/openapi.json
+++ b/apis/openapi/businesslogic.online/businesslogic-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "BusinessLogic API",
     "version": "1.0.0",
     "description": "BusinessLogic.online allows you to create APIs from Excel spreadsheets. The API enables executing webservices, retrieving input/output JSON schemas, and listing available webservices. Authentication uses an API key.",
-    "x-jentic-source-url": "https://www.businesslogic.online/docs/api"
+    "x-jentic-source-url": "https://www.businesslogic.online/docs/api",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/busybusy.com/busybusy/v3/openapi.json
+++ b/apis/openapi/busybusy.com/busybusy/v3/openapi.json
@@ -4,7 +4,8 @@
     "title": "busybusy REST API",
     "version": "3.2.0",
     "description": "The busybusy REST API provides access to time tracking, project management, and safety data for construction businesses. Supports GET, POST, and PATCH methods.",
-    "x-jentic-source-url": "https://api.busybusy.io/docs/apiv3.html"
+    "x-jentic-source-url": "https://api.busybusy.io/docs/apiv3.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -124,7 +125,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Time Entries"
       },
       "post": {
         "operationId": "createTimeEntry",
@@ -184,7 +186,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Time Entry"
       }
     },
     "/project": {
@@ -263,7 +266,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Projects"
       },
       "post": {
         "operationId": "createProject",
@@ -323,7 +327,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Project"
       }
     },
     "/member": {
@@ -378,7 +383,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Members"
       }
     },
     "/cost-code": {
@@ -433,7 +439,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Cost Codes"
       }
     },
     "/api-key": {
@@ -488,7 +495,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get API Keys"
       },
       "post": {
         "operationId": "createApiKey",
@@ -548,7 +556,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create API Key"
       }
     },
     "/certification": {
@@ -603,7 +612,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Certifications"
       },
       "post": {
         "operationId": "createCertification",
@@ -663,7 +673,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Certification"
       }
     }
   },
@@ -978,5 +989,25 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "ApiKey"
+    },
+    {
+      "name": "Certification"
+    },
+    {
+      "name": "CostCode"
+    },
+    {
+      "name": "Member"
+    },
+    {
+      "name": "Project"
+    },
+    {
+      "name": "TimeEntry"
+    }
+  ]
 }

--- a/apis/openapi/busybusy.io/busybusy/3.2/openapi.json
+++ b/apis/openapi/busybusy.io/busybusy/3.2/openapi.json
@@ -678,6 +678,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "tags": [

--- a/apis/openapi/busybusy.io/busybusy/3.2/openapi.json
+++ b/apis/openapi/busybusy.io/busybusy/3.2/openapi.json
@@ -4,7 +4,8 @@
     "title": "BusyBusy REST API",
     "version": "3.2",
     "description": "BusyBusy REST API for time tracking, project management, and workforce operations. Supports API key management, equipment tracking, certifications, cost codes, and more.",
-    "x-jentic-source-url": "https://api.busybusy.io/docs/apiv3.html"
+    "x-jentic-source-url": "https://api.busybusy.io/docs/apiv3.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -47,7 +48,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "api-key"
+        ]
       },
       "post": {
         "summary": "Create API key",
@@ -70,7 +74,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -97,7 +103,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "api-key"
+        ]
       },
       "patch": {
         "summary": "Update API key",
@@ -137,7 +146,10 @@
           "200": {
             "description": "API key updated"
           }
-        }
+        },
+        "tags": [
+          "api-key"
+        ]
       }
     },
     "/equipment": {
@@ -170,7 +182,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "equipment"
+        ]
       },
       "post": {
         "summary": "Create equipment",
@@ -193,7 +208,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["equipment_name", "equipment_model_id"],
+                "required": [
+                  "equipment_name",
+                  "equipment_model_id"
+                ],
                 "properties": {
                   "equipment_name": {
                     "type": "string"
@@ -210,7 +228,10 @@
           "201": {
             "description": "Equipment created"
           }
-        }
+        },
+        "tags": [
+          "equipment"
+        ]
       },
       "patch": {
         "summary": "Update equipment",
@@ -246,7 +267,10 @@
           "200": {
             "description": "Equipment updated"
           }
-        }
+        },
+        "tags": [
+          "equipment"
+        ]
       }
     },
     "/certification": {
@@ -279,7 +303,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "certification"
+        ]
       },
       "post": {
         "summary": "Create certification",
@@ -302,7 +329,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name"],
+                "required": [
+                  "name"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
@@ -322,7 +351,10 @@
           "201": {
             "description": "Certification created"
           }
-        }
+        },
+        "tags": [
+          "certification"
+        ]
       }
     },
     "/cost-code": {
@@ -355,7 +387,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "cost-code"
+        ]
       },
       "post": {
         "summary": "Create cost code",
@@ -378,7 +413,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["cost_code", "title"],
+                "required": [
+                  "cost_code",
+                  "title"
+                ],
                 "properties": {
                   "cost_code": {
                     "type": "string"
@@ -395,7 +433,10 @@
           "201": {
             "description": "Cost code created"
           }
-        }
+        },
+        "tags": [
+          "cost-code"
+        ]
       }
     },
     "/budget-cost": {
@@ -418,7 +459,10 @@
           "200": {
             "description": "List of budget costs"
           }
-        }
+        },
+        "tags": [
+          "budget-cost"
+        ]
       },
       "post": {
         "summary": "Create budget cost",
@@ -441,7 +485,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["project_id", "cost_budget"],
+                "required": [
+                  "project_id",
+                  "cost_budget"
+                ],
                 "properties": {
                   "project_id": {
                     "type": "integer"
@@ -458,7 +505,10 @@
           "201": {
             "description": "Budget cost created"
           }
-        }
+        },
+        "tags": [
+          "budget-cost"
+        ]
       }
     },
     "/authoritative-signature": {
@@ -481,7 +531,10 @@
           "200": {
             "description": "List of signatures"
           }
-        }
+        },
+        "tags": [
+          "authoritative-signature"
+        ]
       },
       "post": {
         "summary": "Create authoritative signature",
@@ -504,7 +557,11 @@
             "multipart/form-data": {
               "schema": {
                 "type": "object",
-                "required": ["member_id", "created_on", "signature"],
+                "required": [
+                  "member_id",
+                  "created_on",
+                  "signature"
+                ],
                 "properties": {
                   "member_id": {
                     "type": "integer"
@@ -526,19 +583,14 @@
           "201": {
             "description": "Signature created"
           }
-        }
+        },
+        "tags": [
+          "authoritative-signature"
+        ]
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "API key for authentication"
-      }
-    },
     "schemas": {
       "ApiKey": {
         "type": "object",
@@ -625,23 +677,27 @@
             "format": "date-time"
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "object",
-            "properties": {
-              "message": {
-                "type": "string"
-              },
-              "code": {
-                "type": "string"
-              }
-            }
-          }
-        }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "api-key"
+    },
+    {
+      "name": "authoritative-signature"
+    },
+    {
+      "name": "budget-cost"
+    },
+    {
+      "name": "certification"
+    },
+    {
+      "name": "cost-code"
+    },
+    {
+      "name": "equipment"
+    }
+  ]
 }

--- a/apis/openapi/buymeacoffee.com/buymeacoffee-api/1.0.0/openapi.json
+++ b/apis/openapi/buymeacoffee.com/buymeacoffee-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Buy Me a Coffee API",
     "version": "1.0.0",
     "description": "Buy Me a Coffee is a creator support platform. The API allows retrieving supporters, members, and extras data. Authentication uses a Bearer token.",
-    "x-jentic-source-url": "https://developers.buymeacoffee.com/"
+    "x-jentic-source-url": "https://developers.buymeacoffee.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -133,7 +134,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a one-time supporter by ID"
       }
     },
     "/subscriptions": {
@@ -249,7 +251,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a member by ID"
       }
     },
     "/extras": {


### PR DESCRIPTION
## Summary

Spectral-lint clean **50** OpenAPI specs. All specs now pass `spectral lint` with the default `spectral:oas` ruleset with zero warnings and zero errors.

### Fixes Applied

| Rule | Specs Fixed |
|------|-------------|
| info-contact | 40 |
| operation-tag-defined | 40 |
| operation-description | 26 |
| operation-tags | 8 |
| unused-components | 5 |
| operation-operationId | 2 |
| info-description | 2 |
| path-keys-no-trailing-slash | 1 |

### APIs Fixed

- billetto.com/billetto
- billplz.com/billplz-api
- bimbala.com/bimbala-api
- biodiversitydata.se/biodiversity-data-api
- bitbadges.io/bitbadges-api
- bitcoinaverage.com/bitcoinaverage-api
- bitfinex.com/bitfinex-api
- bitskout.com/bitskout-zapier-api
- bittrex.com/bittrex-api
- biztoc.com/biztoc
- blackbaud.com/blackbaud
- blip.ai/blip-api
- blockchain.com/blockchain-api
- bloomgrowth.com/bloom-growth-api
- blueink.com/blueink-api
- bluemix.net/ibm-containers-api
- bluesnap.com/bluesnap-payment-api
- boast.io/boast-api
- bokio.se/bokio-api
- bokun.io/bokun-api
- bolna.ai/bolna-api
- bond.tech/bond-api
- bondradar.com/bondradar
- bonusly.com/bonusly-api
- booking.com/booking
- bookingsync.com/bookingsync-api
- boschrexroth.github.io/rest-api
- botcake.io/botcake-1
- botschaft.local/fastapi
- bpaygroup.com.au/bpaygroup
- brainbi.net/brainbi-api
- brainbi.net/brainbi
- braincert.com/virtual-classroom-api
- bri.co.id/bri-api
- bridgedb.org/bridgedb-webservices
- brightcove.com/brightcove-platform-api
- btcturk.com/btcturk-api
- bubosales.com/buboai
- buddypunch.com/buddy-punch-api
- buffer.com/buffer-api
- buildkite.com/buildkite-api
- builtfirst.com/builtfirst-api
- bulkgate.com/sms-api
- bullhorn.github.io/bullhorn-resume-parsing-api
- burstyai.com/burstyai
- businessfinland.fi/business-finland-api
- businesslogic.online/businesslogic-api
- busybusy.com/busybusy
- busybusy.io/busybusy
- buymeacoffee.com/buymeacoffee-api

## Test plan
- [x] All 50 specs pass `spectral lint` after fixes
