### PR TITLE
Spectral-lint clean 50 OpenAPI specs (batch 008)

### DIFF
--- a/apis/openapi/code-scan.com/codescan-api/1.0.0/openapi.json
+++ b/apis/openapi/code-scan.com/codescan-api/1.0.0/openapi.json
@@ -80,7 +80,11 @@
             "codescan_auth": []
           }
         ],
-        "summary": "Get the status of a job"
+        "summary": "Get the status of a job",
+        "tags": [
+          "job"
+        ],
+        "operationId": "get-job"
       },
       "post": {
         "description": "Creates a new job",
@@ -114,7 +118,11 @@
             "codescan_auth": []
           }
         ],
-        "summary": "Queues a job"
+        "summary": "Queues a job",
+        "tags": [
+          "job"
+        ],
+        "operationId": "post-job"
       }
     }
   },
@@ -232,5 +240,10 @@
       ],
       "type": "object"
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "job"
+    }
+  ]
 }

--- a/apis/openapi/codeclimate.com/quality-api/1.0.0/openapi.json
+++ b/apis/openapi/codeclimate.com/quality-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Code Climate Quality API",
     "version": "1.0.0",
     "description": "Code Climate (now Qlty) provides a REST API for managing code quality projects, issues, metrics, workspaces, and user information. Uses Bearer token authentication.",
-    "x-jentic-source-url": "https://api.codeclimate.com/v1/"
+    "x-jentic-source-url": "https://api.codeclimate.com/v1/",
+    "contact": {}
   },
   "paths": {
     "/gh/{ownerKeyOrId}/projects/{projectKeyOrId}/issues": {
@@ -892,24 +893,20 @@
             "description": "Human-readable description of the issue"
           },
           "category": {
-            "$ref": "#/components/schemas/type_common:MiniIssueCategory",
-            "description": "The category of the issue"
+            "$ref": "#/components/schemas/type_common:MiniIssueCategory"
           },
           "level": {
-            "$ref": "#/components/schemas/type_common:MiniLevel",
-            "description": "The severity level of the issue"
+            "$ref": "#/components/schemas/type_common:MiniLevel"
           },
           "status": {
-            "$ref": "#/components/schemas/type_common:MiniIssueStatus",
-            "description": "The current workflow status of the issue"
+            "$ref": "#/components/schemas/type_common:MiniIssueStatus"
           },
           "documentationUrl": {
             "type": "string",
             "description": "URL to documentation about this issue type or rule"
           },
           "location": {
-            "$ref": "#/components/schemas/type_issues:MiniLocation",
-            "description": "Information about where the issue was found in the codebase"
+            "$ref": "#/components/schemas/type_issues:MiniLocation"
           }
         },
         "required": [
@@ -949,8 +946,7 @@
             "description": "List of Issue items returned in the response"
           },
           "meta": {
-            "$ref": "#/components/schemas/type_common:PaginationMeta",
-            "description": "Pagination metadata for the response"
+            "$ref": "#/components/schemas/type_common:PaginationMeta"
           }
         },
         "required": [
@@ -979,30 +975,6 @@
           "status"
         ],
         "title": "ErrorBody"
-      },
-      "type_metrics:TShirtSize": {
-        "type": "string",
-        "enum": [
-          "XS",
-          "S",
-          "M",
-          "L",
-          "XL"
-        ],
-        "description": "T-shirt sizes for metrics, where XS is the smallest and XL is the largest",
-        "title": "TShirtSize"
-      },
-      "type_metrics:LetterRating": {
-        "type": "string",
-        "enum": [
-          "A",
-          "B",
-          "C",
-          "D",
-          "F"
-        ],
-        "description": "Letter ratings for metrics, where A is the best and F is the worst",
-        "title": "LetterRating"
       },
       "type_metrics:MeasureValue": {
         "description": "The metric value which can be a number, T-shirt size (XS-XL), or letter rating (A-F)",
@@ -1053,8 +1025,7 @@
             "description": "The category of the metric (e.g., maintainability, reliability, security)"
           },
           "value": {
-            "$ref": "#/components/schemas/type_metrics:MeasureValue",
-            "description": "The latest value of the metric, which can be a float, T-shirt size, or letter rating"
+            "$ref": "#/components/schemas/type_metrics:MeasureValue"
           },
           "inverted": {
             "type": "boolean",
@@ -1130,8 +1101,7 @@
             "description": "List of Project items returned in the response"
           },
           "meta": {
-            "$ref": "#/components/schemas/type_common:PaginationMeta",
-            "description": "Pagination metadata for the response"
+            "$ref": "#/components/schemas/type_common:PaginationMeta"
           }
         },
         "required": [
@@ -1241,8 +1211,7 @@
             "description": "List of Workspace items returned in the response"
           },
           "meta": {
-            "$ref": "#/components/schemas/type_common:PaginationMeta",
-            "description": "Pagination metadata for the response"
+            "$ref": "#/components/schemas/type_common:PaginationMeta"
           }
         },
         "required": [
@@ -1250,40 +1219,29 @@
           "meta"
         ],
         "title": "ListWorkspacesResponse"
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string",
-            "description": "The HTTP status code of the error"
-          },
-          "title": {
-            "type": "string",
-            "description": "A short, human-readable summary of the error"
-          },
-          "detail": {
-            "type": "string",
-            "description": "A detailed explanation of the error"
-          }
-        },
-        "required": [
-          "status"
-        ],
-        "title": "ErrorBody"
-      }
-    },
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "Bearer token authentication"
       }
     }
   },
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "subpackage_issues"
+    },
+    {
+      "name": "subpackage_metrics"
+    },
+    {
+      "name": "subpackage_projects"
+    },
+    {
+      "name": "subpackage_user"
+    },
+    {
+      "name": "subpackage_workspaces"
     }
   ]
 }

--- a/apis/openapi/codeclimate.com/quality-api/1.0.0/openapi.json
+++ b/apis/openapi/codeclimate.com/quality-api/1.0.0/openapi.json
@@ -1220,6 +1220,12 @@
         ],
         "title": "ListWorkspacesResponse"
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   },
   "security": [

--- a/apis/openapi/cognisantmd.com/ocean-health-api/1.0.0/openapi.json
+++ b/apis/openapi/cognisantmd.com/ocean-health-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Ocean Health Platform API",
     "version": "1.0.0",
     "description": "Ocean by CognisantMD provides a health platform API for eReferrals, eConsults, and patient engagement in healthcare.",
-    "x-jentic-source-url": "https://ocean.cognisantmd.com/public/apiDocs.html"
+    "x-jentic-source-url": "https://ocean.cognisantmd.com/public/apiDocs.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -76,7 +77,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search patients"
       }
     },
     "/fhir/v1/Patient/{patientId}": {
@@ -127,7 +129,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get patient details"
       }
     },
     "/fhir/v1/ServiceRequest": {
@@ -229,7 +232,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search referrals"
       }
     },
     "/fhir/v1/ServiceRequest/{referralId}": {
@@ -280,7 +284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get referral details"
       }
     },
     "/api/v1/sites": {
@@ -364,6 +369,17 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Patients"
+    },
+    {
+      "name": "Referrals"
+    },
+    {
+      "name": "Sites"
     }
   ]
 }

--- a/apis/openapi/cognitivefashion.github.io/ibm-ai-for-fashion-api/1.0.0/openapi.json
+++ b/apis/openapi/cognitivefashion.github.io/ibm-ai-for-fashion-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "IBM Research AI for Fashion API",
     "version": "1.0.0",
     "description": "Provides catalog management, visual search, visual browse, and text search for fashion products.",
-    "x-jentic-source-url": "https://cognitivefashion.github.io/slate/"
+    "x-jentic-source-url": "https://cognitivefashion.github.io/slate/",
+    "contact": {}
   },
   "servers": [
     {
@@ -50,7 +51,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a fashion quote"
       }
     },
     "/catalog_names": {
@@ -91,7 +93,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List catalog names"
       }
     },
     "/catalog/{catalog_name}": {
@@ -152,7 +155,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add catalog metadata"
       },
       "get": {
         "operationId": "getCatalogInfo",
@@ -201,7 +205,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get catalog info"
       },
       "delete": {
         "operationId": "deleteCatalog",
@@ -258,7 +263,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete catalog"
       }
     },
     "/catalog/{catalog_name}/products/{id}": {
@@ -335,7 +341,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add product"
       },
       "get": {
         "operationId": "getProduct",
@@ -392,7 +399,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get product"
       },
       "put": {
         "operationId": "updateProduct",
@@ -459,7 +467,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update product"
       },
       "delete": {
         "operationId": "deleteProduct",
@@ -516,7 +525,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete product"
       }
     },
     "/catalog/{catalog_name}/text_search": {
@@ -583,7 +593,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Text search"
       }
     },
     "/catalog/{catalog_name}/visual_search_index": {
@@ -634,7 +645,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Build visual search index"
       },
       "get": {
         "operationId": "getVisualSearchIndexStatus",
@@ -683,7 +695,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get index status"
       },
       "delete": {
         "operationId": "deleteVisualSearchIndex",
@@ -732,7 +745,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete index"
       }
     },
     "/catalog/{catalog_name}/visual_browse/{id}/{image_id}": {
@@ -807,7 +821,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Visual browse similar products"
       }
     },
     "/catalog/{catalog_name}/visual_search": {
@@ -882,7 +897,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Visual search by image"
       }
     }
   },
@@ -999,6 +1015,23 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Catalogs"
+    },
+    {
+      "name": "General"
+    },
+    {
+      "name": "Products"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Visual Search"
     }
   ]
 }

--- a/apis/openapi/cohere.com/cohere-api/1.0/openapi.json
+++ b/apis/openapi/cohere.com/cohere-api/1.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cohere API",
     "version": "1.0",
     "description": "The Cohere API for interacting with Chat, Embed, and Rerank models. Provides endpoints for text generation, embeddings, and reranking.",
-    "x-jentic-source-url": "https://docs.cohere.com/reference/about"
+    "x-jentic-source-url": "https://docs.cohere.com/reference/about",
+    "contact": {}
   },
   "servers": [
     {
@@ -361,6 +362,17 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Chat"
+    },
+    {
+      "name": "Embed"
+    },
+    {
+      "name": "Rerank"
     }
   ]
 }

--- a/apis/openapi/coindcx.com/coindcx-api/1.0.0/openapi.json
+++ b/apis/openapi/coindcx.com/coindcx-api/1.0.0/openapi.json
@@ -48,7 +48,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-exchange-ticker"
       }
     },
     "/exchange/v1/markets": {
@@ -73,7 +74,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-exchange-v1-markets"
       }
     },
     "/exchange/v1/markets_details": {
@@ -98,7 +100,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-exchange-v1-markets-details"
       }
     },
     "/market_data/trade_history": {
@@ -143,7 +146,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-market-data-trade-history"
       }
     },
     "/market_data/orderbook": {
@@ -176,7 +180,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-market-data-orderbook"
       }
     },
     "/market_data/candles": {
@@ -255,7 +260,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "get-market-data-candles"
       }
     },
     "/exchange/v1/users/balances": {
@@ -298,7 +304,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-exchange-v1-users-balances"
       }
     },
     "/exchange/v1/users/info": {
@@ -337,7 +344,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-exchange-v1-users-info"
       }
     },
     "/exchange/v1/orders/create": {
@@ -407,7 +415,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-create"
       }
     },
     "/exchange/v1/orders/create_multiple": {
@@ -439,7 +448,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-create-multiple"
       }
     },
     "/exchange/v1/orders/status": {
@@ -477,7 +487,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-status"
       }
     },
     "/exchange/v1/orders/active_orders": {
@@ -516,7 +527,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-active-orders"
       }
     },
     "/exchange/v1/orders/cancel": {
@@ -554,7 +566,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-cancel"
       }
     },
     "/exchange/v1/orders/cancel_all": {
@@ -593,7 +606,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-cancel-all"
       }
     },
     "/exchange/v1/orders/cancel_by_ids": {
@@ -631,7 +645,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-cancel-by-ids"
       }
     },
     "/exchange/v1/orders/edit": {
@@ -671,7 +686,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-edit"
       }
     },
     "/exchange/v1/orders/trade_history": {
@@ -721,7 +737,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-orders-trade-history"
       }
     },
     "/exchange/v1/funding/lend": {
@@ -765,7 +782,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-funding-lend"
       }
     },
     "/exchange/v1/funding/settle": {
@@ -801,7 +819,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-funding-settle"
       }
     },
     "/exchange/v1/margin/orders/create": {
@@ -862,7 +881,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-margin-orders-create"
       }
     },
     "/exchange/v1/margin/orders/cancel": {
@@ -897,7 +917,9 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "Cancel Margin Order",
+        "operationId": "post-exchange-v1-margin-orders-cancel"
       }
     },
     "/exchange/v1/margin/orders/exit": {
@@ -932,7 +954,9 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "Exit Margin Position",
+        "operationId": "post-exchange-v1-margin-orders-exit"
       }
     },
     "/exchange/v1/wallets/transfer": {
@@ -980,7 +1004,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "post-exchange-v1-wallets-transfer"
       }
     }
   },
@@ -1109,5 +1134,25 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Lending"
+    },
+    {
+      "name": "Margin"
+    },
+    {
+      "name": "Market Data"
+    },
+    {
+      "name": "Spot Orders"
+    },
+    {
+      "name": "Wallet"
+    }
+  ]
 }

--- a/apis/openapi/coinigy.com/coinigy-api/1.0.0/openapi.json
+++ b/apis/openapi/coinigy.com/coinigy-api/1.0.0/openapi.json
@@ -40,7 +40,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-userinfo"
       }
     },
     "/activity": {
@@ -61,7 +62,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-activity"
       }
     },
     "/pushNotifications": {
@@ -75,7 +77,8 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "operationId": "get-pushnotifications"
       }
     },
     "/accounts": {
@@ -96,7 +99,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-accounts"
       }
     },
     "/balances": {
@@ -140,7 +144,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-balances"
       }
     },
     "/balanceHistory": {
@@ -177,7 +182,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-balancehistory"
       }
     },
     "/orders": {
@@ -198,7 +204,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-orders"
       }
     },
     "/alerts": {
@@ -219,7 +226,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-alerts"
       }
     },
     "/userWatchList": {
@@ -240,7 +248,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-userwatchlist"
       }
     },
     "/newsFeed": {
@@ -261,7 +270,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-newsfeed"
       }
     },
     "/updateUser": {
@@ -324,7 +334,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-updateuser"
       }
     },
     "/savePrefs": {
@@ -392,7 +403,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-saveprefs"
       }
     },
     "/updateTickers": {
@@ -429,7 +441,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-updatetickers"
       }
     },
     "/orderTypes": {
@@ -450,7 +463,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-ordertypes"
       }
     },
     "/refreshBalance": {
@@ -490,7 +504,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-refreshbalance"
       }
     },
     "/addAlert": {
@@ -544,7 +559,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-addalert"
       }
     },
     "/deleteAlert": {
@@ -583,7 +599,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-deletealert"
       }
     },
     "/addApiKey": {
@@ -636,7 +653,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-addapikey"
       }
     },
     "/deleteApiKey": {
@@ -675,7 +693,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-deleteapikey"
       }
     },
     "/activateApiKey": {
@@ -722,7 +741,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-activateapikey"
       }
     },
     "/activateTradingKey": {
@@ -769,7 +789,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-activatetradingkey"
       }
     },
     "/addOrder": {
@@ -839,7 +860,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-addorder"
       }
     },
     "/cancelOrder": {
@@ -878,7 +900,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-cancelorder"
       }
     },
     "/exchanges": {
@@ -899,7 +922,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-exchanges"
       }
     },
     "/markets": {
@@ -939,7 +963,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-markets"
       }
     },
     "/data": {
@@ -996,7 +1021,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-data"
       }
     },
     "/ticker": {
@@ -1039,7 +1065,8 @@
               }
             }
           }
-        }
+        },
+        "operationId": "post-ticker"
       }
     }
   },
@@ -1103,5 +1130,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Account Data"
+    },
+    {
+      "name": "Account Functions"
+    },
+    {
+      "name": "Market Data"
+    }
+  ]
 }

--- a/apis/openapi/coinlayer.com/coinlayer-api/1.0.0/openapi.json
+++ b/apis/openapi/coinlayer.com/coinlayer-api/1.0.0/openapi.json
@@ -66,7 +66,10 @@
             "description": "Set to 1 to expand rate objects to include additional details such as volume, market cap, and percentage changes.",
             "schema": {
               "type": "integer",
-              "enum": [0, 1]
+              "enum": [
+                0,
+                1
+              ]
             }
           }
         ],
@@ -81,7 +84,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "live"
+        ]
       }
     },
     "/historical": {
@@ -135,7 +141,10 @@
             "description": "Set to 1 to include additional details.",
             "schema": {
               "type": "integer",
-              "enum": [0, 1]
+              "enum": [
+                0,
+                1
+              ]
             }
           }
         ],
@@ -150,7 +159,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "historical"
+        ]
       }
     },
     "/convert": {
@@ -217,7 +229,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "convert"
+        ]
       }
     },
     "/timeframe": {
@@ -286,7 +301,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "timeframe"
+        ]
       }
     },
     "/change": {
@@ -355,7 +373,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "change"
+        ]
       }
     },
     "/list": {
@@ -385,19 +406,14 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "list"
+        ]
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "query",
-        "name": "access_key",
-        "description": "API access key obtained from your Coinlayer account dashboard."
-      }
-    },
     "schemas": {
       "LiveResponse": {
         "type": "object",
@@ -633,33 +649,27 @@
             "description": "Object containing all supported fiat currencies."
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "example": false
-          },
-          "error": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "integer",
-                "description": "Error code."
-              },
-              "type": {
-                "type": "string",
-                "description": "Error type identifier."
-              },
-              "info": {
-                "type": "string",
-                "description": "Human-readable error description."
-              }
-            }
-          }
-        }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "change"
+    },
+    {
+      "name": "convert"
+    },
+    {
+      "name": "historical"
+    },
+    {
+      "name": "list"
+    },
+    {
+      "name": "live"
+    },
+    {
+      "name": "timeframe"
+    }
+  ]
 }

--- a/apis/openapi/coinlayer.com/coinlayer-api/1.0.0/openapi.json
+++ b/apis/openapi/coinlayer.com/coinlayer-api/1.0.0/openapi.json
@@ -650,6 +650,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "tags": [

--- a/apis/openapi/coinlib.io/coinlib-api/1.0.0/openapi.json
+++ b/apis/openapi/coinlib.io/coinlib-api/1.0.0/openapi.json
@@ -83,7 +83,8 @@
           "429": {
             "description": "Rate limit exceeded"
           }
-        }
+        },
+        "operationId": "get-global"
       }
     },
     "/coinlist": {
@@ -189,7 +190,8 @@
           "429": {
             "description": "Rate limit exceeded"
           }
-        }
+        },
+        "operationId": "get-coinlist"
       }
     },
     "/coin": {
@@ -311,7 +313,8 @@
           "429": {
             "description": "Rate limit exceeded"
           }
-        }
+        },
+        "operationId": "get-coin"
       }
     }
   },
@@ -324,5 +327,10 @@
         "description": "API key obtained from Coinlib profile page"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Market Data"
+    }
+  ]
 }

--- a/apis/openapi/coinlore.com/coinlore-api/1.0.0/openapi.json
+++ b/apis/openapi/coinlore.com/coinlore-api/1.0.0/openapi.json
@@ -34,7 +34,7 @@
     }
   ],
   "paths": {
-    "/api/global/": {
+    "/api/global": {
       "get": {
         "tags": [
           "Global"
@@ -79,7 +79,7 @@
         }
       }
     },
-    "/api/tickers/": {
+    "/api/tickers": {
       "get": {
         "tags": [
           "Coins"
@@ -146,7 +146,7 @@
         }
       }
     },
-    "/api/ticker/": {
+    "/api/ticker": {
       "get": {
         "tags": [
           "Coins"
@@ -203,7 +203,7 @@
         }
       }
     },
-    "/api/coin/markets/": {
+    "/api/coin/markets": {
       "get": {
         "tags": [
           "Coins"
@@ -260,7 +260,7 @@
         }
       }
     },
-    "/api/exchanges/": {
+    "/api/exchanges": {
       "get": {
         "tags": [
           "Exchanges"
@@ -305,7 +305,7 @@
         }
       }
     },
-    "/api/exchange/": {
+    "/api/exchange": {
       "get": {
         "tags": [
           "Exchanges"
@@ -359,7 +359,7 @@
         }
       }
     },
-    "/api/coin/social_stats/": {
+    "/api/coin/social_stats": {
       "get": {
         "tags": [
           "Social"

--- a/apis/openapi/coinmarketcap.com/coinmarketcap-api/1.0.0/openapi.json
+++ b/apis/openapi/coinmarketcap.com/coinmarketcap-api/1.0.0/openapi.json
@@ -30,43 +30,73 @@
         "operationId": "getCryptoMap",
         "summary": "CoinMarketCap ID Map",
         "description": "Returns a mapping of all cryptocurrencies to unique CoinMarketCap IDs.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "listing_status",
             "in": "query",
             "description": "Only active cryptocurrencies are returned by default. Pass 'inactive' to get a list of cryptocurrencies that are no longer active. Pass 'untracked' to get a list of cryptocurrencies that are listed but do not yet meet methodology requirements.",
-            "schema": { "type": "string", "default": "active", "enum": ["active", "inactive", "untracked"] }
+            "schema": {
+              "type": "string",
+              "default": "active",
+              "enum": [
+                "active",
+                "inactive",
+                "untracked"
+              ]
+            }
           },
           {
             "name": "start",
             "in": "query",
             "description": "Optionally offset the start (1-based index) of the paginated list of items to return.",
-            "schema": { "type": "integer", "minimum": 1, "default": 1 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "Optionally specify the number of results to return.",
-            "schema": { "type": "integer", "minimum": 1, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5000
+            }
           },
           {
             "name": "sort",
             "in": "query",
             "description": "What field to sort the list by.",
-            "schema": { "type": "string", "enum": ["cmc_rank", "id"], "default": "id" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cmc_rank",
+                "id"
+              ],
+              "default": "id"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
             "description": "Optionally pass a comma-separated list of cryptocurrency symbols to return.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
             "description": "Optionally specify a comma-separated list of supplemental data fields to return.",
-            "schema": { "type": "string", "default": "platform,first_historical_data,last_historical_data,is_active" }
+            "schema": {
+              "type": "string",
+              "default": "platform,first_historical_data,last_historical_data,is_active"
+            }
           }
         ],
         "responses": {
@@ -80,9 +110,15 @@
               }
             }
           },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" },
-          "429": { "description": "Too many requests" }
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          }
         }
       }
     },
@@ -91,43 +127,62 @@
         "operationId": "getCryptoInfo",
         "summary": "Metadata",
         "description": "Returns all static metadata available for one or more cryptocurrencies.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
             "description": "One or more comma-separated CoinMarketCap cryptocurrency IDs.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
             "description": "One or more comma-separated cryptocurrency slugs.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
             "description": "One or more comma-separated cryptocurrency symbols.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "address",
             "in": "query",
             "description": "One or more comma-separated contract addresses.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
             "description": "Optionally specify a comma-separated list of supplemental data fields to return.",
-            "schema": { "type": "string", "default": "urls,logo,description,tags,platform,date_added,notice" }
+            "schema": {
+              "type": "string",
+              "default": "urls,logo,description,tags,platform,date_added,notice"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -136,112 +191,196 @@
         "operationId": "getListingsLatest",
         "summary": "Listings Latest",
         "description": "Returns a paginated list of all active cryptocurrencies with latest market data.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "minimum": 1, "default": 1 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "minimum": 1, "maximum": 5000, "default": 100 }
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 5000,
+              "default": 100
+            }
           },
           {
             "name": "price_min",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "price_max",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "market_cap_min",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "market_cap_max",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "volume_24h_min",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "volume_24h_max",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "circulating_supply_min",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "circulating_supply_max",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "percent_change_24h_min",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "percent_change_24h_max",
             "in": "query",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "convert",
             "in": "query",
             "description": "Optionally calculate market quotes in up to 120 currencies.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
             "description": "Optionally calculate market quotes by CoinMarketCap ID instead of symbol.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["name", "symbol", "date_added", "market_cap", "market_cap_strict", "price", "circulating_supply", "total_supply", "max_supply", "num_market_pairs", "volume_24h", "percent_change_1h", "percent_change_24h", "percent_change_7d", "market_cap_by_total_supply_strict", "volume_7d", "volume_30d"], "default": "market_cap" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "symbol",
+                "date_added",
+                "market_cap",
+                "market_cap_strict",
+                "price",
+                "circulating_supply",
+                "total_supply",
+                "max_supply",
+                "num_market_pairs",
+                "volume_24h",
+                "percent_change_1h",
+                "percent_change_24h",
+                "percent_change_7d",
+                "market_cap_by_total_supply_strict",
+                "volume_7d",
+                "volume_30d"
+              ],
+              "default": "market_cap"
+            }
           },
           {
             "name": "sort_dir",
             "in": "query",
-            "schema": { "type": "string", "enum": ["asc", "desc"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           },
           {
             "name": "cryptocurrency_type",
             "in": "query",
-            "schema": { "type": "string", "enum": ["all", "coins", "tokens"], "default": "all" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "coins",
+                "tokens"
+              ],
+              "default": "all"
+            }
           },
           {
             "name": "tag",
             "in": "query",
             "description": "Filter by tag such as 'defi' or 'filesharing'.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string", "default": "num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply" }
+            "schema": {
+              "type": "string",
+              "default": "num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" },
-          "429": { "description": "Too many requests" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Too many requests"
+          }
         }
       }
     },
@@ -250,59 +389,115 @@
         "operationId": "getListingsHistorical",
         "summary": "Listings Historical",
         "description": "Returns a ranked and sorted list of all cryptocurrencies for a historical UTC date.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "date",
             "in": "query",
             "description": "Date (ISO 8601) to reference day of snapshot.",
-            "schema": { "type": "string", "format": "date" }
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
           },
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 100, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 100,
+              "maximum": 5000
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["cmc_rank", "name", "symbol", "market_cap", "price", "circulating_supply", "total_supply", "max_supply", "num_market_pairs", "volume_24h", "percent_change_1h", "percent_change_24h", "percent_change_7d"], "default": "cmc_rank" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "cmc_rank",
+                "name",
+                "symbol",
+                "market_cap",
+                "price",
+                "circulating_supply",
+                "total_supply",
+                "max_supply",
+                "num_market_pairs",
+                "volume_24h",
+                "percent_change_1h",
+                "percent_change_24h",
+                "percent_change_7d"
+              ],
+              "default": "cmc_rank"
+            }
           },
           {
             "name": "sort_dir",
             "in": "query",
-            "schema": { "type": "string", "enum": ["asc", "desc"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           },
           {
             "name": "cryptocurrency_type",
             "in": "query",
-            "schema": { "type": "string", "enum": ["all", "coins", "tokens"], "default": "all" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "coins",
+                "tokens"
+              ],
+              "default": "all"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -311,49 +506,73 @@
         "operationId": "getQuotesLatest",
         "summary": "Quotes Latest",
         "description": "Returns the latest market quote for 1 or more cryptocurrencies.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
             "description": "One or more comma-separated cryptocurrency CoinMarketCap IDs.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string", "default": "num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply,market_cap_by_total_supply,volume_24h_reported,volume_7d,volume_7d_reported,volume_30d,volume_30d_reported,is_active,is_fiat" }
+            "schema": {
+              "type": "string",
+              "default": "num_market_pairs,cmc_rank,date_added,tags,platform,max_supply,circulating_supply,total_supply,market_cap_by_total_supply,volume_24h_reported,volume_7d,volume_7d_reported,volume_30d,volume_30d_reported,is_active,is_fiat"
+            }
           },
           {
             "name": "skip_invalid",
             "in": "query",
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -362,63 +581,120 @@
         "operationId": "getQuotesHistorical",
         "summary": "Quotes Historical",
         "description": "Returns an interval of historic market quotes for any cryptocurrency based on time and interval parameters.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_start",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_end",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "count",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "interval",
             "in": "query",
-            "schema": { "type": "string", "enum": ["yearly", "monthly", "weekly", "daily", "hourly", "5m", "10m", "15m", "30m", "45m", "1h", "2h", "3h", "4h", "6h", "12h", "24h", "1d", "2d", "3d", "7d", "14d", "15d", "30d", "60d", "90d", "365d"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "yearly",
+                "monthly",
+                "weekly",
+                "daily",
+                "hourly",
+                "5m",
+                "10m",
+                "15m",
+                "30m",
+                "45m",
+                "1h",
+                "2h",
+                "3h",
+                "4h",
+                "6h",
+                "12h",
+                "24h",
+                "1d",
+                "2d",
+                "3d",
+                "7d",
+                "14d",
+                "15d",
+                "30d",
+                "60d",
+                "90d",
+                "365d"
+              ]
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "skip_invalid",
             "in": "query",
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -427,38 +703,56 @@
         "operationId": "getOhlcvLatest",
         "summary": "OHLCV Latest",
         "description": "Returns the latest OHLCV (Open, High, Low, Close, Volume) market values for one or more cryptocurrencies.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "skip_invalid",
             "in": "query",
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -467,63 +761,97 @@
         "operationId": "getOhlcvHistorical",
         "summary": "OHLCV Historical",
         "description": "Returns historical OHLCV data along with market cap for any cryptocurrency.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_start",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_end",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_period",
             "in": "query",
-            "schema": { "type": "string", "enum": ["daily", "hourly", "weekly", "monthly"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "daily",
+                "hourly",
+                "weekly",
+                "monthly"
+              ]
+            }
           },
           {
             "name": "count",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "interval",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "skip_invalid",
             "in": "query",
-            "schema": { "type": "boolean" }
+            "schema": {
+              "type": "boolean"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -532,83 +860,148 @@
         "operationId": "getMarketPairsLatest",
         "summary": "Market Pairs Latest",
         "description": "Lists all active market pairs that CoinMarketCap tracks for a given cryptocurrency or exchange.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
           },
           {
             "name": "sort_dir",
             "in": "query",
-            "schema": { "type": "string", "enum": ["asc", "desc"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["volume_24h_strict", "cmc_rank", "cmc_rank_advanced", "effective_liquidity", "market_score", "market_reputation"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "volume_24h_strict",
+                "cmc_rank",
+                "cmc_rank_advanced",
+                "effective_liquidity",
+                "market_score",
+                "market_reputation"
+              ]
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "matched_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "matched_symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "category",
             "in": "query",
-            "schema": { "type": "string", "enum": ["all", "spot", "derivatives", "otc"], "default": "all" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "spot",
+                "derivatives",
+                "otc"
+              ],
+              "default": "all"
+            }
           },
           {
             "name": "fee_type",
             "in": "query",
-            "schema": { "type": "string", "enum": ["all", "percentage", "no-fees", "transactional-mining", "unknown"], "default": "all" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "all",
+                "percentage",
+                "no-fees",
+                "transactional-mining",
+                "unknown"
+              ],
+              "default": "all"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -617,48 +1010,76 @@
         "operationId": "getExchangeMap",
         "summary": "Exchange Map",
         "description": "Returns a paginated list of all cryptocurrency exchanges by CoinMarketCap ID.",
-        "tags": ["Exchange"],
+        "tags": [
+          "Exchange"
+        ],
         "parameters": [
           {
             "name": "listing_status",
             "in": "query",
-            "schema": { "type": "string", "default": "active" }
+            "schema": {
+              "type": "string",
+              "default": "active"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["id", "volume_24h"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "volume_24h"
+              ]
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "crypto_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -667,28 +1088,42 @@
         "operationId": "getExchangeInfo",
         "summary": "Exchange Info",
         "description": "Returns all static metadata for one or more exchanges.",
-        "tags": ["Exchange"],
+        "tags": [
+          "Exchange"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -697,53 +1132,96 @@
         "operationId": "getExchangeListingsLatest",
         "summary": "Exchange Listings Latest",
         "description": "Returns a paginated list of all cryptocurrency exchanges including the latest aggregate market data.",
-        "tags": ["Exchange"],
+        "tags": [
+          "Exchange"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["name", "volume_24h", "volume_24h_adjusted", "exchange_score"], "default": "volume_24h" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "name",
+                "volume_24h",
+                "volume_24h_adjusted",
+                "exchange_score"
+              ],
+              "default": "volume_24h"
+            }
           },
           {
             "name": "sort_dir",
             "in": "query",
-            "schema": { "type": "string", "enum": ["asc", "desc"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           },
           {
             "name": "market_type",
             "in": "query",
-            "schema": { "type": "string", "enum": ["fees", "no_fees", "all"], "default": "all" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "fees",
+                "no_fees",
+                "all"
+              ],
+              "default": "all"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -752,38 +1230,56 @@
         "operationId": "getExchangeQuotesLatest",
         "summary": "Exchange Quotes Latest",
         "description": "Returns the latest aggregate market data for 1 or more exchanges.",
-        "tags": ["Exchange"],
+        "tags": [
+          "Exchange"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -792,23 +1288,35 @@
         "operationId": "getGlobalMetricsLatest",
         "summary": "Global Metrics Latest",
         "description": "Returns the latest global cryptocurrency market metrics.",
-        "tags": ["Global Metrics"],
+        "tags": [
+          "Global Metrics"
+        ],
         "parameters": [
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -817,48 +1325,70 @@
         "operationId": "getGlobalMetricsHistorical",
         "summary": "Global Metrics Historical",
         "description": "Returns an interval of historical global cryptocurrency market metrics.",
-        "tags": ["Global Metrics"],
+        "tags": [
+          "Global Metrics"
+        ],
         "parameters": [
           {
             "name": "time_start",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time_end",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "count",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "interval",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "aux",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -867,48 +1397,68 @@
         "operationId": "getPriceConversion",
         "summary": "Price Conversion",
         "description": "Convert an amount of one cryptocurrency or fiat currency into one or more different currencies.",
-        "tags": ["Tools"],
+        "tags": [
+          "Tools"
+        ],
         "parameters": [
           {
             "name": "amount",
             "in": "query",
             "required": true,
             "description": "An amount of currency to convert.",
-            "schema": { "type": "number" }
+            "schema": {
+              "type": "number"
+            }
           },
           {
             "name": "id",
             "in": "query",
             "description": "The CoinMarketCap currency ID of the base cryptocurrency or fiat to convert from.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
             "description": "Alternatively pass the currency symbol of the base cryptocurrency or fiat to convert from.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "time",
             "in": "query",
             "description": "Optional timestamp to reference historical pricing during conversion.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -917,38 +1467,57 @@
         "operationId": "getCategories",
         "summary": "Categories",
         "description": "Returns information about all coin categories available on CoinMarketCap.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "slug",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "symbol",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -957,39 +1526,59 @@
         "operationId": "getCategory",
         "summary": "Category",
         "description": "Returns information about a single coin category available on CoinMarketCap.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "id",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 100 }
+            "schema": {
+              "type": "integer",
+              "default": 100
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -998,38 +1587,64 @@
         "operationId": "getTrendingLatest",
         "summary": "Trending Latest",
         "description": "Returns a list of the most searched/trending cryptocurrencies.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 10 }
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
           },
           {
             "name": "time_period",
             "in": "query",
-            "schema": { "type": "string", "enum": ["24h", "30d", "7d"], "default": "24h" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "24h",
+                "30d",
+                "7d"
+              ],
+              "default": "24h"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1038,38 +1653,64 @@
         "operationId": "getTrendingMostVisited",
         "summary": "Trending Most Visited",
         "description": "Returns a list of the most visited cryptocurrencies on CoinMarketCap.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 10 }
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
           },
           {
             "name": "time_period",
             "in": "query",
-            "schema": { "type": "string", "enum": ["24h", "30d", "7d"], "default": "24h" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "24h",
+                "30d",
+                "7d"
+              ],
+              "default": "24h"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1078,48 +1719,86 @@
         "operationId": "getTrendingGainersLosers",
         "summary": "Trending Gainers & Losers",
         "description": "Returns a list of the biggest gainers and losers in the crypto market.",
-        "tags": ["Cryptocurrency"],
+        "tags": [
+          "Cryptocurrency"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 10 }
+            "schema": {
+              "type": "integer",
+              "default": 10
+            }
           },
           {
             "name": "time_period",
             "in": "query",
-            "schema": { "type": "string", "enum": ["1h", "24h", "30d", "7d"], "default": "24h" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "1h",
+                "24h",
+                "30d",
+                "7d"
+              ],
+              "default": "24h"
+            }
           },
           {
             "name": "convert",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "convert_id",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["percent_change_24h"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "percent_change_24h"
+              ]
+            }
           },
           {
             "name": "sort_dir",
             "in": "query",
-            "schema": { "type": "string", "enum": ["asc", "desc"] }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1128,33 +1807,56 @@
         "operationId": "getFiatMap",
         "summary": "Fiat Map",
         "description": "Returns a mapping of all supported fiat currencies to unique CoinMarketCap IDs.",
-        "tags": ["Fiat"],
+        "tags": [
+          "Fiat"
+        ],
         "parameters": [
           {
             "name": "start",
             "in": "query",
-            "schema": { "type": "integer", "default": 1 }
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           },
           {
             "name": "sort",
             "in": "query",
-            "schema": { "type": "string", "enum": ["id", "name"], "default": "id" }
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "name"
+              ],
+              "default": "id"
+            }
           },
           {
             "name": "include_metals",
             "in": "query",
-            "schema": { "type": "boolean", "default": false }
+            "schema": {
+              "type": "boolean",
+              "default": false
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     },
@@ -1163,10 +1865,16 @@
         "operationId": "getKeyInfo",
         "summary": "Key Info",
         "description": "Returns API key details and usage stats.",
-        "tags": ["Key"],
+        "tags": [
+          "Key"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "401": { "description": "Unauthorized" }
+          "200": {
+            "description": "Successful response"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
         }
       }
     }
@@ -1198,37 +1906,97 @@
       "Status": {
         "type": "object",
         "properties": {
-          "timestamp": { "type": "string", "format": "date-time" },
-          "error_code": { "type": "integer" },
-          "error_message": { "type": "string", "nullable": true },
-          "elapsed": { "type": "integer" },
-          "credit_count": { "type": "integer" }
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "error_code": {
+            "type": "integer"
+          },
+          "error_message": {
+            "type": "string",
+            "nullable": true
+          },
+          "elapsed": {
+            "type": "integer"
+          },
+          "credit_count": {
+            "type": "integer"
+          }
         }
       },
       "CryptoMapItem": {
         "type": "object",
         "properties": {
-          "id": { "type": "integer" },
-          "name": { "type": "string" },
-          "symbol": { "type": "string" },
-          "slug": { "type": "string" },
-          "rank": { "type": "integer" },
-          "is_active": { "type": "integer" },
-          "first_historical_data": { "type": "string", "format": "date-time" },
-          "last_historical_data": { "type": "string", "format": "date-time" },
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "is_active": {
+            "type": "integer"
+          },
+          "first_historical_data": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "last_historical_data": {
+            "type": "string",
+            "format": "date-time"
+          },
           "platform": {
             "type": "object",
             "nullable": true,
             "properties": {
-              "id": { "type": "integer" },
-              "name": { "type": "string" },
-              "symbol": { "type": "string" },
-              "slug": { "type": "string" },
-              "token_address": { "type": "string" }
+              "id": {
+                "type": "integer"
+              },
+              "name": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "slug": {
+                "type": "string"
+              },
+              "token_address": {
+                "type": "string"
+              }
             }
           }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Cryptocurrency"
+    },
+    {
+      "name": "Exchange"
+    },
+    {
+      "name": "Fiat"
+    },
+    {
+      "name": "Global Metrics"
+    },
+    {
+      "name": "Key"
+    },
+    {
+      "name": "Tools"
+    }
+  ]
 }

--- a/apis/openapi/coinranking.com/coinranking-api/2.0/openapi.json
+++ b/apis/openapi/coinranking.com/coinranking-api/2.0/openapi.json
@@ -25,85 +25,188 @@
         "summary": "List of coins",
         "description": "Get a list of coins with market data.",
         "operationId": "getCoins",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
             "description": "UUID of reference currency for price calculations.",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
             "description": "Time period for change and sparkline data.",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           },
           {
             "name": "symbols[]",
             "in": "query",
             "description": "Filter by coin symbols.",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "contractAddresses[]",
             "in": "query",
             "description": "Filter by contract addresses.",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "blockchains[]",
             "in": "query",
             "description": "Filter by blockchain names.",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "uuids[]",
             "in": "query",
             "description": "Filter by coin UUIDs.",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "tiers[]",
             "in": "query",
             "description": "Filter by coin tiers.",
-            "schema": { "type": "array", "items": { "type": "integer", "enum": [1, 2, 3] } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              }
+            }
           },
           {
             "name": "tags[]",
             "in": "query",
             "description": "Filter by tags.",
-            "schema": { "type": "array", "items": { "type": "string", "enum": ["defi", "stablecoin", "nft", "dex", "exchange", "staking", "dao", "meme", "privacy", "metaverse", "gaming", "wrapped", "layer-1", "layer-2", "fan-token", "football-club", "web3", "social"] } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "defi",
+                  "stablecoin",
+                  "nft",
+                  "dex",
+                  "exchange",
+                  "staking",
+                  "dao",
+                  "meme",
+                  "privacy",
+                  "metaverse",
+                  "gaming",
+                  "wrapped",
+                  "layer-1",
+                  "layer-2",
+                  "fan-token",
+                  "football-club",
+                  "web3",
+                  "social"
+                ]
+              }
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
             "description": "Order coins by field.",
-            "schema": { "type": "string", "default": "marketCap", "enum": ["price", "marketCap", "24hVolume", "change", "listedAt"] }
+            "schema": {
+              "type": "string",
+              "default": "marketCap",
+              "enum": [
+                "price",
+                "marketCap",
+                "24hVolume",
+                "change",
+                "listedAt"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
             "description": "Sort direction.",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           },
           {
             "name": "limit",
             "in": "query",
             "description": "Maximum number of results.",
-            "schema": { "type": "integer", "default": 50, "minimum": 0, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 0,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
             "description": "Pagination offset.",
-            "schema": { "type": "integer", "default": 0, "minimum": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0,
+              "minimum": 0
+            }
           },
           {
             "name": "cursor",
             "in": "query",
             "description": "Pagination cursor string.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -121,7 +224,9 @@
             "description": "Validation error",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -133,32 +238,70 @@
         "summary": "Trending coins",
         "description": "Get trending coins ranked by user engagement.",
         "operationId": "getTrendingCoins",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           },
           {
             "name": "tiers[]",
             "in": "query",
-            "schema": { "type": "array", "items": { "type": "integer", "enum": [1, 2, 3] } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer",
+                "enum": [
+                  1,
+                  2,
+                  3
+                ]
+              }
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "minimum": 1, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "minimum": 1,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           }
         ],
         "responses": {
@@ -166,7 +309,9 @@
             "description": "Successful response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CoinsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CoinsResponse"
+                }
               }
             }
           }
@@ -178,23 +323,45 @@
         "summary": "Coin details",
         "description": "Get detailed information about a specific coin.",
         "operationId": "getCoinDetails",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
@@ -202,7 +369,9 @@
             "description": "Successful response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/CoinDetailResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/CoinDetailResponse"
+                }
               }
             }
           },
@@ -210,7 +379,9 @@
             "description": "Coin not found",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -222,24 +393,33 @@
         "summary": "Coin price",
         "description": "Get the price of a specific coin.",
         "operationId": "getCoinPrice",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timestamp",
             "in": "query",
             "description": "Epoch timestamp in seconds for historical price.",
-            "schema": { "type": "integer" }
+            "schema": {
+              "type": "integer"
+            }
           }
         ],
         "responses": {
@@ -250,12 +430,18 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "price": { "type": "string" },
-                        "timestamp": { "type": "integer" }
+                        "price": {
+                          "type": "string"
+                        },
+                        "timestamp": {
+                          "type": "integer"
+                        }
                       }
                     }
                   }
@@ -271,23 +457,46 @@
         "summary": "Coin price history",
         "description": "Get historical price data for a coin.",
         "operationId": "getCoinPriceHistory",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y", "all"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y",
+                "all"
+              ]
+            }
           }
         ],
         "responses": {
@@ -298,18 +507,26 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "change": { "type": "string" },
+                        "change": {
+                          "type": "string"
+                        },
                         "history": {
                           "type": "array",
                           "items": {
                             "type": "object",
                             "properties": {
-                              "price": { "type": "string" },
-                              "timestamp": { "type": "integer" }
+                              "price": {
+                                "type": "string"
+                              },
+                              "timestamp": {
+                                "type": "integer"
+                              }
                             }
                           }
                         }
@@ -328,34 +545,60 @@
         "summary": "Coin OHLCV",
         "description": "Get OHLCV (Open, High, Low, Close, Volume) candlestick data for a coin. Pro endpoint.",
         "operationId": "getCoinOhlcv",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "interval",
             "in": "query",
             "description": "Interval for OHLCV data.",
-            "schema": { "type": "string", "default": "day", "enum": ["minute", "5min", "hour", "8hour", "day", "week", "month"] }
+            "schema": {
+              "type": "string",
+              "default": "day",
+              "enum": [
+                "minute",
+                "5min",
+                "hour",
+                "8hour",
+                "day",
+                "week",
+                "month"
+              ]
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           }
         ],
         "responses": {
@@ -366,7 +609,9 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
@@ -375,15 +620,33 @@
                           "items": {
                             "type": "object",
                             "properties": {
-                              "startingAt": { "type": "integer" },
-                              "endingAt": { "type": "integer" },
-                              "open": { "type": "string" },
-                              "high": { "type": "string" },
-                              "low": { "type": "string" },
-                              "close": { "type": "string" },
-                              "avg": { "type": "string" },
-                              "volume": { "type": "string" },
-                              "count": { "type": "integer" }
+                              "startingAt": {
+                                "type": "integer"
+                              },
+                              "endingAt": {
+                                "type": "integer"
+                              },
+                              "open": {
+                                "type": "string"
+                              },
+                              "high": {
+                                "type": "string"
+                              },
+                              "low": {
+                                "type": "string"
+                              },
+                              "close": {
+                                "type": "string"
+                              },
+                              "avg": {
+                                "type": "string"
+                              },
+                              "volume": {
+                                "type": "string"
+                              },
+                              "count": {
+                                "type": "integer"
+                              }
                             }
                           }
                         }
@@ -402,38 +665,66 @@
         "summary": "Coin exchange listings",
         "description": "Get exchanges where a coin is traded. Pro endpoint.",
         "operationId": "getCoinExchanges",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "price"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "price"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           }
         ],
         "responses": {
@@ -444,19 +735,25 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
                         "stats": {
                           "type": "object",
                           "properties": {
-                            "total": { "type": "integer" }
+                            "total": {
+                              "type": "integer"
+                            }
                           }
                         },
                         "exchanges": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Exchange" }
+                          "items": {
+                            "$ref": "#/components/schemas/Exchange"
+                          }
                         }
                       }
                     }
@@ -473,38 +770,66 @@
         "summary": "Coin market listings",
         "description": "Get markets for a specific coin. Pro endpoint.",
         "operationId": "getCoinMarkets",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "price"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "price"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           }
         ],
         "responses": {
@@ -515,17 +840,25 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
                         "stats": {
                           "type": "object",
-                          "properties": { "total": { "type": "integer" } }
+                          "properties": {
+                            "total": {
+                              "type": "integer"
+                            }
+                          }
                         },
                         "markets": {
                           "type": "array",
-                          "items": { "$ref": "#/components/schemas/Market" }
+                          "items": {
+                            "$ref": "#/components/schemas/Market"
+                          }
                         }
                       }
                     }
@@ -542,30 +875,44 @@
         "summary": "Coin supply modifiers",
         "description": "Get supply modifier wallets for a coin. Pro endpoint.",
         "operationId": "getCoinSupplyModifiers",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -576,20 +923,28 @@
         "summary": "Coin fiat prices",
         "description": "Get real-time coin prices in multiple fiat currencies. Pro endpoint.",
         "operationId": "getCoinFiatPrices",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -600,30 +955,56 @@
         "summary": "Coin market cap history",
         "description": "Get historical market cap data for a coin. Pro endpoint.",
         "operationId": "getCoinMarketCapHistory",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -634,25 +1015,48 @@
         "summary": "Coin rank history",
         "description": "Get historical ranking data for a coin. Pro endpoint.",
         "operationId": "getCoinRankHistory",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -663,30 +1067,56 @@
         "summary": "Coin trading volume history",
         "description": "Get historical trading volume data. Pro endpoint.",
         "operationId": "getCoinVolumeHistory",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -697,25 +1127,48 @@
         "summary": "Coin supply history",
         "description": "Get historical supply data. Pro endpoint.",
         "operationId": "getCoinSupplyHistory",
-        "tags": ["Coins"],
+        "tags": [
+          "Coins"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -726,12 +1179,17 @@
         "summary": "Global stats",
         "description": "Get global cryptocurrency market statistics.",
         "operationId": "getStats",
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           }
         ],
         "responses": {
@@ -739,7 +1197,9 @@
             "description": "Successful response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/StatsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/StatsResponse"
+                }
               }
             }
           }
@@ -751,29 +1211,48 @@
         "summary": "Stats for selection of coins",
         "description": "Get summarized statistics for a filtered selection of coins. Pro endpoint.",
         "operationId": "getStatsCoins",
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "uuids[]",
             "in": "query",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           },
           {
             "name": "tags[]",
             "in": "query",
-            "schema": { "type": "array", "items": { "type": "string" } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -784,24 +1263,48 @@
         "summary": "Global market cap history",
         "description": "Get historical global cryptocurrency market capitalization. Pro endpoint.",
         "operationId": "getGlobalMarketCapHistory",
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -812,24 +1315,48 @@
         "summary": "Global trading volume history",
         "description": "Get historical global trading volume. Pro endpoint.",
         "operationId": "getGlobalVolumeHistory",
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -840,19 +1367,40 @@
         "summary": "Bitcoin dominance history",
         "description": "Get historical Bitcoin dominance data. Pro endpoint.",
         "operationId": "getBtcDominanceHistory",
-        "tags": ["Stats"],
+        "tags": [
+          "Stats"
+        ],
         "parameters": [
           {
             "name": "timePeriod",
             "in": "query",
-            "schema": { "type": "string", "default": "24h", "enum": ["1h", "3h", "12h", "24h", "7d", "30d", "3m", "1y", "3y", "5y"] }
+            "schema": {
+              "type": "string",
+              "default": "24h",
+              "enum": [
+                "1h",
+                "3h",
+                "12h",
+                "24h",
+                "7d",
+                "30d",
+                "3m",
+                "1y",
+                "3y",
+                "5y"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -863,44 +1411,76 @@
         "summary": "List exchanges",
         "description": "Get a list of centralized exchanges. Pro endpoint.",
         "operationId": "getExchanges",
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 50,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "numberOfMarkets"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "numberOfMarkets"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           },
           {
             "name": "search",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -911,25 +1491,36 @@
         "summary": "Exchange details",
         "description": "Get detailed information about a specific exchange. Pro endpoint.",
         "operationId": "getExchangeDetails",
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -940,45 +1531,76 @@
         "summary": "Exchange coin listings",
         "description": "Get coins listed on a specific exchange. Pro endpoint.",
         "operationId": "getExchangeCoins",
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "price"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "price"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -989,50 +1611,83 @@
         "summary": "Exchange markets",
         "description": "Get markets on a specific exchange. Pro endpoint.",
         "operationId": "getExchangeMarkets",
-        "tags": ["Exchanges"],
+        "tags": [
+          "Exchanges"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "price"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "price"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           },
           {
             "name": "search",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1043,39 +1698,68 @@
         "summary": "List DEXs",
         "description": "Get a list of decentralized exchanges.",
         "operationId": "getDexs",
-        "tags": ["DEXs"],
+        "tags": [
+          "DEXs"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "numberOfMarkets"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "numberOfMarkets"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1086,25 +1770,36 @@
         "summary": "DEX details",
         "description": "Get detailed information about a specific DEX.",
         "operationId": "getDexDetails",
-        "tags": ["DEXs"],
+        "tags": [
+          "DEXs"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1115,30 +1810,44 @@
         "summary": "DEX coin listings",
         "description": "Get coins listed on a specific DEX.",
         "operationId": "getDexCoins",
-        "tags": ["DEXs"],
+        "tags": [
+          "DEXs"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1149,30 +1858,44 @@
         "summary": "DEX markets",
         "description": "Get markets on a specific DEX.",
         "operationId": "getDexMarkets",
-        "tags": ["DEXs"],
+        "tags": [
+          "DEXs"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1183,44 +1906,75 @@
         "summary": "List markets",
         "description": "Get a list of markets. Pro endpoint.",
         "operationId": "getMarkets",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "orderBy",
             "in": "query",
-            "schema": { "type": "string", "default": "24hVolume", "enum": ["24hVolume", "price"] }
+            "schema": {
+              "type": "string",
+              "default": "24hVolume",
+              "enum": [
+                "24hVolume",
+                "price"
+              ]
+            }
           },
           {
             "name": "orderDirection",
             "in": "query",
-            "schema": { "type": "string", "default": "desc", "enum": ["desc", "asc"] }
+            "schema": {
+              "type": "string",
+              "default": "desc",
+              "enum": [
+                "desc",
+                "asc"
+              ]
+            }
           },
           {
             "name": "search",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1231,25 +1985,36 @@
         "summary": "Market details",
         "description": "Get details about a specific market. Pro endpoint.",
         "operationId": "getMarketDetails",
-        "tags": ["Markets"],
+        "tags": [
+          "Markets"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1260,29 +2025,43 @@
         "summary": "List blockchains",
         "description": "Get a list of blockchains. Pro endpoint.",
         "operationId": "getBlockchains",
-        "tags": ["Blockchains"],
+        "tags": [
+          "Blockchains"
+        ],
         "parameters": [
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 50 }
+            "schema": {
+              "type": "integer",
+              "default": 50
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "search",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1293,20 +2072,28 @@
         "summary": "Blockchain details",
         "description": "Get details about a specific blockchain. Pro endpoint.",
         "operationId": "getBlockchainDetails",
-        "tags": ["Blockchains"],
+        "tags": [
+          "Blockchains"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1317,26 +2104,36 @@
         "summary": "Blockchain contract address",
         "description": "Resolve a contract address to a coin UUID. Pro endpoint.",
         "operationId": "getBlockchainContractAddress",
-        "tags": ["Blockchains"],
+        "tags": [
+          "Blockchains"
+        ],
         "parameters": [
           {
             "name": "uuid",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "contractAddress",
             "in": "path",
             "required": true,
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "Successful response",
             "content": {
-              "application/json": { "schema": { "type": "object" } }
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -1347,33 +2144,57 @@
         "summary": "List reference currencies",
         "description": "Get a list of available reference currencies (fiat and crypto).",
         "operationId": "getReferenceCurrencies",
-        "tags": ["Reference Currencies"],
+        "tags": [
+          "Reference Currencies"
+        ],
         "parameters": [
           {
             "name": "types[]",
             "in": "query",
             "description": "Filter by currency type.",
-            "schema": { "type": "array", "items": { "type": "string", "enum": ["coin", "fiat", "denominator", "asset"] } }
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "coin",
+                  "fiat",
+                  "denominator",
+                  "asset"
+                ]
+              }
+            }
           },
           {
             "name": "search",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "limit",
             "in": "query",
-            "schema": { "type": "integer", "default": 20, "maximum": 5000 }
+            "schema": {
+              "type": "integer",
+              "default": 20,
+              "maximum": 5000
+            }
           },
           {
             "name": "offset",
             "in": "query",
-            "schema": { "type": "integer", "default": 0 }
+            "schema": {
+              "type": "integer",
+              "default": 0
+            }
           },
           {
             "name": "cursor",
             "in": "query",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           }
         ],
         "responses": {
@@ -1381,7 +2202,9 @@
             "description": "Successful response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReferenceCurrenciesResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ReferenceCurrenciesResponse"
+                }
               }
             }
           }
@@ -1393,18 +2216,25 @@
         "summary": "Search suggestions",
         "description": "Search for coins, exchanges, markets, and categories.",
         "operationId": "getSearchSuggestions",
-        "tags": ["Search"],
+        "tags": [
+          "Search"
+        ],
         "parameters": [
           {
             "name": "query",
             "in": "query",
             "description": "Search term.",
-            "schema": { "type": "string" }
+            "schema": {
+              "type": "string"
+            }
           },
           {
             "name": "referenceCurrencyUuid",
             "in": "query",
-            "schema": { "type": "string", "default": "yhjMzLPhuIDl" }
+            "schema": {
+              "type": "string",
+              "default": "yhjMzLPhuIDl"
+            }
           }
         ],
         "responses": {
@@ -1415,15 +2245,42 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status": { "type": "string" },
+                    "status": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "coins": { "type": "array", "items": { "$ref": "#/components/schemas/CoinSummary" } },
-                        "exchanges": { "type": "array", "items": { "type": "object" } },
-                        "markets": { "type": "array", "items": { "type": "object" } },
-                        "fiat": { "type": "array", "items": { "type": "object" } },
-                        "categories": { "type": "array", "items": { "type": "object" } }
+                        "coins": {
+                          "type": "array",
+                          "items": {
+                            "$ref": "#/components/schemas/CoinSummary"
+                          }
+                        },
+                        "exchanges": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "markets": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "fiat": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        },
+                        "categories": {
+                          "type": "array",
+                          "items": {
+                            "type": "object"
+                          }
+                        }
                       }
                     }
                   }
@@ -1448,126 +2305,280 @@
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "example": "fail" },
-          "type": { "type": "string", "example": "VALIDATION_ERROR" },
-          "message": { "type": "string" }
+          "status": {
+            "type": "string",
+            "example": "fail"
+          },
+          "type": {
+            "type": "string",
+            "example": "VALIDATION_ERROR"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       },
       "CoinSummary": {
         "type": "object",
         "properties": {
-          "uuid": { "type": "string" },
-          "symbol": { "type": "string" },
-          "name": { "type": "string" },
-          "color": { "type": "string" },
-          "iconUrl": { "type": "string" },
-          "marketCap": { "type": "string" },
-          "price": { "type": "string" },
-          "listedAt": { "type": "integer", "nullable": true },
-          "tier": { "type": "integer", "nullable": true },
-          "change": { "type": "string" },
-          "rank": { "type": "integer" },
-          "sparkline": { "type": "array", "items": { "type": "string" } },
-          "lowVolume": { "type": "boolean" },
-          "coinrankingUrl": { "type": "string" },
-          "24hVolume": { "type": "string" },
-          "btcPrice": { "type": "string" },
-          "contractAddresses": { "type": "array", "items": { "type": "object" } }
+          "uuid": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "marketCap": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "listedAt": {
+            "type": "integer",
+            "nullable": true
+          },
+          "tier": {
+            "type": "integer",
+            "nullable": true
+          },
+          "change": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "sparkline": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "lowVolume": {
+            "type": "boolean"
+          },
+          "coinrankingUrl": {
+            "type": "string"
+          },
+          "24hVolume": {
+            "type": "string"
+          },
+          "btcPrice": {
+            "type": "string"
+          },
+          "contractAddresses": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
         }
       },
       "CoinDetail": {
         "type": "object",
         "properties": {
-          "uuid": { "type": "string" },
-          "symbol": { "type": "string" },
-          "name": { "type": "string" },
-          "description": { "type": "string" },
-          "color": { "type": "string" },
-          "iconUrl": { "type": "string" },
-          "websiteUrl": { "type": "string" },
+          "uuid": {
+            "type": "string"
+          },
+          "symbol": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "color": {
+            "type": "string"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "websiteUrl": {
+            "type": "string"
+          },
           "links": {
             "type": "array",
             "items": {
               "type": "object",
               "properties": {
-                "name": { "type": "string" },
-                "url": { "type": "string" },
-                "type": { "type": "string" }
+                "name": {
+                  "type": "string"
+                },
+                "url": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                }
               }
             }
           },
           "supply": {
             "type": "object",
             "properties": {
-              "confirmed": { "type": "boolean" },
-              "supplyAt": { "type": "integer" },
-              "circulating": { "type": "string" },
-              "total": { "type": "string" },
-              "max": { "type": "string" }
+              "confirmed": {
+                "type": "boolean"
+              },
+              "supplyAt": {
+                "type": "integer"
+              },
+              "circulating": {
+                "type": "string"
+              },
+              "total": {
+                "type": "string"
+              },
+              "max": {
+                "type": "string"
+              }
             }
           },
-          "24hVolume": { "type": "string" },
-          "marketCap": { "type": "string" },
-          "fullyDilutedMarketCap": { "type": "string" },
-          "price": { "type": "string" },
-          "btcPrice": { "type": "string" },
-          "priceAt": { "type": "integer" },
-          "change": { "type": "string" },
-          "rank": { "type": "integer" },
-          "numberOfMarkets": { "type": "integer" },
-          "numberOfExchanges": { "type": "integer" },
-          "sparkline": { "type": "array", "items": { "type": "string" } },
+          "24hVolume": {
+            "type": "string"
+          },
+          "marketCap": {
+            "type": "string"
+          },
+          "fullyDilutedMarketCap": {
+            "type": "string"
+          },
+          "price": {
+            "type": "string"
+          },
+          "btcPrice": {
+            "type": "string"
+          },
+          "priceAt": {
+            "type": "integer"
+          },
+          "change": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "numberOfMarkets": {
+            "type": "integer"
+          },
+          "numberOfExchanges": {
+            "type": "integer"
+          },
+          "sparkline": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
           "allTimeHigh": {
             "type": "object",
             "properties": {
-              "price": { "type": "string" },
-              "timestamp": { "type": "integer" }
+              "price": {
+                "type": "string"
+              },
+              "timestamp": {
+                "type": "integer"
+              }
             }
           },
-          "coinrankingUrl": { "type": "string" },
-          "tier": { "type": "integer" },
-          "lowVolume": { "type": "boolean" },
-          "listedAt": { "type": "integer" },
-          "notices": { "type": "array", "items": { "type": "object" } },
-          "contractAddresses": { "type": "array", "items": { "type": "object" } },
-          "tags": { "type": "array", "items": { "type": "string" } }
+          "coinrankingUrl": {
+            "type": "string"
+          },
+          "tier": {
+            "type": "integer"
+          },
+          "lowVolume": {
+            "type": "boolean"
+          },
+          "listedAt": {
+            "type": "integer"
+          },
+          "notices": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "contractAddresses": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       },
       "CoinsResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string" },
+          "status": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
               "stats": {
                 "type": "object",
                 "properties": {
-                  "total": { "type": "integer" },
-                  "totalCoins": { "type": "integer" },
-                  "totalMarkets": { "type": "integer" },
-                  "totalExchanges": { "type": "integer" },
-                  "totalMarketCap": { "type": "string" },
-                  "total24hVolume": { "type": "string" }
+                  "total": {
+                    "type": "integer"
+                  },
+                  "totalCoins": {
+                    "type": "integer"
+                  },
+                  "totalMarkets": {
+                    "type": "integer"
+                  },
+                  "totalExchanges": {
+                    "type": "integer"
+                  },
+                  "totalMarketCap": {
+                    "type": "string"
+                  },
+                  "total24hVolume": {
+                    "type": "string"
+                  }
                 }
               },
               "coins": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/CoinSummary" }
+                "items": {
+                  "$ref": "#/components/schemas/CoinSummary"
+                }
               }
             }
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         }
       },
       "CoinDetailResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string" },
+          "status": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "coin": { "$ref": "#/components/schemas/CoinDetail" }
+              "coin": {
+                "$ref": "#/components/schemas/CoinDetail"
+              }
             }
           }
         }
@@ -1575,18 +2586,42 @@
       "StatsResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string" },
+          "status": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "totalCoins": { "type": "integer" },
-              "totalMarkets": { "type": "integer" },
-              "totalExchanges": { "type": "integer" },
-              "totalMarketCap": { "type": "string" },
-              "total24hVolume": { "type": "string" },
-              "btcDominance": { "type": "number" },
-              "bestCoins": { "type": "array", "items": { "$ref": "#/components/schemas/CoinSummary" } },
-              "newestCoins": { "type": "array", "items": { "$ref": "#/components/schemas/CoinSummary" } }
+              "totalCoins": {
+                "type": "integer"
+              },
+              "totalMarkets": {
+                "type": "integer"
+              },
+              "totalExchanges": {
+                "type": "integer"
+              },
+              "totalMarketCap": {
+                "type": "string"
+              },
+              "total24hVolume": {
+                "type": "string"
+              },
+              "btcDominance": {
+                "type": "number"
+              },
+              "bestCoins": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CoinSummary"
+                }
+              },
+              "newestCoins": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/CoinSummary"
+                }
+              }
             }
           }
         }
@@ -1594,88 +2629,186 @@
       "ReferenceCurrenciesResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string" },
+          "status": {
+            "type": "string"
+          },
           "data": {
             "type": "object",
             "properties": {
               "stats": {
                 "type": "object",
-                "properties": { "total": { "type": "integer" } }
+                "properties": {
+                  "total": {
+                    "type": "integer"
+                  }
+                }
               },
               "currencies": {
                 "type": "array",
                 "items": {
                   "type": "object",
                   "properties": {
-                    "uuid": { "type": "string" },
-                    "type": { "type": "string" },
-                    "symbol": { "type": "string" },
-                    "name": { "type": "string" },
-                    "iconUrl": { "type": "string" },
-                    "sign": { "type": "string" }
+                    "uuid": {
+                      "type": "string"
+                    },
+                    "type": {
+                      "type": "string"
+                    },
+                    "symbol": {
+                      "type": "string"
+                    },
+                    "name": {
+                      "type": "string"
+                    },
+                    "iconUrl": {
+                      "type": "string"
+                    },
+                    "sign": {
+                      "type": "string"
+                    }
                   }
                 }
               }
             }
           },
-          "pagination": { "$ref": "#/components/schemas/Pagination" }
+          "pagination": {
+            "$ref": "#/components/schemas/Pagination"
+          }
         }
       },
       "Exchange": {
         "type": "object",
         "properties": {
-          "uuid": { "type": "string" },
-          "name": { "type": "string" },
-          "iconUrl": { "type": "string" },
-          "numberOfMarkets": { "type": "integer" },
-          "24hVolume": { "type": "string" },
-          "rank": { "type": "integer" },
-          "recommended": { "type": "boolean" },
-          "coinrankingUrl": { "type": "string" }
+          "uuid": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "numberOfMarkets": {
+            "type": "integer"
+          },
+          "24hVolume": {
+            "type": "string"
+          },
+          "rank": {
+            "type": "integer"
+          },
+          "recommended": {
+            "type": "boolean"
+          },
+          "coinrankingUrl": {
+            "type": "string"
+          }
         }
       },
       "Market": {
         "type": "object",
         "properties": {
-          "uuid": { "type": "string" },
+          "uuid": {
+            "type": "string"
+          },
           "base": {
             "type": "object",
             "properties": {
-              "uuid": { "type": "string" },
-              "symbol": { "type": "string" },
-              "name": { "type": "string" }
+              "uuid": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             }
           },
           "quote": {
             "type": "object",
             "properties": {
-              "uuid": { "type": "string" },
-              "symbol": { "type": "string" },
-              "name": { "type": "string" }
+              "uuid": {
+                "type": "string"
+              },
+              "symbol": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             }
           },
           "exchange": {
             "type": "object",
             "properties": {
-              "uuid": { "type": "string" },
-              "name": { "type": "string" }
+              "uuid": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              }
             }
           },
-          "price": { "type": "string" },
-          "24hVolume": { "type": "string" },
-          "recommended": { "type": "boolean" }
+          "price": {
+            "type": "string"
+          },
+          "24hVolume": {
+            "type": "string"
+          },
+          "recommended": {
+            "type": "boolean"
+          }
         }
       },
       "Pagination": {
         "type": "object",
         "properties": {
-          "limit": { "type": "integer" },
-          "hasNextPage": { "type": "boolean" },
-          "hasPreviousPage": { "type": "boolean" },
-          "nextCursor": { "type": "string", "nullable": true },
-          "previousCursor": { "type": "string", "nullable": true }
+          "limit": {
+            "type": "integer"
+          },
+          "hasNextPage": {
+            "type": "boolean"
+          },
+          "hasPreviousPage": {
+            "type": "boolean"
+          },
+          "nextCursor": {
+            "type": "string",
+            "nullable": true
+          },
+          "previousCursor": {
+            "type": "string",
+            "nullable": true
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Blockchains"
+    },
+    {
+      "name": "Coins"
+    },
+    {
+      "name": "DEXs"
+    },
+    {
+      "name": "Exchanges"
+    },
+    {
+      "name": "Markets"
+    },
+    {
+      "name": "Reference Currencies"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "Stats"
+    }
+  ]
 }

--- a/apis/openapi/coinremitter.com/coinremitter-api/1.0/openapi.json
+++ b/apis/openapi/coinremitter.com/coinremitter-api/1.0/openapi.json
@@ -26,7 +26,9 @@
         "summary": "Create new address",
         "description": "Generate a new receiving address for the wallet.",
         "operationId": "createAddress",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -51,18 +53,38 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer", "example": 1 },
-                    "msg": { "type": "string", "example": "success" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "msg": {
+                      "type": "string",
+                      "example": "success"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "wallet_id": { "type": "string" },
-                        "address": { "type": "string" },
-                        "coin": { "type": "string" },
-                        "label": { "type": "string" },
-                        "qr_code": { "type": "string" },
-                        "expire_time": { "type": "string" }
+                        "wallet_id": {
+                          "type": "string"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "label": {
+                          "type": "string"
+                        },
+                        "qr_code": {
+                          "type": "string"
+                        },
+                        "expire_time": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -74,7 +96,9 @@
             "description": "Bad request",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -86,14 +110,18 @@
         "summary": "Validate address",
         "description": "Validate a cryptocurrency address format.",
         "operationId": "validateAddress",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "type": "string",
@@ -112,13 +140,21 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "valid": { "type": "boolean" }
+                        "valid": {
+                          "type": "boolean"
+                        }
                       }
                     }
                   }
@@ -134,14 +170,18 @@
         "summary": "Estimate withdrawal cost",
         "description": "Calculate the estimated cost of a withdrawal including fees.",
         "operationId": "estimateWithdrawal",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "string",
@@ -154,7 +194,11 @@
                   "withdrawal_speed": {
                     "type": "string",
                     "description": "Transaction speed.",
-                    "enum": ["Low", "Medium", "Priority"]
+                    "enum": [
+                      "Low",
+                      "Medium",
+                      "Priority"
+                    ]
                   }
                 }
               }
@@ -169,17 +213,33 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "amount": { "type": "string" },
-                        "transaction_fee": { "type": "string" },
-                        "processing_fee": { "type": "string" },
-                        "total_amount": { "type": "string" },
-                        "fee_structure": { "type": "object" }
+                        "amount": {
+                          "type": "string"
+                        },
+                        "transaction_fee": {
+                          "type": "string"
+                        },
+                        "processing_fee": {
+                          "type": "string"
+                        },
+                        "total_amount": {
+                          "type": "string"
+                        },
+                        "fee_structure": {
+                          "type": "object"
+                        }
                       }
                     }
                   }
@@ -195,14 +255,19 @@
         "summary": "Withdraw",
         "description": "Execute a cryptocurrency withdrawal from the wallet.",
         "operationId": "withdraw",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["address", "amount"],
+                "required": [
+                  "address",
+                  "amount"
+                ],
                 "properties": {
                   "address": {
                     "type": "string",
@@ -215,7 +280,11 @@
                   "withdrawal_speed": {
                     "type": "string",
                     "description": "Transaction speed.",
-                    "enum": ["Low", "Medium", "Priority"]
+                    "enum": [
+                      "Low",
+                      "Medium",
+                      "Priority"
+                    ]
                   }
                 }
               }
@@ -230,23 +299,51 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": { "type": "string" },
-                        "txid": { "type": "string" },
-                        "explorer_url": { "type": "string" },
-                        "amount": { "type": "string" },
-                        "transaction_fee": { "type": "string" },
-                        "processing_fee": { "type": "string" },
-                        "total_amount": { "type": "string" },
-                        "to_address": { "type": "string" },
-                        "wallet_id": { "type": "string" },
-                        "coin": { "type": "string" },
-                        "date": { "type": "string" }
+                        "id": {
+                          "type": "string"
+                        },
+                        "txid": {
+                          "type": "string"
+                        },
+                        "explorer_url": {
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "string"
+                        },
+                        "transaction_fee": {
+                          "type": "string"
+                        },
+                        "processing_fee": {
+                          "type": "string"
+                        },
+                        "total_amount": {
+                          "type": "string"
+                        },
+                        "to_address": {
+                          "type": "string"
+                        },
+                        "wallet_id": {
+                          "type": "string"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -262,14 +359,18 @@
         "summary": "Get transaction",
         "description": "Fetch details of a specific transaction by its Coinremitter ID.",
         "operationId": "getTransaction",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["id"],
+                "required": [
+                  "id"
+                ],
                 "properties": {
                   "id": {
                     "type": "string",
@@ -288,22 +389,48 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": { "type": "string" },
-                        "txid": { "type": "string" },
-                        "explorer_url": { "type": "string" },
-                        "type": { "type": "string" },
-                        "coin": { "type": "string" },
-                        "amount": { "type": "string" },
-                        "confirmations": { "type": "integer" },
-                        "status": { "type": "string" },
-                        "address": { "type": "string" },
-                        "date": { "type": "string" }
+                        "id": {
+                          "type": "string"
+                        },
+                        "txid": {
+                          "type": "string"
+                        },
+                        "explorer_url": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "amount": {
+                          "type": "string"
+                        },
+                        "confirmations": {
+                          "type": "integer"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "address": {
+                          "type": "string"
+                        },
+                        "date": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -319,14 +446,18 @@
         "summary": "Get transactions by address",
         "description": "Get transaction history for a specific wallet address.",
         "operationId": "getAddressTransactions",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["address"],
+                "required": [
+                  "address"
+                ],
                 "properties": {
                   "address": {
                     "type": "string",
@@ -345,27 +476,53 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "address": { "type": "string" },
-                        "coin": { "type": "string" },
-                        "confirmed_amount": { "type": "string" },
-                        "pending_amount": { "type": "string" },
+                        "address": {
+                          "type": "string"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "confirmed_amount": {
+                          "type": "string"
+                        },
+                        "pending_amount": {
+                          "type": "string"
+                        },
                         "transactions": {
                           "type": "array",
                           "items": {
                             "type": "object",
                             "properties": {
-                              "id": { "type": "string" },
-                              "txid": { "type": "string" },
-                              "amount": { "type": "string" },
-                              "confirmations": { "type": "integer" },
-                              "status": { "type": "string" },
-                              "date": { "type": "string" }
+                              "id": {
+                                "type": "string"
+                              },
+                              "txid": {
+                                "type": "string"
+                              },
+                              "amount": {
+                                "type": "string"
+                              },
+                              "confirmations": {
+                                "type": "integer"
+                              },
+                              "status": {
+                                "type": "string"
+                              },
+                              "date": {
+                                "type": "string"
+                              }
                             }
                           }
                         }
@@ -384,7 +541,9 @@
         "summary": "Get wallet balance",
         "description": "Retrieve the balance and details of the wallet.",
         "operationId": "getWalletBalance",
-        "tags": ["Wallet"],
+        "tags": [
+          "Wallet"
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -402,17 +561,33 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "wallet_id": { "type": "string" },
-                        "coin": { "type": "string" },
-                        "balance": { "type": "string" },
-                        "minimum_withdrawal": { "type": "string" },
-                        "maximum_withdrawal": { "type": "string" }
+                        "wallet_id": {
+                          "type": "string"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "balance": {
+                          "type": "string"
+                        },
+                        "minimum_withdrawal": {
+                          "type": "string"
+                        },
+                        "maximum_withdrawal": {
+                          "type": "string"
+                        }
                       }
                     }
                   }
@@ -428,14 +603,18 @@
         "summary": "Create invoice",
         "description": "Generate a new payment invoice.",
         "operationId": "createInvoice",
-        "tags": ["Invoice"],
+        "tags": [
+          "Invoice"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["amount"],
+                "required": [
+                  "amount"
+                ],
                 "properties": {
                   "amount": {
                     "type": "string",
@@ -502,26 +681,56 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": { "type": "string" },
-                        "invoice_id": { "type": "string" },
-                        "url": { "type": "string" },
-                        "total_amount": { "type": "object" },
-                        "paid_amount": { "type": "object" },
-                        "coin": { "type": "string" },
-                        "fiat_currency": { "type": "string" },
-                        "status": { "type": "string" },
-                        "status_code": { "type": "integer" },
-                        "expire_on": { "type": "string" },
-                        "description": { "type": "string" },
+                        "id": {
+                          "type": "string"
+                        },
+                        "invoice_id": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "total_amount": {
+                          "type": "object"
+                        },
+                        "paid_amount": {
+                          "type": "object"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "fiat_currency": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "status_code": {
+                          "type": "integer"
+                        },
+                        "expire_on": {
+                          "type": "string"
+                        },
+                        "description": {
+                          "type": "string"
+                        },
                         "payment_history": {
                           "type": "array",
-                          "items": { "type": "object" }
+                          "items": {
+                            "type": "object"
+                          }
                         }
                       }
                     }
@@ -538,14 +747,18 @@
         "summary": "Get invoice",
         "description": "Retrieve details of an existing invoice.",
         "operationId": "getInvoice",
-        "tags": ["Invoice"],
+        "tags": [
+          "Invoice"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["invoice_id"],
+                "required": [
+                  "invoice_id"
+                ],
                 "properties": {
                   "invoice_id": {
                     "type": "string",
@@ -564,24 +777,50 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "flag": { "type": "integer" },
-                    "msg": { "type": "string" },
-                    "action": { "type": "string" },
+                    "flag": {
+                      "type": "integer"
+                    },
+                    "msg": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    },
                     "data": {
                       "type": "object",
                       "properties": {
-                        "id": { "type": "string" },
-                        "invoice_id": { "type": "string" },
-                        "url": { "type": "string" },
-                        "total_amount": { "type": "object" },
-                        "paid_amount": { "type": "object" },
-                        "coin": { "type": "string" },
-                        "status": { "type": "string" },
-                        "status_code": { "type": "integer" },
-                        "expire_on": { "type": "string" },
+                        "id": {
+                          "type": "string"
+                        },
+                        "invoice_id": {
+                          "type": "string"
+                        },
+                        "url": {
+                          "type": "string"
+                        },
+                        "total_amount": {
+                          "type": "object"
+                        },
+                        "paid_amount": {
+                          "type": "object"
+                        },
+                        "coin": {
+                          "type": "string"
+                        },
+                        "status": {
+                          "type": "string"
+                        },
+                        "status_code": {
+                          "type": "integer"
+                        },
+                        "expire_on": {
+                          "type": "string"
+                        },
                         "payment_history": {
                           "type": "array",
-                          "items": { "type": "object" }
+                          "items": {
+                            "type": "object"
+                          }
                         }
                       }
                     }
@@ -613,12 +852,29 @@
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "flag": { "type": "integer", "example": 0 },
-          "msg": { "type": "string" },
-          "action": { "type": "string" },
-          "data": { "type": "object" }
+          "flag": {
+            "type": "integer",
+            "example": 0
+          },
+          "msg": {
+            "type": "string"
+          },
+          "action": {
+            "type": "string"
+          },
+          "data": {
+            "type": "object"
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Invoice"
+    },
+    {
+      "name": "Wallet"
+    }
+  ]
 }

--- a/apis/openapi/comet.com/comet-ml-rest-api/2.0.0/openapi.json
+++ b/apis/openapi/comet.com/comet-ml-rest-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Comet ML REST API",
     "version": "2.0.0",
     "description": "Comet ML REST API for managing machine learning experiments, projects, metrics, and assets.",
-    "x-jentic-source-url": "https://www.comet.com/docs/v2/api-and-sdk/rest-api/"
+    "x-jentic-source-url": "https://www.comet.com/docs/v2/api-and-sdk/rest-api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -601,36 +602,23 @@
             "type": "string"
           }
         }
-      },
-      "Metric": {
-        "type": "object",
-        "properties": {
-          "metricName": {
-            "type": "string"
-          },
-          "metricValue": {
-            "type": "number"
-          },
-          "step": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "type": "integer"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
       }
     }
   },
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Experiments"
+    },
+    {
+      "name": "Projects"
+    },
+    {
+      "name": "Write"
     }
   ]
 }

--- a/apis/openapi/comet.com/comet-ml-rest-api/2.0.0/openapi.json
+++ b/apis/openapi/comet.com/comet-ml-rest-api/2.0.0/openapi.json
@@ -603,6 +603,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/cometapi.com/comet-api/1.0.0/openapi.json
+++ b/apis/openapi/cometapi.com/comet-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CometAPI",
     "version": "1.0.0",
     "description": "CometAPI provides access to 500+ AI models (including GPT-4, Claude, Gemini, Llama, etc.) through an OpenAI-compatible API endpoint. Single API key for all models.",
-    "x-jentic-source-url": "https://www.cometapi.com/"
+    "x-jentic-source-url": "https://www.cometapi.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -144,7 +145,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a text completion"
       }
     },
     "/embeddings": {
@@ -270,7 +272,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get model details"
       }
     },
     "/images/generations": {
@@ -373,7 +376,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Transcribe audio to text"
       }
     },
     "/audio/speech": {
@@ -425,7 +429,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Generate speech from text"
       }
     }
   },

--- a/apis/openapi/cometly.com/cometly-api/1.0.0/openapi.json
+++ b/apis/openapi/cometly.com/cometly-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cometly API",
     "version": "1.0.0",
     "description": "Cometly API for managing contacts, sending events, and exporting data for ad attribution and tracking.",
-    "x-jentic-source-url": "https://docs.cometly.com/api-reference"
+    "x-jentic-source-url": "https://docs.cometly.com/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -189,7 +190,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a contact"
       },
       "put": {
         "operationId": "updateContact",
@@ -248,7 +250,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a contact"
       },
       "delete": {
         "operationId": "deleteContact",
@@ -280,7 +283,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a contact"
       }
     },
     "/events": {
@@ -514,7 +518,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List exports"
       }
     },
     "/exports/{exportId}": {
@@ -555,7 +560,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get export status and download URL"
       }
     }
   },

--- a/apis/openapi/commissioncrowd.com/commissioncrowd-api/1.0.0/openapi.json
+++ b/apis/openapi/commissioncrowd.com/commissioncrowd-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CommissionCrowd API",
     "version": "1.0.0",
     "description": "CommissionCrowd CRM API for managing sales activities, leads, contacts, companies, and agents.",
-    "x-jentic-source-url": "https://www.commissioncrowd.com/api/"
+    "x-jentic-source-url": "https://www.commissioncrowd.com/api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -12,7 +13,7 @@
     }
   ],
   "paths": {
-    "/activities/": {
+    "/activities": {
       "get": {
         "operationId": "listActivities",
         "summary": "List Activities",
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Activities"
       },
       "post": {
         "operationId": "createActivities",
@@ -102,10 +104,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Activities"
       }
     },
-    "/tasks/": {
+    "/tasks": {
       "get": {
         "operationId": "listTasks",
         "summary": "List Tasks",
@@ -146,7 +149,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Tasks"
       },
       "post": {
         "operationId": "createTasks",
@@ -195,10 +199,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Tasks"
       }
     },
-    "/wall_posts/": {
+    "/wall_posts": {
       "get": {
         "operationId": "listWallPosts",
         "summary": "List Wall Posts",
@@ -239,7 +244,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Wall Posts"
       },
       "post": {
         "operationId": "createWallPosts",
@@ -288,10 +294,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Wall Posts"
       }
     },
-    "/users/": {
+    "/users": {
       "get": {
         "operationId": "listUsers",
         "summary": "List Users",
@@ -332,7 +339,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Users"
       },
       "post": {
         "operationId": "createUsers",
@@ -381,10 +389,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Users"
       }
     },
-    "/lead_statuses/": {
+    "/lead_statuses": {
       "get": {
         "operationId": "listLeadStatuses",
         "summary": "List Lead Statuses",
@@ -425,7 +434,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Lead Statuses"
       },
       "post": {
         "operationId": "createLeadStatuses",
@@ -474,10 +484,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Lead Statuses"
       }
     },
-    "/contacts/": {
+    "/contacts": {
       "get": {
         "operationId": "listContacts",
         "summary": "List Contacts",
@@ -518,7 +529,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Contacts"
       },
       "post": {
         "operationId": "createContacts",
@@ -567,10 +579,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Contacts"
       }
     },
-    "/wall_post_replies/": {
+    "/wall_post_replies": {
       "get": {
         "operationId": "listWallPostReplies",
         "summary": "List Wall Post Replies",
@@ -611,7 +624,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Wall Post Replies"
       },
       "post": {
         "operationId": "createWallPostReplies",
@@ -660,10 +674,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Wall Post Replies"
       }
     },
-    "/companies/": {
+    "/companies": {
       "get": {
         "operationId": "listCompanies",
         "summary": "List Companies",
@@ -704,7 +719,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Companies"
       },
       "post": {
         "operationId": "createCompanies",
@@ -753,10 +769,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Companies"
       }
     },
-    "/opportunities/": {
+    "/opportunities": {
       "get": {
         "operationId": "listOpportunities",
         "summary": "List Opportunities",
@@ -797,7 +814,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Opportunities"
       },
       "post": {
         "operationId": "createOpportunities",
@@ -846,10 +864,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Opportunities"
       }
     },
-    "/organizations/": {
+    "/organizations": {
       "get": {
         "operationId": "listOrganizations",
         "summary": "List Organizations",
@@ -890,7 +909,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Organizations"
       },
       "post": {
         "operationId": "createOrganizations",
@@ -939,10 +959,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Organizations"
       }
     },
-    "/leads/": {
+    "/leads": {
       "get": {
         "operationId": "listLeads",
         "summary": "List Leads",
@@ -983,7 +1004,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Leads"
       },
       "post": {
         "operationId": "createLeads",
@@ -1032,10 +1054,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Leads"
       }
     },
-    "/agents/": {
+    "/agents": {
       "get": {
         "operationId": "listAgents",
         "summary": "List Agents",
@@ -1076,7 +1099,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Agents"
       },
       "post": {
         "operationId": "createAgents",
@@ -1125,10 +1149,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Agents"
       }
     },
-    "/phone_numbers/": {
+    "/phone_numbers": {
       "get": {
         "operationId": "listPhoneNumbers",
         "summary": "List Phone Numbers",
@@ -1169,7 +1194,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Phone Numbers"
       },
       "post": {
         "operationId": "createPhoneNumbers",
@@ -1218,10 +1244,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Phone Numbers"
       }
     },
-    "/lead_stages/": {
+    "/lead_stages": {
       "get": {
         "operationId": "listLeadStages",
         "summary": "List Lead Stages",
@@ -1262,7 +1289,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Lead Stages"
       },
       "post": {
         "operationId": "createLeadStages",
@@ -1311,10 +1339,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Lead Stages"
       }
     },
-    "/events/": {
+    "/events": {
       "get": {
         "operationId": "listEvents",
         "summary": "List Events",
@@ -1355,7 +1384,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Events"
       },
       "post": {
         "operationId": "createEvents",
@@ -1404,10 +1434,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Events"
       }
     },
-    "/email_addresses/": {
+    "/email_addresses": {
       "get": {
         "operationId": "listEmailAddresses",
         "summary": "List Email Addresses",
@@ -1448,7 +1479,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Email Addresses"
       },
       "post": {
         "operationId": "createEmailAddresses",
@@ -1497,10 +1529,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Email Addresses"
       }
     },
-    "/company_users/": {
+    "/company_users": {
       "get": {
         "operationId": "listCompanyUsers",
         "summary": "List Company Users",
@@ -1541,7 +1574,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Company Users"
       },
       "post": {
         "operationId": "createCompanyUsers",
@@ -1590,7 +1624,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Company Users"
       }
     }
   },
@@ -1622,6 +1657,59 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Activities"
+    },
+    {
+      "name": "Agents"
+    },
+    {
+      "name": "Companies"
+    },
+    {
+      "name": "Company Users"
+    },
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Email Addresses"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Lead Stages"
+    },
+    {
+      "name": "Lead Statuses"
+    },
+    {
+      "name": "Leads"
+    },
+    {
+      "name": "Opportunities"
+    },
+    {
+      "name": "Organizations"
+    },
+    {
+      "name": "Phone Numbers"
+    },
+    {
+      "name": "Tasks"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Wall Post Replies"
+    },
+    {
+      "name": "Wall Posts"
     }
   ]
 }

--- a/apis/openapi/commmune.com/commune/2.0.0/openapi.json
+++ b/apis/openapi/commmune.com/commune/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Commune API",
     "version": "2.0.0",
     "description": "Community management and engagement platform API (Swagger spec unavailable)",
-    "x-jentic-source-url": "https://api.commmune.com/v2/api-docs/"
+    "x-jentic-source-url": "https://api.commmune.com/v2/api-docs/",
+    "contact": {}
   },
   "servers": [
     {
@@ -47,7 +48,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "communities"
+        ]
       }
     },
     "/communities/{id}": {
@@ -76,7 +80,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "communities"
+        ]
       }
     },
     "/members": {
@@ -107,7 +114,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "members"
+        ]
       }
     },
     "/posts": {
@@ -138,7 +148,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "posts"
+        ]
       },
       "post": {
         "summary": "Create Post",
@@ -165,7 +178,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/posts/{id}": {
@@ -194,7 +210,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "posts"
+        ]
       }
     },
     "/events": {
@@ -216,7 +235,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "events"
+        ]
       }
     }
   },
@@ -308,7 +330,11 @@
       },
       "PostRequest": {
         "type": "object",
-        "required": ["community_id", "title", "content"],
+        "required": [
+          "community_id",
+          "title",
+          "content"
+        ],
         "properties": {
           "community_id": {
             "type": "string"
@@ -344,5 +370,19 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "communities"
+    },
+    {
+      "name": "events"
+    },
+    {
+      "name": "members"
+    },
+    {
+      "name": "posts"
+    }
+  ]
 }

--- a/apis/openapi/commpeak.com/commpeak-api/2.0.1/openapi.json
+++ b/apis/openapi/commpeak.com/commpeak-api/2.0.1/openapi.json
@@ -4,7 +4,8 @@
     "title": "CommPeak API",
     "version": "2.0.1",
     "description": "CommPeak API providing access to Dialer, Cloud PBX, TextPeak SMS, Billing, Lookup (HLR), and SMS Gateway services for cloud communications.",
-    "x-jentic-source-url": "https://docs.commpeak.com"
+    "x-jentic-source-url": "https://docs.commpeak.com",
+    "contact": {}
   },
   "servers": [
     {
@@ -154,7 +155,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all calls"
       }
     },
     "/calls/aggregated": {
@@ -225,7 +227,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get aggregated call statistics"
       }
     },
     "/calls/{callId}": {
@@ -266,7 +269,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific call"
       }
     },
     "/calls/{callId}/record": {
@@ -308,7 +312,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get call recording file"
       }
     },
     "/click2call": {
@@ -373,7 +378,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Initiate a Click2Call"
       }
     },
     "/campaigns": {
@@ -404,7 +410,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all campaigns"
       }
     },
     "/campaigns/{campaignId}": {
@@ -445,7 +452,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific campaign"
       },
       "put": {
         "operationId": "updateCampaign",
@@ -503,7 +511,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a campaign"
       },
       "delete": {
         "operationId": "deleteCampaign",
@@ -535,7 +544,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a campaign"
       }
     },
     "/campaigns/clone": {
@@ -597,7 +607,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Clone a campaign"
       }
     },
     "/campaigns/{campaignId}/leads": {
@@ -652,7 +663,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get campaign leads"
       }
     },
     "/dispatch/leads": {
@@ -732,7 +744,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Dispatch leads to campaigns"
       }
     },
     "/dispatch/statuses": {
@@ -763,7 +776,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get dispatch statuses"
       }
     },
     "/leads": {
@@ -810,7 +824,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all leads"
       },
       "post": {
         "operationId": "createLead",
@@ -859,7 +874,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a lead"
       }
     },
     "/leads/{leadId}": {
@@ -919,7 +935,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a lead"
       },
       "delete": {
         "operationId": "deleteLead",
@@ -951,7 +968,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a lead"
       }
     },
     "/users": {
@@ -982,7 +1000,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all users"
       },
       "post": {
         "operationId": "createUser",
@@ -1031,7 +1050,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a user"
       }
     },
     "/users/{userId}": {
@@ -1072,7 +1092,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a user"
       },
       "put": {
         "operationId": "updateUser",
@@ -1130,7 +1151,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a user"
       },
       "delete": {
         "operationId": "deleteUser",
@@ -1162,7 +1184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a user"
       }
     },
     "/dnc": {
@@ -1193,7 +1216,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get DNC list"
       },
       "post": {
         "operationId": "createDnc",
@@ -1250,7 +1274,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add number to DNC"
       }
     },
     "/dnc/{dncId}": {
@@ -1291,7 +1316,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a DNC entry"
       },
       "delete": {
         "operationId": "deleteDnc",
@@ -1323,7 +1349,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a DNC entry"
       }
     },
     "/statuses": {
@@ -1354,7 +1381,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all statuses"
       }
     },
     "/statuses/{statusId}": {
@@ -1395,7 +1423,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific status"
       }
     },
     "/cdrs": {
@@ -1458,7 +1487,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all CDRs"
       }
     },
     "/cdrs/aggregate": {
@@ -1511,7 +1541,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Aggregate CDRs"
       }
     },
     "/sms/send": {
@@ -1614,7 +1645,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Send an SMS event"
       }
     },
     "/sms/status": {
@@ -1673,7 +1705,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get SMS message status"
       }
     },
     "/lookup/sync": {
@@ -1725,7 +1758,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Synchronous HLR lookup"
       }
     },
     "/lookup/async": {
@@ -1791,7 +1825,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Asynchronous HLR lookup"
       }
     },
     "/lookup/result/{requestId}": {
@@ -1832,7 +1867,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get async lookup result"
       }
     },
     "/billing/customer": {
@@ -1863,7 +1899,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get customer account details"
       }
     },
     "/billing/voice-rates": {
@@ -1894,7 +1931,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get voice rates"
       }
     },
     "/billing/sms-rates": {
@@ -1925,7 +1963,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get SMS rates"
       }
     }
   },

--- a/apis/openapi/commpeak.com/sms-streams-api/1.0.0/openapi.json
+++ b/apis/openapi/commpeak.com/sms-streams-api/1.0.0/openapi.json
@@ -27,12 +27,14 @@
     }
   ],
   "paths": {
-    "/simple_send/": {
+    "/simple_send": {
       "post": {
         "operationId": "sendMessage",
         "summary": "Send SMS message(s)",
         "description": "Send one or more SMS messages to specified recipients. Each message requires a unique internal ID, sender identifier, recipient phone number, and message content.",
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -121,12 +123,14 @@
         }
       }
     },
-    "/messages_status/": {
+    "/messages_status": {
       "post": {
         "operationId": "getMessageStatus",
         "summary": "Check message delivery status",
         "description": "Check the delivery status of previously sent SMS messages using their message UUIDs.",
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -183,7 +187,9 @@
     "schemas": {
       "SendMessageRequest": {
         "type": "object",
-        "required": ["messages"],
+        "required": [
+          "messages"
+        ],
         "properties": {
           "messages": {
             "type": "array",
@@ -196,7 +202,12 @@
       },
       "MessageItem": {
         "type": "object",
-        "required": ["internal_id", "sender", "recipient_phone", "message_content"],
+        "required": [
+          "internal_id",
+          "sender",
+          "recipient_phone",
+          "message_content"
+        ],
         "properties": {
           "internal_id": {
             "type": "string",
@@ -259,7 +270,9 @@
       },
       "MessageStatusRequest": {
         "type": "object",
-        "required": ["message_uuids"],
+        "required": [
+          "message_uuids"
+        ],
         "properties": {
           "message_uuids": {
             "type": "array",

--- a/apis/openapi/communitiesuk.github.io/waste-services-api/1.0.0/openapi.json
+++ b/apis/openapi/communitiesuk.github.io/waste-services-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Waste Services API",
     "version": "1.0.0",
     "description": "UK government Waste Services API for querying waste collection services, tasks, events, features, sites, and cases by UPRN/USRN.",
-    "x-jentic-source-url": "https://communitiesuk.github.io/waste-service-standards/apis/waste_services.html"
+    "x-jentic-source-url": "https://communitiesuk.github.io/waste-service-standards/apis/waste_services.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,17 +18,83 @@
         "operationId": "listServices",
         "summary": "Retrieve list of waste services",
         "description": "Retrieve list of waste services, optionally filtered by UPRN and date range",
-        "tags": ["Services"],
+        "tags": [
+          "Services"
+        ],
         "parameters": [
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "full", "in": "query", "description": "Return full details", "required": false, "schema": {"type": "boolean"}},
-          {"name": "start_date", "in": "query", "description": "Start date filter", "required": false, "schema": {"type": "string", "format": "date"}},
-          {"name": "end_date", "in": "query", "description": "End date filter", "required": false, "schema": {"type": "string", "format": "date"}}
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "full",
+            "in": "query",
+            "description": "Return full details",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Start date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "End date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Service"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Service"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -36,15 +103,60 @@
         "operationId": "getService",
         "summary": "Retrieve single waste service details",
         "description": "Retrieve details of a single waste service by ID",
-        "tags": ["Services"],
+        "tags": [
+          "Services"
+        ],
         "parameters": [
-          {"name": "serviceId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Service ID"},
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "serviceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Service ID"
+          },
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Service"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Service"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -53,18 +165,92 @@
         "operationId": "listTasks",
         "summary": "Retrieve collection tasks",
         "description": "Retrieve list of collection tasks filtered by type, UPRN, or date range",
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "parameters": [
-          {"name": "type", "in": "query", "description": "Task type filter", "required": false, "schema": {"type": "string"}},
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "start_date", "in": "query", "description": "Start date filter", "required": false, "schema": {"type": "string", "format": "date"}},
-          {"name": "end_date", "in": "query", "description": "End date filter", "required": false, "schema": {"type": "string", "format": "date"}},
-          {"name": "include", "in": "query", "description": "Include related resources", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "type",
+            "in": "query",
+            "description": "Task type filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Start date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "End date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "include",
+            "in": "query",
+            "description": "Include related resources",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Task"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Task"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -72,196 +258,811 @@
       "get": {
         "operationId": "getTask",
         "summary": "Retrieve single task details",
-        "tags": ["Tasks"],
-        "parameters": [{"name": "taskId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Task ID"}],
+        "tags": [
+          "Tasks"
+        ],
+        "parameters": [
+          {
+            "name": "taskId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Task ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Task"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Task"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single task details"
       }
     },
     "/event-types": {
       "get": {
         "operationId": "listEventTypes",
         "summary": "Retrieve event type classifications",
-        "tags": ["Event Types"],
+        "tags": [
+          "Event Types"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/EventType"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/EventType"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve event type classifications"
       }
     },
     "/event-types/{eventTypeId}": {
       "get": {
         "operationId": "getEventType",
         "summary": "Retrieve single event type",
-        "tags": ["Event Types"],
-        "parameters": [{"name": "eventTypeId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Event Type ID"}],
+        "tags": [
+          "Event Types"
+        ],
+        "parameters": [
+          {
+            "name": "eventTypeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Event Type ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/EventType"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventType"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single event type"
       }
     },
     "/events": {
       "get": {
         "operationId": "listEvents",
         "summary": "Retrieve waste collection events",
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "parameters": [
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "usrn", "in": "query", "description": "Unique Street Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "start_date", "in": "query", "description": "Start date filter", "required": false, "schema": {"type": "string", "format": "date"}},
-          {"name": "end_date", "in": "query", "description": "End date filter", "required": false, "schema": {"type": "string", "format": "date"}}
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "usrn",
+            "in": "query",
+            "description": "Unique Street Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "start_date",
+            "in": "query",
+            "description": "Start date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          },
+          {
+            "name": "end_date",
+            "in": "query",
+            "description": "End date filter",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Event"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Event"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve waste collection events"
       }
     },
     "/events/{eventId}": {
       "get": {
         "operationId": "getEvent",
         "summary": "Retrieve single event details",
-        "tags": ["Events"],
-        "parameters": [{"name": "eventId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Event ID"}],
+        "tags": [
+          "Events"
+        ],
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Event ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Event"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single event details"
       }
     },
     "/features": {
       "get": {
         "operationId": "listFeatures",
         "summary": "Retrieve waste container features",
-        "tags": ["Features"],
+        "tags": [
+          "Features"
+        ],
         "parameters": [
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "usrn", "in": "query", "description": "Unique Street Reference Number", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "usrn",
+            "in": "query",
+            "description": "Unique Street Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Feature"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Feature"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve waste container features"
       }
     },
     "/features/{featureId}": {
       "get": {
         "operationId": "getFeature",
         "summary": "Retrieve single feature details",
-        "tags": ["Features"],
-        "parameters": [{"name": "featureId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Feature ID"}],
+        "tags": [
+          "Features"
+        ],
+        "parameters": [
+          {
+            "name": "featureId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Feature"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Feature"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single feature details"
       }
     },
     "/feature-types": {
       "get": {
         "operationId": "listFeatureTypes",
         "summary": "Retrieve container type definitions",
-        "tags": ["Feature Types"],
+        "tags": [
+          "Feature Types"
+        ],
         "parameters": [
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/FeatureType"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/FeatureType"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve container type definitions"
       }
     },
     "/feature-types/{featureTypeId}": {
       "get": {
         "operationId": "getFeatureType",
         "summary": "Retrieve single feature type",
-        "tags": ["Feature Types"],
-        "parameters": [{"name": "featureTypeId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Feature Type ID"}],
+        "tags": [
+          "Feature Types"
+        ],
+        "parameters": [
+          {
+            "name": "featureTypeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Feature Type ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/FeatureType"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FeatureType"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single feature type"
       }
     },
     "/sites": {
       "get": {
         "operationId": "listSites",
         "summary": "Retrieve collection sites",
-        "tags": ["Sites"],
+        "tags": [
+          "Sites"
+        ],
         "parameters": [
-          {"name": "usrn", "in": "query", "description": "Unique Street Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "postcode", "in": "query", "description": "Postcode filter", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "usrn",
+            "in": "query",
+            "description": "Unique Street Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postcode",
+            "in": "query",
+            "description": "Postcode filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Site"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Site"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve collection sites"
       }
     },
     "/sites/{id}": {
       "get": {
         "operationId": "getSite",
         "summary": "Retrieve single site by UPRN or alternative ID",
-        "tags": ["Sites"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Site ID or UPRN"}],
+        "tags": [
+          "Sites"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Site ID or UPRN"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Site"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Site"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single site by UPRN or alternative ID"
       }
     },
     "/cases": {
       "get": {
         "operationId": "listCases",
         "summary": "Retrieve service cases",
-        "tags": ["Cases"],
+        "tags": [
+          "Cases"
+        ],
         "parameters": [
-          {"name": "uprn", "in": "query", "description": "Unique Property Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "usrn", "in": "query", "description": "Unique Street Reference Number", "required": false, "schema": {"type": "string"}},
-          {"name": "postcode", "in": "query", "description": "Postcode filter", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "uprn",
+            "in": "query",
+            "description": "Unique Property Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "usrn",
+            "in": "query",
+            "description": "Unique Street Reference Number",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "postcode",
+            "in": "query",
+            "description": "Postcode filter",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Case"}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Case"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve service cases"
       },
       "post": {
         "operationId": "createCase",
         "summary": "Create new service case",
-        "tags": ["Cases"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CaseInput"}}}},
+        "tags": [
+          "Cases"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CaseInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Case created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Case"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Case created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Case"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create new service case"
       }
     },
     "/cases/{caseId}": {
       "get": {
         "operationId": "getCase",
         "summary": "Retrieve single case record",
-        "tags": ["Cases"],
-        "parameters": [{"name": "caseId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Case ID"}],
+        "tags": [
+          "Cases"
+        ],
+        "parameters": [
+          {
+            "name": "caseId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Case ID"
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Case"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Case"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve single case record"
       }
     }
   },
@@ -270,98 +1071,229 @@
       "Service": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "provider": {"type": "string"},
-          "channel": {"type": "string"},
-          "collections": {"type": "array", "items": {"type": "object"}}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string"
+          },
+          "collections": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
         }
       },
       "Task": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "type": {"type": "string"},
-          "status": {"type": "string"},
-          "scheduledDate": {"type": "string", "format": "date"},
-          "features": {"type": "array", "items": {"type": "object"}}
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "scheduledDate": {
+            "type": "string",
+            "format": "date"
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
         }
       },
       "EventType": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          }
         }
       },
       "Event": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "eventTypeId": {"type": "string"},
-          "timestamp": {"type": "string", "format": "date-time"},
-          "latitude": {"type": "number"},
-          "longitude": {"type": "number"},
-          "features": {"type": "array", "items": {"type": "object"}}
+          "id": {
+            "type": "string"
+          },
+          "eventTypeId": {
+            "type": "string"
+          },
+          "timestamp": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          },
+          "features": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          }
         }
       },
       "Feature": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "featureTypeId": {"type": "string"},
-          "uprn": {"type": "string"},
-          "usrn": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "featureTypeId": {
+            "type": "string"
+          },
+          "uprn": {
+            "type": "string"
+          },
+          "usrn": {
+            "type": "string"
+          }
         }
       },
       "FeatureType": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "size": {"type": "string"},
-          "material": {"type": "string"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "size": {
+            "type": "string"
+          },
+          "material": {
+            "type": "string"
+          }
         }
       },
       "Site": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "uprn": {"type": "string"},
-          "address": {"type": "string"},
-          "postcode": {"type": "string"},
-          "latitude": {"type": "number"},
-          "longitude": {"type": "number"}
+          "id": {
+            "type": "string"
+          },
+          "uprn": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          },
+          "latitude": {
+            "type": "number"
+          },
+          "longitude": {
+            "type": "number"
+          }
         }
       },
       "Case": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "status": {"type": "string"},
-          "description": {"type": "string"},
-          "customer": {"type": "object"},
-          "createdAt": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "customer": {
+            "type": "object"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "CaseInput": {
         "type": "object",
         "properties": {
-          "uprn": {"type": "string"},
-          "description": {"type": "string"},
-          "type": {"type": "string"}
+          "uprn": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": {"type": "string", "enum": ["error"]},
-          "code": {"type": "string"},
-          "message": {"type": "string"}
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Cases"
+    },
+    {
+      "name": "Event Types"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Feature Types"
+    },
+    {
+      "name": "Features"
+    },
+    {
+      "name": "Services"
+    },
+    {
+      "name": "Sites"
+    },
+    {
+      "name": "Tasks"
+    }
+  ]
 }

--- a/apis/openapi/computop.com/computop/1.0.0/openapi.json
+++ b/apis/openapi/computop.com/computop/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Computop API",
     "version": "1.0.0",
     "description": "Computop payment processing API for Swish and various payment methods",
-    "x-jentic-source-url": "https://developer.computop.com/"
+    "x-jentic-source-url": "https://developer.computop.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -198,5 +199,13 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Payments"
+    },
+    {
+      "name": "Refunds"
+    }
+  ]
 }

--- a/apis/openapi/conekta.com/conekta-api/2.2.0/openapi.json
+++ b/apis/openapi/conekta.com/conekta-api/2.2.0/openapi.json
@@ -4,449 +4,2087 @@
     "title": "Conekta API",
     "version": "2.2.0",
     "description": "Conekta payment processing API for Mexico. Supports orders, charges, customers, subscriptions, payment links, webhooks, and more.",
-    "x-jentic-source-url": "https://developers.conekta.com/reference/autenticaci%C3%B3n"
+    "x-jentic-source-url": "https://developers.conekta.com/reference/autenticaci%C3%B3n",
+    "contact": {}
   },
-  "servers": [{"url": "https://api.conekta.io"}],
+  "servers": [
+    {
+      "url": "https://api.conekta.io"
+    }
+  ],
   "paths": {
     "/orders": {
       "get": {
-        "operationId": "listOrders", "summary": "List orders", "tags": ["Orders"],
+        "operationId": "listOrders",
+        "summary": "List orders",
+        "tags": [
+          "Orders"
+        ],
         "parameters": [
-          {"name": "limit", "in": "query", "schema": {"type": "integer", "default": 20}},
-          {"name": "next", "in": "query", "schema": {"type": "string"}},
-          {"name": "previous", "in": "query", "schema": {"type": "string"}}
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "next",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "previous",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/OrderListResponse"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OrderListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List orders"
       },
       "post": {
-        "operationId": "createOrder", "summary": "Create order", "tags": ["Orders"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/OrderRequest"}}}},
+        "operationId": "createOrder",
+        "summary": "Create order",
+        "tags": [
+          "Orders"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create order"
       }
     },
     "/orders/{id}": {
       "get": {
-        "operationId": "getOrder", "summary": "Get order", "tags": ["Orders"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getOrder",
+        "summary": "Get order",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get order"
       },
       "put": {
-        "operationId": "updateOrder", "summary": "Update order", "tags": ["Orders"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/OrderRequest"}}}},
+        "operationId": "updateOrder",
+        "summary": "Update order",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/OrderRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update order"
       }
     },
     "/orders/{id}/cancel": {
       "post": {
-        "operationId": "cancelOrder", "summary": "Cancel order", "tags": ["Orders"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "cancelOrder",
+        "summary": "Cancel order",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Cancelled", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Cancel order"
       }
     },
     "/orders/{id}/captures": {
       "post": {
-        "operationId": "captureOrder", "summary": "Capture order", "tags": ["Orders"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "captureOrder",
+        "summary": "Capture order",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Captured", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Captured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Capture order"
       }
     },
     "/orders/{id}/refunds": {
       "post": {
-        "operationId": "refundOrder", "summary": "Refund order", "tags": ["Orders"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "properties": {"amount": {"type": "integer"}, "reason": {"type": "string"}}}}}},
+        "operationId": "refundOrder",
+        "summary": "Refund order",
+        "tags": [
+          "Orders"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "amount": {
+                    "type": "integer"
+                  },
+                  "reason": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Refunded", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Order"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Refunded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Order"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Refund order"
       }
     },
     "/orders/{order_id}/charges": {
       "post": {
-        "operationId": "createCharge", "summary": "Create charge for order", "tags": ["Charges"],
-        "parameters": [{"name": "order_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ChargeRequest"}}}},
+        "operationId": "createCharge",
+        "summary": "Create charge for order",
+        "tags": [
+          "Charges"
+        ],
+        "parameters": [
+          {
+            "name": "order_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ChargeRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Charge"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Charge"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create charge for order"
       }
     },
     "/customers": {
       "get": {
-        "operationId": "listCustomers", "summary": "List customers", "tags": ["Customers"],
-        "parameters": [{"name": "limit", "in": "query", "schema": {"type": "integer", "default": 20}}, {"name": "next", "in": "query", "schema": {"type": "string"}}],
+        "operationId": "listCustomers",
+        "summary": "List customers",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          },
+          {
+            "name": "next",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CustomerListResponse"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CustomerListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List customers"
       },
       "post": {
-        "operationId": "createCustomer", "summary": "Create customer", "tags": ["Customers"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CustomerRequest"}}}},
+        "operationId": "createCustomer",
+        "summary": "Create customer",
+        "tags": [
+          "Customers"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomerRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Customer"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create customer"
       }
     },
     "/customers/{id}": {
       "get": {
-        "operationId": "getCustomer", "summary": "Get customer", "tags": ["Customers"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getCustomer",
+        "summary": "Get customer",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Customer"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get customer"
       },
       "put": {
-        "operationId": "updateCustomer", "summary": "Update customer", "tags": ["Customers"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/CustomerRequest"}}}},
+        "operationId": "updateCustomer",
+        "summary": "Update customer",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CustomerRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Customer"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update customer"
       },
       "delete": {
-        "operationId": "deleteCustomer", "summary": "Delete customer", "tags": ["Customers"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "deleteCustomer",
+        "summary": "Delete customer",
+        "tags": [
+          "Customers"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Deleted", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Customer"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Customer"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete customer"
       }
     },
     "/customers/{customer_id}/payment_methods": {
       "get": {
-        "operationId": "listPaymentMethods", "summary": "List payment methods", "tags": ["PaymentMethods"],
-        "parameters": [{"name": "customer_id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "listPaymentMethods",
+        "summary": "List payment methods",
+        "tags": [
+          "PaymentMethods"
+        ],
+        "parameters": [
+          {
+            "name": "customer_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List payment methods"
       },
       "post": {
-        "operationId": "createPaymentMethod", "summary": "Create payment method", "tags": ["PaymentMethods"],
-        "parameters": [{"name": "customer_id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "properties": {"type": {"type": "string"}, "token_id": {"type": "string"}}}}}},
+        "operationId": "createPaymentMethod",
+        "summary": "Create payment method",
+        "tags": [
+          "PaymentMethods"
+        ],
+        "parameters": [
+          {
+            "name": "customer_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string"
+                  },
+                  "token_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create payment method"
       }
     },
     "/plans": {
       "get": {
-        "operationId": "listPlans", "summary": "List plans", "tags": ["Plans"],
+        "operationId": "listPlans",
+        "summary": "List plans",
+        "tags": [
+          "Plans"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List plans"
       },
       "post": {
-        "operationId": "createPlan", "summary": "Create plan", "tags": ["Plans"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PlanRequest"}}}},
+        "operationId": "createPlan",
+        "summary": "Create plan",
+        "tags": [
+          "Plans"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Plan"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plan"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create plan"
       }
     },
     "/plans/{id}": {
       "get": {
-        "operationId": "getPlan", "summary": "Get plan", "tags": ["Plans"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getPlan",
+        "summary": "Get plan",
+        "tags": [
+          "Plans"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Plan"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get plan"
       },
       "put": {
-        "operationId": "updatePlan", "summary": "Update plan", "tags": ["Plans"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PlanRequest"}}}},
+        "operationId": "updatePlan",
+        "summary": "Update plan",
+        "tags": [
+          "Plans"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanRequest"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Plan"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update plan"
       },
       "delete": {
-        "operationId": "deletePlan", "summary": "Delete plan", "tags": ["Plans"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "deletePlan",
+        "summary": "Delete plan",
+        "tags": [
+          "Plans"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Deleted", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Plan"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Plan"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete plan"
       }
     },
     "/subscriptions": {
       "get": {
-        "operationId": "listSubscriptions", "summary": "List subscriptions", "tags": ["Subscriptions"],
+        "operationId": "listSubscriptions",
+        "summary": "List subscriptions",
+        "tags": [
+          "Subscriptions"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List subscriptions"
       },
       "post": {
-        "operationId": "createSubscription", "summary": "Create subscription", "tags": ["Subscriptions"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createSubscription",
+        "summary": "Create subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create subscription"
       }
     },
     "/subscriptions/{id}": {
       "get": {
-        "operationId": "getSubscription", "summary": "Get subscription", "tags": ["Subscriptions"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getSubscription",
+        "summary": "Get subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get subscription"
       },
       "put": {
-        "operationId": "updateSubscription", "summary": "Update subscription", "tags": ["Subscriptions"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "updateSubscription",
+        "summary": "Update subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Updated", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update subscription"
       }
     },
     "/subscriptions/{id}/cancel": {
       "post": {
-        "operationId": "cancelSubscription", "summary": "Cancel subscription", "tags": ["Subscriptions"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "cancelSubscription",
+        "summary": "Cancel subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Cancelled", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Cancelled",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Cancel subscription"
       }
     },
     "/subscriptions/{id}/pause": {
       "post": {
-        "operationId": "pauseSubscription", "summary": "Pause subscription", "tags": ["Subscriptions"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "pauseSubscription",
+        "summary": "Pause subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Paused", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Paused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Pause subscription"
       }
     },
     "/subscriptions/{id}/resume": {
       "post": {
-        "operationId": "resumeSubscription", "summary": "Resume subscription", "tags": ["Subscriptions"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "resumeSubscription",
+        "summary": "Resume subscription",
+        "tags": [
+          "Subscriptions"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Resumed", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Resumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Resume subscription"
       }
     },
     "/checkouts": {
       "get": {
-        "operationId": "listPaymentLinks", "summary": "List payment links", "tags": ["PaymentLinks"],
+        "operationId": "listPaymentLinks",
+        "summary": "List payment links",
+        "tags": [
+          "PaymentLinks"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List payment links"
       },
       "post": {
-        "operationId": "createPaymentLink", "summary": "Create payment link", "tags": ["PaymentLinks"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createPaymentLink",
+        "summary": "Create payment link",
+        "tags": [
+          "PaymentLinks"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create payment link"
       }
     },
     "/webhooks": {
       "get": {
-        "operationId": "listWebhooks", "summary": "List webhooks", "tags": ["Webhooks"],
+        "operationId": "listWebhooks",
+        "summary": "List webhooks",
+        "tags": [
+          "Webhooks"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List webhooks"
       },
       "post": {
-        "operationId": "createWebhook", "summary": "Create webhook", "tags": ["Webhooks"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object", "properties": {"url": {"type": "string"}, "subscribed_events": {"type": "array", "items": {"type": "string"}}}}}}},
+        "operationId": "createWebhook",
+        "summary": "Create webhook",
+        "tags": [
+          "Webhooks"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "url": {
+                    "type": "string"
+                  },
+                  "subscribed_events": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create webhook"
       }
     },
     "/webhooks/{id}": {
       "get": {
-        "operationId": "getWebhook", "summary": "Get webhook", "tags": ["Webhooks"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getWebhook",
+        "summary": "Get webhook",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get webhook"
       },
       "put": {
-        "operationId": "updateWebhook", "summary": "Update webhook", "tags": ["Webhooks"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "updateWebhook",
+        "summary": "Update webhook",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Updated", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update webhook"
       },
       "delete": {
-        "operationId": "deleteWebhook", "summary": "Delete webhook", "tags": ["Webhooks"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "deleteWebhook",
+        "summary": "Delete webhook",
+        "tags": [
+          "Webhooks"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Deleted", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete webhook"
       }
     },
     "/tokens": {
       "post": {
-        "operationId": "createToken", "summary": "Create token", "tags": ["Tokens"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createToken",
+        "summary": "Create token",
+        "tags": [
+          "Tokens"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create token"
       }
     },
     "/events": {
       "get": {
-        "operationId": "listEvents", "summary": "List events", "tags": ["Events"],
+        "operationId": "listEvents",
+        "summary": "List events",
+        "tags": [
+          "Events"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List events"
       }
     },
     "/events/{id}": {
       "get": {
-        "operationId": "getEvent", "summary": "Get event", "tags": ["Events"],
-        "parameters": [{"name": "id", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "operationId": "getEvent",
+        "summary": "Get event",
+        "tags": [
+          "Events"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get event"
       }
     },
     "/balance": {
       "get": {
-        "operationId": "getBalance", "summary": "Get company balance", "tags": ["Balances"],
+        "operationId": "getBalance",
+        "summary": "Get company balance",
+        "tags": [
+          "Balances"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get company balance"
       }
     },
     "/transactions": {
       "get": {
-        "operationId": "listTransactions", "summary": "List transactions", "tags": ["Transactions"],
+        "operationId": "listTransactions",
+        "summary": "List transactions",
+        "tags": [
+          "Transactions"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List transactions"
       }
     },
     "/transfers": {
       "get": {
-        "operationId": "listTransfers", "summary": "List transfers", "tags": ["Transfers"],
+        "operationId": "listTransfers",
+        "summary": "List transfers",
+        "tags": [
+          "Transfers"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List transfers"
       }
     },
     "/payout_orders": {
       "get": {
-        "operationId": "listPayoutOrders", "summary": "List payout orders", "tags": ["Payouts"],
+        "operationId": "listPayoutOrders",
+        "summary": "List payout orders",
+        "tags": [
+          "Payouts"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List payout orders"
       },
       "post": {
-        "operationId": "createPayoutOrder", "summary": "Create payout order", "tags": ["Payouts"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createPayoutOrder",
+        "summary": "Create payout order",
+        "tags": [
+          "Payouts"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create payout order"
       }
     },
     "/api_keys": {
       "get": {
-        "operationId": "listApiKeys", "summary": "List API keys", "tags": ["ApiKeys"],
+        "operationId": "listApiKeys",
+        "summary": "List API keys",
+        "tags": [
+          "ApiKeys"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List API keys"
       },
       "post": {
-        "operationId": "createApiKey", "summary": "Create API key", "tags": ["ApiKeys"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createApiKey",
+        "summary": "Create API key",
+        "tags": [
+          "ApiKeys"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create API key"
       }
     },
     "/antifraud/blacklist/rules": {
       "get": {
-        "operationId": "listBlacklistRules", "summary": "Get blacklisted rules", "tags": ["Antifraud"],
+        "operationId": "listBlacklistRules",
+        "summary": "Get blacklisted rules",
+        "tags": [
+          "Antifraud"
+        ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get blacklisted rules"
       },
       "post": {
-        "operationId": "createBlacklistRule", "summary": "Create blacklisted rule", "tags": ["Antifraud"],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"type": "object"}}}},
+        "operationId": "createBlacklistRule",
+        "summary": "Create blacklisted rule",
+        "tags": [
+          "Antifraud"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Created", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
-        }
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create blacklisted rule"
       }
     }
   },
@@ -455,106 +2093,259 @@
       "Order": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "amount": {"type": "integer"},
-          "currency": {"type": "string"},
-          "payment_status": {"type": "string"},
-          "created_at": {"type": "integer"},
-          "updated_at": {"type": "integer"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "payment_status": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "integer"
+          }
         }
       },
       "OrderRequest": {
         "type": "object",
-        "required": ["currency", "line_items"],
+        "required": [
+          "currency",
+          "line_items"
+        ],
         "properties": {
-          "currency": {"type": "string"},
-          "customer_info": {"type": "object", "properties": {"customer_id": {"type": "string"}, "name": {"type": "string"}, "email": {"type": "string"}, "phone": {"type": "string"}}},
-          "line_items": {"type": "array", "items": {"type": "object", "properties": {"name": {"type": "string"}, "unit_price": {"type": "integer"}, "quantity": {"type": "integer"}}}}
+          "currency": {
+            "type": "string"
+          },
+          "customer_info": {
+            "type": "object",
+            "properties": {
+              "customer_id": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "email": {
+                "type": "string"
+              },
+              "phone": {
+                "type": "string"
+              }
+            }
+          },
+          "line_items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "unit_price": {
+                  "type": "integer"
+                },
+                "quantity": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
         }
       },
       "OrderListResponse": {
         "type": "object",
         "properties": {
-          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Order"}},
-          "has_more": {"type": "boolean"},
-          "total": {"type": "integer"}
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Order"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          },
+          "total": {
+            "type": "integer"
+          }
         }
       },
       "Charge": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "amount": {"type": "integer"},
-          "status": {"type": "string"},
-          "payment_method": {"type": "object"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string"
+          },
+          "payment_method": {
+            "type": "object"
+          }
         }
       },
       "ChargeRequest": {
         "type": "object",
         "properties": {
-          "payment_method": {"type": "object", "properties": {"type": {"type": "string"}, "token_id": {"type": "string"}}}
+          "payment_method": {
+            "type": "object",
+            "properties": {
+              "type": {
+                "type": "string"
+              },
+              "token_id": {
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "Customer": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "phone": {"type": "string"},
-          "created_at": {"type": "integer"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "integer"
+          }
         }
       },
       "CustomerRequest": {
         "type": "object",
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "email": {"type": "string"},
-          "phone": {"type": "string"}
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phone": {
+            "type": "string"
+          }
         }
       },
       "CustomerListResponse": {
         "type": "object",
         "properties": {
-          "data": {"type": "array", "items": {"$ref": "#/components/schemas/Customer"}},
-          "has_more": {"type": "boolean"}
+          "data": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Customer"
+            }
+          },
+          "has_more": {
+            "type": "boolean"
+          }
         }
       },
       "Plan": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "object": {"type": "string"},
-          "name": {"type": "string"},
-          "amount": {"type": "integer"},
-          "currency": {"type": "string"},
-          "interval": {"type": "string"},
-          "frequency": {"type": "integer"}
+          "id": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string"
+          },
+          "frequency": {
+            "type": "integer"
+          }
         }
       },
       "PlanRequest": {
         "type": "object",
-        "required": ["name", "amount", "currency", "interval"],
+        "required": [
+          "name",
+          "amount",
+          "currency",
+          "interval"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "amount": {"type": "integer"},
-          "currency": {"type": "string"},
-          "interval": {"type": "string", "enum": ["week", "half_month", "month", "year"]},
-          "frequency": {"type": "integer"}
+          "name": {
+            "type": "string"
+          },
+          "amount": {
+            "type": "integer"
+          },
+          "currency": {
+            "type": "string"
+          },
+          "interval": {
+            "type": "string",
+            "enum": [
+              "week",
+              "half_month",
+              "month",
+              "year"
+            ]
+          },
+          "frequency": {
+            "type": "integer"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "object": {"type": "string"},
-          "type": {"type": "string"},
-          "message": {"type": "string"},
-          "message_to_purchaser": {"type": "string"},
-          "code": {"type": "string"}
+          "object": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          },
+          "message_to_purchaser": {
+            "type": "string"
+          },
+          "code": {
+            "type": "string"
+          }
         }
       }
     },
@@ -566,5 +2357,59 @@
       }
     }
   },
-  "security": [{"bearerAuth": []}]
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Antifraud"
+    },
+    {
+      "name": "ApiKeys"
+    },
+    {
+      "name": "Balances"
+    },
+    {
+      "name": "Charges"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "PaymentLinks"
+    },
+    {
+      "name": "PaymentMethods"
+    },
+    {
+      "name": "Payouts"
+    },
+    {
+      "name": "Plans"
+    },
+    {
+      "name": "Subscriptions"
+    },
+    {
+      "name": "Tokens"
+    },
+    {
+      "name": "Transactions"
+    },
+    {
+      "name": "Transfers"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }

--- a/apis/openapi/confluence.dimagi.com/commcare-api/0.5.0/openapi.json
+++ b/apis/openapi/confluence.dimagi.com/commcare-api/0.5.0/openapi.json
@@ -1686,6 +1686,17 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      },
+      "BasicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
     }
   }
 }

--- a/apis/openapi/confluence.dimagi.com/commcare-api/0.5.0/openapi.json
+++ b/apis/openapi/confluence.dimagi.com/commcare-api/0.5.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CommCare HQ API",
     "version": "0.5.0",
     "description": "CommCare HQ REST API for managing cases, forms, users, applications, and other data in CommCare mobile data collection platform by Dimagi.",
-    "x-jentic-source-url": "https://confluence.dimagi.com/display/commcarepublic/CommCare+API+Overview"
+    "x-jentic-source-url": "https://confluence.dimagi.com/display/commcarepublic/CommCare+API+Overview",
+    "contact": {}
   },
   "servers": [
     {
@@ -55,7 +56,7 @@
     }
   ],
   "paths": {
-    "/a/{domain}/api/v0.5/case/": {
+    "/a/{domain}/api/v0.5/case": {
       "post": {
         "operationId": "createOrUpdateCase",
         "tags": [
@@ -111,7 +112,7 @@
         }
       }
     },
-    "/a/{domain}/api/v0.5/case/{caseId}/": {
+    "/a/{domain}/api/v0.5/case/{caseId}": {
       "get": {
         "operationId": "getCase",
         "tags": [
@@ -171,10 +172,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific case"
       }
     },
-    "/a/{domain}/api/v0.5/case/bulk-fetch/": {
+    "/a/{domain}/api/v0.5/case/bulk-fetch": {
       "post": {
         "operationId": "bulkFetchCases",
         "tags": [
@@ -248,7 +250,7 @@
         }
       }
     },
-    "/a/{domain}/api/v0.5/form/": {
+    "/a/{domain}/api/v0.5/form": {
       "get": {
         "operationId": "listForms",
         "tags": [
@@ -370,7 +372,7 @@
         }
       }
     },
-    "/a/{domain}/api/v0.5/form/{formId}/": {
+    "/a/{domain}/api/v0.5/form/{formId}": {
       "get": {
         "operationId": "getForm",
         "tags": [
@@ -430,7 +432,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific form submission"
       }
     },
     "/a/{domain}/api/v0.5/form/{formId}/attachment/{attachmentName}": {
@@ -489,10 +492,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a form attachment"
       }
     },
-    "/a/{domain}/api/v0.5/user/": {
+    "/a/{domain}/api/v0.5/user": {
       "get": {
         "operationId": "listMobileWorkers",
         "tags": [
@@ -562,10 +566,11 @@
               }
             }
           }
-        }
+        },
+        "description": "List mobile workers"
       }
     },
-    "/a/{domain}/api/v0.5/user/{userId}/": {
+    "/a/{domain}/api/v0.5/user/{userId}": {
       "get": {
         "operationId": "getMobileWorker",
         "tags": [
@@ -625,10 +630,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a mobile worker"
       }
     },
-    "/a/{domain}/api/v0.5/web-user/": {
+    "/a/{domain}/api/v0.5/web-user": {
       "get": {
         "operationId": "listWebUsers",
         "tags": [
@@ -698,10 +704,11 @@
               }
             }
           }
-        }
+        },
+        "description": "List web users"
       }
     },
-    "/a/{domain}/api/v0.5/web-user/{userId}/": {
+    "/a/{domain}/api/v0.5/web-user/{userId}": {
       "get": {
         "operationId": "getWebUser",
         "tags": [
@@ -761,10 +768,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a web user"
       }
     },
-    "/a/{domain}/api/v0.5/application/": {
+    "/a/{domain}/api/v0.5/application": {
       "get": {
         "operationId": "listApplications",
         "tags": [
@@ -834,10 +842,11 @@
               }
             }
           }
-        }
+        },
+        "description": "List applications"
       }
     },
-    "/a/{domain}/api/v0.5/application/{appId}/": {
+    "/a/{domain}/api/v0.5/application/{appId}": {
       "get": {
         "operationId": "getApplication",
         "tags": [
@@ -897,10 +906,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an application"
       }
     },
-    "/a/{domain}/api/v0.5/fixture/": {
+    "/a/{domain}/api/v0.5/fixture": {
       "get": {
         "operationId": "listFixtures",
         "tags": [
@@ -978,10 +988,11 @@
               }
             }
           }
-        }
+        },
+        "description": "List lookup tables (fixtures)"
       }
     },
-    "/a/{domain}/api/v0.5/fixture/{fixtureId}/": {
+    "/a/{domain}/api/v0.5/fixture/{fixtureId}": {
       "get": {
         "operationId": "getFixture",
         "tags": [
@@ -1041,10 +1052,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a lookup table"
       }
     },
-    "/a/{domain}/api/v0.5/sms/": {
+    "/a/{domain}/api/v0.5/sms": {
       "get": {
         "operationId": "listSmsMessages",
         "tags": [
@@ -1114,10 +1126,11 @@
               }
             }
           }
-        }
+        },
+        "description": "List SMS messages"
       }
     },
-    "/a/{domain}/api/v0.5/sms/{messageId}/": {
+    "/a/{domain}/api/v0.5/sms/{messageId}": {
       "get": {
         "operationId": "getSmsMessage",
         "tags": [
@@ -1177,10 +1190,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an SMS message"
       }
     },
-    "/a/{domain}/receiver/": {
+    "/a/{domain}/receiver": {
       "post": {
         "operationId": "submitForm",
         "tags": [
@@ -1238,19 +1252,6 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "BasicAuth": {
-        "type": "http",
-        "scheme": "basic",
-        "description": "HTTP Basic authentication with CommCare HQ credentials"
-      },
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization",
-        "description": "HMAC API key authentication: ApiKey {username}:{api_key}"
-      }
-    },
     "schemas": {
       "ErrorResponse": {
         "type": "object",
@@ -1682,20 +1683,6 @@
           },
           "resource_uri": {
             "type": "string"
-          }
-        }
-      },
-      "Pagination": {
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer"
-          },
-          "limit": {
-            "type": "integer"
-          },
-          "total": {
-            "type": "integer"
           }
         }
       }

--- a/apis/openapi/congress.gov/congress-api/3.0.0/openapi.json
+++ b/apis/openapi/congress.gov/congress-api/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Congress.gov API",
     "version": "3.0.0",
     "description": "The Congress.gov API provides structured data about U.S. legislative information including bills, amendments, members, committees, nominations, treaties, and more.",
-    "x-jentic-source-url": "https://api.congress.gov"
+    "x-jentic-source-url": "https://api.congress.gov",
+    "contact": {}
   },
   "servers": [
     {
@@ -174,7 +175,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all bills"
       }
     },
     "/bill/{congress}": {
@@ -288,7 +290,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List bills by congress"
       }
     },
     "/bill/{congress}/{billType}": {
@@ -421,7 +424,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List bills by congress and type"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}": {
@@ -563,7 +567,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/actions": {
@@ -705,7 +710,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get actions on a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/amendments": {
@@ -847,7 +853,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get amendments to a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/committees": {
@@ -989,7 +996,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get committees for a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/cosponsors": {
@@ -1131,7 +1139,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cosponsors of a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/relatedbills": {
@@ -1273,7 +1282,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get related bills"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/subjects": {
@@ -1415,7 +1425,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get subjects for a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/summaries": {
@@ -1557,7 +1568,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get summaries for a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/text": {
@@ -1699,7 +1711,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get text versions of a bill"
       }
     },
     "/bill/{congress}/{billType}/{billNumber}/titles": {
@@ -1841,7 +1854,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get titles of a bill"
       }
     },
     "/amendment": {
@@ -1946,7 +1960,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all amendments"
       }
     },
     "/amendment/{congress}": {
@@ -2060,7 +2075,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List amendments by congress"
       }
     },
     "/amendment/{congress}/{amendmentType}": {
@@ -2188,7 +2204,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List amendments by type"
       }
     },
     "/amendment/{congress}/{amendmentType}/{amendmentNumber}": {
@@ -2325,7 +2342,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific amendment"
       }
     },
     "/amendment/{congress}/{amendmentType}/{amendmentNumber}/actions": {
@@ -2462,7 +2480,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get actions on an amendment"
       }
     },
     "/amendment/{congress}/{amendmentType}/{amendmentNumber}/cosponsors": {
@@ -2599,7 +2618,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cosponsors of an amendment"
       }
     },
     "/amendment/{congress}/{amendmentType}/{amendmentNumber}/amendments": {
@@ -2736,7 +2756,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get amendments to an amendment"
       }
     },
     "/amendment/{congress}/{amendmentType}/{amendmentNumber}/text": {
@@ -2873,7 +2894,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get text of an amendment"
       }
     },
     "/member": {
@@ -2985,7 +3007,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all members"
       }
     },
     "/member/{bioguideId}": {
@@ -3099,7 +3122,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific member"
       }
     },
     "/member/congress/{congress}": {
@@ -3220,7 +3244,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List members by congress"
       }
     },
     "/member/congress/{congress}/{stateCode}": {
@@ -3350,7 +3375,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List members by congress and state"
       }
     },
     "/member/congress/{congress}/{stateCode}/{district}": {
@@ -3489,7 +3515,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List members by congress, state and district"
       }
     },
     "/member/{bioguideId}/sponsored-legislation": {
@@ -3603,7 +3630,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get sponsored legislation"
       }
     },
     "/member/{bioguideId}/cosponsored-legislation": {
@@ -3717,7 +3745,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get cosponsored legislation"
       }
     },
     "/committee": {
@@ -3822,7 +3851,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all committees"
       }
     },
     "/committee/{chamber}": {
@@ -3940,7 +3970,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List committees by chamber"
       }
     },
     "/committee-report": {
@@ -4045,7 +4076,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all committee reports"
       }
     },
     "/committee-report/{congress}": {
@@ -4159,7 +4191,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List reports by congress"
       }
     },
     "/committee-report/{congress}/{reportType}": {
@@ -4287,7 +4320,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List reports by type"
       }
     },
     "/committee-report/{congress}/{reportType}/{reportNumber}": {
@@ -4424,7 +4458,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific report"
       }
     },
     "/nomination": {
@@ -4529,7 +4564,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all nominations"
       }
     },
     "/nomination/{congress}": {
@@ -4643,7 +4679,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List nominations by congress"
       }
     },
     "/nomination/{congress}/{nominationNumber}": {
@@ -4766,7 +4803,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific nomination"
       }
     },
     "/nomination/{congress}/{nominationNumber}/actions": {
@@ -4889,7 +4927,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get nomination actions"
       }
     },
     "/treaty": {
@@ -4994,7 +5033,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all treaties"
       }
     },
     "/treaty/{congress}": {
@@ -5108,7 +5148,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List treaties by congress"
       }
     },
     "/treaty/{congress}/{treatyNumber}": {
@@ -5231,7 +5272,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific treaty"
       }
     },
     "/treaty/{congress}/{treatyNumber}/actions": {
@@ -5354,7 +5396,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get treaty actions"
       }
     },
     "/law/{congress}": {
@@ -5468,7 +5511,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List laws by congress"
       }
     },
     "/law/{congress}/{lawType}": {
@@ -5595,7 +5639,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List laws by type"
       }
     },
     "/law/{congress}/{lawType}/{lawNumber}": {
@@ -5731,7 +5776,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific law"
       }
     },
     "/house-communication": {
@@ -5836,7 +5882,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all house communications"
       }
     },
     "/house-communication/{congress}": {
@@ -5950,7 +5997,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List house communications by congress"
       }
     },
     "/house-communication/{congress}/{communicationType}": {
@@ -6079,7 +6127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List by type"
       }
     },
     "/house-communication/{congress}/{communicationType}/{communicationNumber}": {
@@ -6217,7 +6266,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific house communication"
       }
     },
     "/senate-communication": {
@@ -6322,7 +6372,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all senate communications"
       }
     },
     "/senate-communication/{congress}": {
@@ -6436,7 +6487,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List senate communications by congress"
       }
     },
     "/senate-communication/{congress}/{communicationType}": {
@@ -6565,7 +6617,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List by type"
       }
     },
     "/senate-communication/{congress}/{communicationType}/{communicationNumber}": {
@@ -6703,7 +6756,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific senate communication"
       }
     },
     "/congressional-record": {
@@ -6829,7 +6883,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Congressional Record issues"
       }
     },
     "/summaries": {
@@ -6934,7 +6989,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all bill summaries"
       }
     },
     "/summaries/{congress}": {
@@ -7048,7 +7104,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List summaries by congress"
       }
     },
     "/summaries/{congress}/{billType}": {
@@ -7181,7 +7238,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List summaries by bill type"
       }
     },
     "/congress": {
@@ -7286,7 +7344,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all congresses"
       }
     },
     "/congress/{congress}": {
@@ -7400,7 +7459,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a specific congress"
       }
     },
     "/congress/current": {
@@ -7505,7 +7565,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get the current congress"
       }
     }
   },

--- a/apis/openapi/consumerfinance.gov/the-consumer-financial-protection-bureau/1.0/openapi.json
+++ b/apis/openapi/consumerfinance.gov/the-consumer-financial-protection-bureau/1.0/openapi.json
@@ -27,7 +27,8 @@
       }
     ],
     "x-providerName": "consumerfinance.gov",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/consumerfinance.gov/1.0/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/consumerfinance.gov/1.0/swagger.yaml",
+    "contact": {}
   },
   "externalDocs": {
     "url": "http://cfpb.github.io/api/hmda/"
@@ -58,7 +59,8 @@
         "summary": "Get a list of all datasets.",
         "tags": [
           "data"
-        ]
+        ],
+        "description": "Get a list of all datasets."
       }
     },
     "/data/hmda": {
@@ -77,7 +79,8 @@
         "summary": "Get metadata for this dataset.",
         "tags": [
           "hmda"
-        ]
+        ],
+        "description": "Get metadata for this dataset."
       }
     },
     "/data/hmda/concept/{concept}": {
@@ -105,7 +108,8 @@
         "summary": "Get information about a particular concept in this dataset.",
         "tags": [
           "hmda"
-        ]
+        ],
+        "description": "Get information about a particular concept in this dataset."
       }
     },
     "/data/hmda/slice/{slice}": {
@@ -186,7 +190,8 @@
         "summary": "Query a slice in this dataset.",
         "tags": [
           "hmda"
-        ]
+        ],
+        "description": "Query a slice in this dataset."
       }
     },
     "/data/hmda/slice/{slice}/metadata": {
@@ -214,7 +219,8 @@
         "summary": "Get the metadata for a slice in this dataset.",
         "tags": [
           "hmda"
-        ]
+        ],
+        "description": "Get the metadata for a slice in this dataset."
       }
     },
     "/data/{dataset}": {
@@ -241,7 +247,8 @@
         "summary": "Get metadata about a dataset.",
         "tags": [
           "data"
-        ]
+        ],
+        "description": "Get metadata about a dataset."
       }
     }
   },

--- a/apis/openapi/context-link.ai/context-link-api/1.0.0/openapi.json
+++ b/apis/openapi/context-link.ai/context-link-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Context Link API",
     "version": "1.0.0",
     "description": "Context-aware AI API. Retrieves responses from connected knowledge sources based on search queries.",
-    "x-jentic-source-url": "https://context-link.ai/docs/context-endpoint"
+    "x-jentic-source-url": "https://context-link.ai/docs/context-endpoint",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
           "429": {
             "description": "Rate limit exceeded (5 requests per 10 seconds)"
           }
-        }
+        },
+        "description": "Get context response"
       }
     }
   },
@@ -73,27 +75,17 @@
             ]
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "name": "Authorization",
-        "in": "header"
       }
     }
   },
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Context"
     }
   ]
 }

--- a/apis/openapi/context-link.ai/context-link-api/1.0.0/openapi.json
+++ b/apis/openapi/context-link.ai/context-link-api/1.0.0/openapi.json
@@ -76,6 +76,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/contlo.com/contlo-api/1.0.0/openapi.json
+++ b/apis/openapi/contlo.com/contlo-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Contlo API",
     "version": "1.0.0",
     "description": "Contlo marketing API for managing subscribers, customers, events, and profiles.",
-    "x-jentic-source-url": "https://github.com/rupam-kerketta/contlo-zapier-doc-ref"
+    "x-jentic-source-url": "https://github.com/rupam-kerketta/contlo-zapier-doc-ref",
+    "contact": {}
   },
   "servers": [
     {
@@ -55,7 +56,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Authenticate with API key"
       }
     },
     "/api/integrations/zapier/subscribers": {
@@ -99,7 +101,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscribers"
       }
     },
     "/api/integrations/zapier/customers": {
@@ -143,7 +146,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List customers"
       }
     },
     "/v1/track": {
@@ -216,7 +220,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Track an event"
       }
     },
     "/v1/identify": {
@@ -289,7 +294,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create or identify subscriber"
       }
     }
   },
@@ -367,6 +373,20 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Subscribers"
     }
   ]
 }

--- a/apis/openapi/controller.kloudfox.com/controller/v1/openapi.json
+++ b/apis/openapi/controller.kloudfox.com/controller/v1/openapi.json
@@ -1028,7 +1028,7 @@
     }
   },
   "paths": {
-    "/api/token/": {
+    "/api/token": {
       "post": {
         "operationId": "createToken",
         "summary": "Obtain JWT Token",
@@ -1136,7 +1136,7 @@
         }
       }
     },
-    "/user/register/": {
+    "/user/register": {
       "post": {
         "operationId": "registerUser",
         "summary": "Register New User",
@@ -1172,7 +1172,7 @@
         }
       }
     },
-    "/user/auth/": {
+    "/user/auth": {
       "post": {
         "operationId": "authenticateUser",
         "summary": "Authenticate User",
@@ -1197,10 +1197,11 @@
           "401": {
             "description": "Invalid credentials"
           }
-        }
+        },
+        "description": "Authenticate User"
       }
     },
-    "/user/logout/": {
+    "/user/logout": {
       "post": {
         "operationId": "logoutUser",
         "summary": "Logout User",
@@ -1279,7 +1280,8 @@
           "400": {
             "description": "Invalid input"
           }
-        }
+        },
+        "description": "Update User Profile"
       }
     },
     "/user/profile/update-password": {
@@ -1306,7 +1308,8 @@
           "400": {
             "description": "Invalid input"
           }
-        }
+        },
+        "description": "Update Password"
       }
     },
     "/user/password/forget": {
@@ -1334,7 +1337,8 @@
           "404": {
             "description": "Email not found"
           }
-        }
+        },
+        "description": "Send Password Reset Email"
       }
     },
     "/user/password/reset": {
@@ -1358,7 +1362,8 @@
           "200": {
             "description": "Password reset successful"
           }
-        }
+        },
+        "description": "Reset Password"
       }
     },
     "/user/send/otp": {
@@ -1412,7 +1417,8 @@
           "400": {
             "description": "Invalid OTP"
           }
-        }
+        },
+        "description": "Verify OTP"
       }
     },
     "/user/profile/picture": {
@@ -1433,7 +1439,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Profile Picture"
       },
       "post": {
         "operationId": "uploadProfilePicture",
@@ -1468,7 +1475,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload Profile Picture"
       }
     },
     "/user/get_roles": {
@@ -1482,10 +1490,11 @@
           "200": {
             "description": "Roles list returned"
           }
-        }
+        },
+        "description": "Get Roles"
       }
     },
-    "/user/delete/{id}/": {
+    "/user/delete/{id}": {
       "delete": {
         "operationId": "deleteUser",
         "summary": "Delete User",
@@ -1506,10 +1515,11 @@
           "204": {
             "description": "User deleted"
           }
-        }
+        },
+        "description": "Delete User"
       }
     },
-    "/user/update/{id}/": {
+    "/user/update/{id}": {
       "put": {
         "operationId": "updateUser",
         "summary": "Update User",
@@ -1547,7 +1557,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update User"
       },
       "patch": {
         "operationId": "partialUpdateUser",
@@ -1586,7 +1597,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Partially Update User"
       }
     },
     "/user/delete_account": {
@@ -1610,7 +1622,8 @@
           "204": {
             "description": "Account deleted"
           }
-        }
+        },
+        "description": "Delete Account"
       }
     },
     "/api/user/details": {
@@ -1624,7 +1637,8 @@
           "200": {
             "description": "User details returned"
           }
-        }
+        },
+        "description": "Get User Details"
       }
     },
     "/monitor/list": {
@@ -1701,7 +1715,8 @@
           "400": {
             "description": "Invalid input"
           }
-        }
+        },
+        "description": "Create Monitor"
       }
     },
     "/monitor/bulk/create": {
@@ -1728,7 +1743,8 @@
           "400": {
             "description": "Invalid input"
           }
-        }
+        },
+        "description": "Bulk Create Monitors"
       }
     },
     "/monitor/configure": {
@@ -1752,7 +1768,8 @@
           "200": {
             "description": "Monitor configured"
           }
-        }
+        },
+        "description": "Configure Monitor"
       }
     },
     "/monitor/configure/detail": {
@@ -1776,7 +1793,8 @@
           "200": {
             "description": "Monitor config returned"
           }
-        }
+        },
+        "description": "Get Monitor Configuration"
       }
     },
     "/monitor/detail": {
@@ -1800,7 +1818,8 @@
           "200": {
             "description": "Monitor detail returned"
           }
-        }
+        },
+        "description": "Get Monitor Detail"
       }
     },
     "/monitor/delete": {
@@ -1824,7 +1843,8 @@
           "204": {
             "description": "Monitor deleted"
           }
-        }
+        },
+        "description": "Delete Monitor"
       }
     },
     "/monitor/delete_multiple": {
@@ -1851,7 +1871,8 @@
           "204": {
             "description": "Monitors deleted"
           }
-        }
+        },
+        "description": "Delete Multiple Monitors"
       }
     },
     "/monitor/update_status": {
@@ -1883,7 +1904,8 @@
           "200": {
             "description": "Monitor status updated"
           }
-        }
+        },
+        "description": "Pause/Start Monitoring"
       }
     },
     "/monitor/get_ssl_info": {
@@ -1907,7 +1929,8 @@
           "200": {
             "description": "SSL info returned"
           }
-        }
+        },
+        "description": "Get Monitor SSL Certificate Info"
       }
     },
     "/monitor/graph/stats": {
@@ -1953,7 +1976,8 @@
           "200": {
             "description": "Stats returned"
           }
-        }
+        },
+        "description": "Get Response Time Stats"
       }
     },
     "/monitor/group": {
@@ -1967,7 +1991,8 @@
           "200": {
             "description": "Groups returned"
           }
-        }
+        },
+        "description": "List Monitor Groups"
       },
       "post": {
         "operationId": "createMonitorGroup",
@@ -1989,7 +2014,8 @@
           "201": {
             "description": "Group created"
           }
-        }
+        },
+        "description": "Create Monitor Group"
       }
     },
     "/monitor/group/rename": {
@@ -2013,7 +2039,8 @@
           "200": {
             "description": "Group renamed"
           }
-        }
+        },
+        "description": "Rename Monitor Group"
       }
     },
     "/monitor/group/update": {
@@ -2037,7 +2064,8 @@
           "200": {
             "description": "Monitors returned"
           }
-        }
+        },
+        "description": "Get Monitors in Group"
       },
       "post": {
         "operationId": "updateMonitorGroup",
@@ -2059,7 +2087,8 @@
           "200": {
             "description": "Group updated"
           }
-        }
+        },
+        "description": "Update Monitors in Group"
       },
       "delete": {
         "operationId": "deleteMonitorGroup",
@@ -2081,7 +2110,8 @@
           "204": {
             "description": "Group deleted"
           }
-        }
+        },
+        "description": "Delete Monitor Group"
       }
     },
     "/monitor/list/resources": {
@@ -2095,7 +2125,8 @@
           "200": {
             "description": "Resources returned"
           }
-        }
+        },
+        "description": "Get Resources List"
       }
     },
     "/monitor/metadata": {
@@ -2109,7 +2140,8 @@
           "200": {
             "description": "Metadata returned"
           }
-        }
+        },
+        "description": "Get Monitors Metadata"
       }
     },
     "/incident/list": {
@@ -2134,7 +2166,8 @@
           "200": {
             "description": "Incidents returned"
           }
-        }
+        },
+        "description": "List Incidents"
       }
     },
     "/incident/detail": {
@@ -2158,7 +2191,8 @@
           "200": {
             "description": "Incident detail returned"
           }
-        }
+        },
+        "description": "Get Incident Detail"
       }
     },
     "/incident/log": {
@@ -2185,7 +2219,8 @@
           "400": {
             "description": "Invalid input"
           }
-        }
+        },
+        "description": "Log New Incident"
       }
     },
     "/incident/update": {
@@ -2209,7 +2244,8 @@
           "200": {
             "description": "Incident updated"
           }
-        }
+        },
+        "description": "Update Incident"
       }
     },
     "/incident/delete": {
@@ -2233,7 +2269,8 @@
           "204": {
             "description": "Incident deleted"
           }
-        }
+        },
+        "description": "Delete Incident"
       }
     },
     "/incident/metadata": {
@@ -2247,7 +2284,8 @@
           "200": {
             "description": "Metadata returned"
           }
-        }
+        },
+        "description": "Get Incidents Metadata"
       }
     },
     "/maintenance/list": {
@@ -2261,7 +2299,8 @@
           "200": {
             "description": "Maintenance list returned"
           }
-        }
+        },
+        "description": "List Maintenance Windows"
       }
     },
     "/maintenance/detail": {
@@ -2285,7 +2324,8 @@
           "200": {
             "description": "Maintenance detail returned"
           }
-        }
+        },
+        "description": "Get Maintenance Detail"
       }
     },
     "/maintenance/schedule": {
@@ -2309,7 +2349,8 @@
           "201": {
             "description": "Maintenance scheduled"
           }
-        }
+        },
+        "description": "Schedule Maintenance"
       }
     },
     "/maintenance/update": {
@@ -2333,7 +2374,8 @@
           "200": {
             "description": "Maintenance updated"
           }
-        }
+        },
+        "description": "Update Maintenance"
       }
     },
     "/maintenance/delete": {
@@ -2357,7 +2399,8 @@
           "204": {
             "description": "Maintenance deleted"
           }
-        }
+        },
+        "description": "Delete Maintenance"
       }
     },
     "/statuspage/list": {
@@ -2371,7 +2414,8 @@
           "200": {
             "description": "Status pages returned"
           }
-        }
+        },
+        "description": "List Status Pages"
       }
     },
     "/statuspage/detail": {
@@ -2395,7 +2439,8 @@
           "200": {
             "description": "Status page detail returned"
           }
-        }
+        },
+        "description": "Get Status Page Detail"
       }
     },
     "/statuspage/create": {
@@ -2419,7 +2464,8 @@
           "201": {
             "description": "Status page created"
           }
-        }
+        },
+        "description": "Create Status Page"
       }
     },
     "/statuspage/configure": {
@@ -2443,7 +2489,8 @@
           "200": {
             "description": "Status page configured"
           }
-        }
+        },
+        "description": "Configure Status Page"
       }
     },
     "/statuspage/delete": {
@@ -2467,7 +2514,8 @@
           "204": {
             "description": "Status page deleted"
           }
-        }
+        },
+        "description": "Delete Status Page"
       }
     },
     "/statuspage/add_subscriber": {
@@ -2491,7 +2539,8 @@
           "201": {
             "description": "Subscriber added"
           }
-        }
+        },
+        "description": "Add Subscriber to Status Page"
       }
     },
     "/statuspage/get_subscriber": {
@@ -2515,7 +2564,8 @@
           "200": {
             "description": "Subscribers returned"
           }
-        }
+        },
+        "description": "Get Status Page Subscribers"
       }
     },
     "/statuspage/delete_subscriber": {
@@ -2539,7 +2589,8 @@
           "204": {
             "description": "Subscriber deleted"
           }
-        }
+        },
+        "description": "Delete Subscriber"
       }
     },
     "/statuspage/domain_availability": {
@@ -2563,7 +2614,8 @@
           "200": {
             "description": "Availability checked"
           }
-        }
+        },
+        "description": "Check Domain Availability"
       }
     },
     "/statuspage/v1/data": {
@@ -2587,7 +2639,8 @@
           "200": {
             "description": "Status page data returned"
           }
-        }
+        },
+        "description": "Get Status Page Data"
       }
     },
     "/integration/get": {
@@ -2601,7 +2654,8 @@
           "200": {
             "description": "Integrations returned"
           }
-        }
+        },
+        "description": "Get Integrations"
       }
     },
     "/integration/slack/add": {
@@ -2615,7 +2669,8 @@
           "200": {
             "description": "Slack URL returned"
           }
-        }
+        },
+        "description": "Get Slack Integration URL"
       }
     },
     "/integration/slack/oauth": {
@@ -2639,7 +2694,8 @@
           "200": {
             "description": "OAuth processed"
           }
-        }
+        },
+        "description": "Slack OAuth Request"
       }
     },
     "/integration/slack/get_channels": {
@@ -2653,7 +2709,8 @@
           "200": {
             "description": "Channels returned"
           }
-        }
+        },
+        "description": "Get Slack Channels"
       }
     },
     "/integration/slack/join_channels": {
@@ -2677,7 +2734,8 @@
           "200": {
             "description": "Channel joined"
           }
-        }
+        },
+        "description": "Join Slack Channel"
       }
     },
     "/integration/slack/delete": {
@@ -2691,7 +2749,8 @@
           "204": {
             "description": "Integration deleted"
           }
-        }
+        },
+        "description": "Delete Slack Integration"
       }
     },
     "/integration/webhook/add": {
@@ -2715,7 +2774,8 @@
           "201": {
             "description": "Webhook configured"
           }
-        }
+        },
+        "description": "Configure Ongoing Webhook"
       }
     },
     "/integration/webhook/delete": {
@@ -2729,7 +2789,8 @@
           "204": {
             "description": "Webhook deleted"
           }
-        }
+        },
+        "description": "Delete Webhook Integration"
       }
     },
     "/integration/zapier/subscribe": {
@@ -2743,7 +2804,8 @@
           "201": {
             "description": "Subscribed"
           }
-        }
+        },
+        "description": "Zapier Subscribe"
       },
       "delete": {
         "operationId": "zapierUnsubscribe",
@@ -2755,7 +2817,8 @@
           "204": {
             "description": "Unsubscribed"
           }
-        }
+        },
+        "description": "Zapier Unsubscribe"
       }
     },
     "/integration/zapier/test_data": {
@@ -2769,7 +2832,8 @@
           "200": {
             "description": "Test data returned"
           }
-        }
+        },
+        "description": "Get Zapier Test Data"
       }
     },
     "/notifications": {
@@ -2793,7 +2857,8 @@
           "200": {
             "description": "Notifications returned"
           }
-        }
+        },
+        "description": "Get Notifications"
       },
       "post": {
         "operationId": "markNotificationRead",
@@ -2815,7 +2880,8 @@
           "200": {
             "description": "Notification marked as read"
           }
-        }
+        },
+        "description": "Mark Notification as Read"
       }
     },
     "/plans": {
@@ -2829,7 +2895,8 @@
           "200": {
             "description": "Plans returned"
           }
-        }
+        },
+        "description": "Get Plans"
       }
     },
     "/plans/stripe/session": {
@@ -2853,7 +2920,8 @@
           "200": {
             "description": "Session created"
           }
-        }
+        },
+        "description": "Create Stripe Payment Session"
       }
     },
     "/subusers": {
@@ -2867,7 +2935,8 @@
           "200": {
             "description": "Sub-users returned"
           }
-        }
+        },
+        "description": "List Sub-Users"
       }
     },
     "/subuser/register": {
@@ -2891,7 +2960,8 @@
           "201": {
             "description": "Sub-user created"
           }
-        }
+        },
+        "description": "Register Sub-User"
       }
     },
     "/subuser/permissions": {
@@ -2915,7 +2985,8 @@
           "200": {
             "description": "Permissions returned"
           }
-        }
+        },
+        "description": "Get Sub-User Permissions"
       },
       "post": {
         "operationId": "updateSubUserPermissions",
@@ -2937,7 +3008,8 @@
           "200": {
             "description": "Permissions updated"
           }
-        }
+        },
+        "description": "Update Sub-User Permissions"
       }
     },
     "/search/resources": {
@@ -2951,7 +3023,8 @@
           "200": {
             "description": "Search results returned"
           }
-        }
+        },
+        "description": "Search Resources"
       }
     },
     "/mobile/get_slider_images": {
@@ -2965,7 +3038,8 @@
           "200": {
             "description": "Images returned"
           }
-        }
+        },
+        "description": "Get Mobile Slider Images"
       }
     },
     "/mobile/update_token": {
@@ -2989,7 +3063,8 @@
           "200": {
             "description": "Token updated"
           }
-        }
+        },
+        "description": "Update Device Token"
       }
     },
     "/user/password/update/{token}": {
@@ -3023,7 +3098,8 @@
           "200": {
             "description": "Password updated"
           }
-        }
+        },
+        "description": "Update Password Using Token"
       }
     }
   }

--- a/apis/openapi/conturs.com/conturs-api/1.0.0/openapi.json
+++ b/apis/openapi/conturs.com/conturs-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Conturs Scoring API",
     "version": "1.0.0",
     "description": "Lead scoring API that scores leads against your personalized ICP model.",
-    "x-jentic-source-url": "https://conturs.com/docs/api-reference"
+    "x-jentic-source-url": "https://conturs.com/docs/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -236,6 +237,14 @@
   "security": [
     {
       "ApiKeyBody": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Health"
+    },
+    {
+      "name": "Leads"
     }
   ]
 }

--- a/apis/openapi/convertapi.com/file-conversion-api/2.0.0/openapi.json
+++ b/apis/openapi/convertapi.com/file-conversion-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "ConvertAPI",
     "version": "2.0.0",
     "description": "ConvertAPI is a file conversion service that provides a REST API for converting files between various formats. Supports documents, images, web pages, and more. The API uses a simple pattern: POST to /convert/{source-format}/to/{destination-format}.",
-    "x-jentic-source-url": "https://docs.convertapi.com"
+    "x-jentic-source-url": "https://docs.convertapi.com",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/convertkit.com/convertkit-kit-api-v3/3.0.0/openapi.json
+++ b/apis/openapi/convertkit.com/convertkit-kit-api-v3/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "ConvertKit (Kit) API V3",
     "description": "ConvertKit (now Kit) API V3 for managing email marketing: subscribers, forms, sequences, tags, broadcasts, purchases, and webhooks.",
     "version": "3.0.0",
-    "x-jentic-source-url": "https://developers.convertkit.com/"
+    "x-jentic-source-url": "https://developers.convertkit.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -105,7 +106,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get account info"
       }
     },
     "/forms": {
@@ -156,7 +158,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all forms"
       }
     },
     "/forms/{form_id}/subscribe": {
@@ -245,7 +248,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add subscriber to a form"
       }
     },
     "/forms/{form_id}/subscriptions": {
@@ -333,7 +337,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions to a form"
       }
     },
     "/subscribers": {
@@ -451,7 +456,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscribers"
       }
     },
     "/subscribers/{id}": {
@@ -510,7 +516,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a subscriber"
       },
       "put": {
         "tags": [
@@ -590,7 +597,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a subscriber"
       }
     },
     "/subscribers/{id}/tags": {
@@ -649,7 +657,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List tags for a subscriber"
       }
     },
     "/unsubscribe": {
@@ -713,7 +722,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Unsubscribe a subscriber"
       }
     },
     "/sequences": {
@@ -764,7 +774,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all sequences"
       }
     },
     "/sequences/{sequence_id}/subscribe": {
@@ -853,7 +864,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add subscriber to a sequence"
       }
     },
     "/sequences/{sequence_id}/subscriptions": {
@@ -941,7 +953,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions to a sequence"
       }
     },
     "/tags": {
@@ -992,7 +1005,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all tags"
       },
       "post": {
         "tags": [
@@ -1061,7 +1075,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a tag"
       }
     },
     "/tags/{tag_id}/subscribe": {
@@ -1144,7 +1159,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Tag a subscriber"
       }
     },
     "/tags/{tag_id}/unsubscribe": {
@@ -1218,7 +1234,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove tag from subscriber"
       }
     },
     "/tags/{tag_id}/subscriptions": {
@@ -1306,7 +1323,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List subscriptions to a tag"
       }
     },
     "/broadcasts": {
@@ -1364,7 +1382,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List broadcasts"
       },
       "post": {
         "tags": [
@@ -1452,7 +1471,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a broadcast"
       }
     },
     "/broadcasts/{id}": {
@@ -1511,7 +1531,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a broadcast"
       },
       "put": {
         "tags": [
@@ -1590,7 +1611,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a broadcast"
       },
       "delete": {
         "tags": [
@@ -1647,7 +1669,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a broadcast"
       }
     },
     "/broadcasts/{id}/stats": {
@@ -1706,7 +1729,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get broadcast stats"
       }
     },
     "/purchases": {
@@ -1764,7 +1788,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List purchases"
       },
       "post": {
         "tags": [
@@ -1885,7 +1910,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a purchase"
       }
     },
     "/purchases/{id}": {
@@ -1944,7 +1970,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a purchase"
       }
     },
     "/automations/hooks": {
@@ -2028,7 +2055,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a webhook"
       }
     },
     "/automations/hooks/{id}": {
@@ -2087,7 +2115,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a webhook"
       }
     },
     "/custom_fields": {
@@ -2138,7 +2167,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List custom fields"
       },
       "post": {
         "tags": [
@@ -2199,7 +2229,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a custom field"
       }
     },
     "/custom_fields/{id}": {
@@ -2271,7 +2302,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a custom field"
       },
       "delete": {
         "tags": [
@@ -2328,7 +2360,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a custom field"
       }
     }
   },

--- a/apis/openapi/coordinatehq.com/coordinatehq-api/1.0.0/openapi.json
+++ b/apis/openapi/coordinatehq.com/coordinatehq-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CoordinateHQ API",
     "version": "1.0.0",
     "description": "CoordinateHQ project management API for managing projects, tasks, groups, stakeholders, goals, organizations, and webhooks.",
-    "x-jentic-source-url": "https://app.coordinatehq.com/static/API_Documentation.html"
+    "x-jentic-source-url": "https://app.coordinatehq.com/static/API_Documentation.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -60,7 +61,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a new project"
       },
       "get": {
         "operationId": "listProjects",
@@ -119,7 +121,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all projects"
       }
     },
     "/projects/{project_id}": {
@@ -170,7 +173,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a project"
       },
       "post": {
         "operationId": "updateProject",
@@ -229,7 +233,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a project"
       }
     },
     "/projects/external_object_id/{external_object_id}": {
@@ -280,7 +285,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get project by external ID"
       }
     },
     "/projects/{project_id}/apply_playbook": {
@@ -345,7 +351,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Apply template to project"
       }
     },
     "/projects/{project_id}/task": {
@@ -406,7 +413,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a task"
       },
       "get": {
         "operationId": "listTasks",
@@ -472,7 +480,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project tasks"
       }
     },
     "/projects/{project_id}/task/{task_id}": {
@@ -531,7 +540,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a task"
       },
       "post": {
         "operationId": "updateTask",
@@ -598,7 +608,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a task"
       }
     },
     "/projects/{project_id}/stakeholder": {
@@ -663,7 +674,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add stakeholder to project"
       },
       "get": {
         "operationId": "listStakeholders",
@@ -715,7 +727,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project stakeholders"
       }
     },
     "/projects/{project_id}/group": {
@@ -774,7 +787,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a task group"
       },
       "get": {
         "operationId": "listGroups",
@@ -816,7 +830,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project groups"
       }
     },
     "/projects/{project_id}/goal": {
@@ -875,7 +890,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a goal"
       },
       "get": {
         "operationId": "listGoals",
@@ -917,7 +933,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project goals"
       }
     },
     "/projects/{project_id}/discussion_entry": {
@@ -961,7 +978,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get project comments"
       }
     },
     "/projects/{project_id}/task/{task_id}/discussion_entry": {
@@ -1031,7 +1049,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add comment to task"
       },
       "get": {
         "operationId": "listTaskComments",
@@ -1081,7 +1100,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get task comments"
       }
     },
     "/organizations": {
@@ -1130,7 +1150,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an organization"
       },
       "get": {
         "operationId": "listOrganizations",
@@ -1162,7 +1183,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List organizations"
       }
     },
     "/organizations/{org_id}": {
@@ -1206,7 +1228,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an organization"
       }
     },
     "/webhook_subscribe": {
@@ -1250,7 +1273,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Subscribe to webhooks"
       }
     },
     "/webhook_subscribe/{endpoint_id}": {
@@ -1294,7 +1318,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Unsubscribe from webhooks"
       }
     },
     "/entity": {
@@ -1365,7 +1390,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all entities"
       }
     }
   },
@@ -1494,6 +1520,35 @@
   "security": [
     {
       "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Comments"
+    },
+    {
+      "name": "Entities"
+    },
+    {
+      "name": "Goals"
+    },
+    {
+      "name": "Groups"
+    },
+    {
+      "name": "Organizations"
+    },
+    {
+      "name": "Projects"
+    },
+    {
+      "name": "Stakeholders"
+    },
+    {
+      "name": "Tasks"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/copper.com/copper-crm-api/1.0.0/openapi.json
+++ b/apis/openapi/copper.com/copper-crm-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Copper CRM API",
     "description": "Copper CRM Developer API for managing people, companies, leads, opportunities, projects, tasks, activities, and related items.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developer.copper.com/"
+    "x-jentic-source-url": "https://developer.copper.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -132,7 +133,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get account details"
       }
     },
     "/users/{id}": {
@@ -183,7 +185,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a user by ID"
       }
     },
     "/users/search": {
@@ -241,7 +244,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List users"
       }
     },
     "/people/{id}": {
@@ -292,7 +296,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a person by ID"
       },
       "put": {
         "tags": [
@@ -415,7 +420,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a person"
       },
       "delete": {
         "tags": [
@@ -464,7 +470,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a person"
       }
     },
     "/people": {
@@ -556,7 +563,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a person"
       }
     },
     "/people/search": {
@@ -681,7 +689,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list people"
       }
     },
     "/people/fetch_by_email": {
@@ -741,7 +750,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Fetch person by email"
       }
     },
     "/companies/{id}": {
@@ -792,7 +802,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a company by ID"
       },
       "put": {
         "tags": [
@@ -851,7 +862,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a company"
       },
       "delete": {
         "tags": [
@@ -900,7 +912,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a company"
       }
     },
     "/companies": {
@@ -1001,7 +1014,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a company"
       }
     },
     "/companies/search": {
@@ -1102,7 +1116,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list companies"
       }
     },
     "/leads/{id}": {
@@ -1153,7 +1168,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a lead by ID"
       },
       "put": {
         "tags": [
@@ -1212,7 +1228,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a lead"
       },
       "delete": {
         "tags": [
@@ -1261,7 +1278,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a lead"
       }
     },
     "/leads": {
@@ -1312,7 +1330,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a lead"
       }
     },
     "/leads/search": {
@@ -1392,7 +1411,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list leads"
       }
     },
     "/leads/{id}/convert": {
@@ -1463,7 +1483,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Convert a lead"
       }
     },
     "/opportunities/{id}": {
@@ -1514,7 +1535,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an opportunity by ID"
       },
       "put": {
         "tags": [
@@ -1573,7 +1595,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an opportunity"
       },
       "delete": {
         "tags": [
@@ -1622,7 +1645,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete an opportunity"
       }
     },
     "/opportunities": {
@@ -1673,7 +1697,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an opportunity"
       }
     },
     "/opportunities/search": {
@@ -1798,7 +1823,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list opportunities"
       }
     },
     "/projects/{id}": {
@@ -1849,7 +1875,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a project by ID"
       },
       "put": {
         "tags": [
@@ -1908,7 +1935,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a project"
       },
       "delete": {
         "tags": [
@@ -1957,7 +1985,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a project"
       }
     },
     "/projects": {
@@ -2008,7 +2037,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a project"
       }
     },
     "/projects/search": {
@@ -2082,7 +2112,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list projects"
       }
     },
     "/tasks/{id}": {
@@ -2133,7 +2164,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a task by ID"
       },
       "put": {
         "tags": [
@@ -2192,7 +2224,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a task"
       },
       "delete": {
         "tags": [
@@ -2241,7 +2274,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a task"
       }
     },
     "/tasks": {
@@ -2292,7 +2326,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a task"
       }
     },
     "/tasks/search": {
@@ -2372,7 +2407,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list tasks"
       }
     },
     "/activities/{id}": {
@@ -2423,7 +2459,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an activity by ID"
       },
       "put": {
         "tags": [
@@ -2482,7 +2519,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an activity"
       },
       "delete": {
         "tags": [
@@ -2531,7 +2569,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete an activity"
       }
     },
     "/activities": {
@@ -2609,7 +2648,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an activity"
       }
     },
     "/activities/search": {
@@ -2676,7 +2716,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search/list activities"
       }
     },
     "/activity_types": {
@@ -2717,7 +2758,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List activity types"
       }
     },
     "/pipelines": {
@@ -2758,7 +2800,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List pipelines"
       }
     },
     "/pipelines/{id}": {
@@ -2809,7 +2852,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a pipeline by ID"
       }
     },
     "/pipeline_stages": {
@@ -2850,7 +2894,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List pipeline stages"
       }
     },
     "/pipeline_stages/{id}": {
@@ -2901,7 +2946,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a pipeline stage by ID"
       }
     },
     "/custom_field_definitions": {
@@ -2942,7 +2988,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List custom field definitions"
       }
     },
     "/custom_field_definitions/{id}": {
@@ -2993,7 +3040,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a custom field definition"
       },
       "put": {
         "tags": [
@@ -3052,7 +3100,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a custom field definition"
       }
     },
     "/contact_types": {
@@ -3093,7 +3142,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List contact types"
       }
     },
     "/customer_sources": {
@@ -3134,7 +3184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List customer sources"
       }
     },
     "/loss_reasons": {
@@ -3175,7 +3226,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List loss reasons"
       }
     },
     "/{entity}/{entity_id}/related": {
@@ -3242,7 +3294,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all related records for an entity"
       },
       "post": {
         "tags": [
@@ -3322,7 +3375,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a relationship between entities"
       }
     },
     "/{entity}/{entity_id}/related/{related_entity_id}": {
@@ -3389,7 +3443,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove a relationship between entities"
       }
     },
     "/webhooks": {
@@ -3430,7 +3485,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List webhooks"
       },
       "post": {
         "tags": [
@@ -3513,7 +3569,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a webhook subscription"
       }
     },
     "/webhooks/{id}": {
@@ -3564,7 +3621,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a webhook subscription"
       },
       "delete": {
         "tags": [
@@ -3613,7 +3671,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a webhook subscription"
       }
     },
     "/tags": {
@@ -3654,7 +3713,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List tags"
       }
     }
   },

--- a/apis/openapi/core.ac.uk/core-api-v2/2.0/openapi.json
+++ b/apis/openapi/core.ac.uk/core-api-v2/2.0/openapi.json
@@ -901,7 +901,8 @@
         "summary": "Batch operation for search through journals",
         "tags": [
           "journals"
-        ]
+        ],
+        "operationId": "post-journals-search"
       }
     },
     "/journals/search/{query}": {
@@ -958,7 +959,8 @@
         "summary": "Search through journals",
         "tags": [
           "journals"
-        ]
+        ],
+        "operationId": "get-journals-search-by-query"
       }
     },
     "/repositories/get": {
@@ -1165,7 +1167,8 @@
         "summary": "Batch operation for searching through repositories",
         "tags": [
           "repositories"
-        ]
+        ],
+        "operationId": "post-repositories-search"
       }
     },
     "/repositories/search/{query}": {
@@ -1249,7 +1252,8 @@
         "summary": "Search through all repositories",
         "tags": [
           "repositories"
-        ]
+        ],
+        "operationId": "get-repositories-search-by-query"
       }
     },
     "/search": {
@@ -1298,7 +1302,8 @@
         "summary": "Batch operation for search through all resources",
         "tags": [
           "all"
-        ]
+        ],
+        "operationId": "post-search"
       }
     },
     "/search/{query}": {
@@ -1358,7 +1363,8 @@
         "summary": "Search through all resources",
         "tags": [
           "all"
-        ]
+        ],
+        "operationId": "get-search-by-query"
       }
     }
   },
@@ -1436,8 +1442,7 @@
           "type": "array"
         },
         "language": {
-          "$ref": "#/definitions/Language",
-          "description": "Language of the article"
+          "$ref": "#/definitions/Language"
         },
         "oai": {
           "description": "The OAI of the article",
@@ -1448,8 +1453,7 @@
           "type": "string"
         },
         "rawRecordXml": {
-          "$ref": "#/definitions/RawRecordXml",
-          "description": "Raw XML metadata"
+          "$ref": "#/definitions/RawRecordXml"
         },
         "relations": {
           "description": "URLs of relating articles, etc.",
@@ -1466,8 +1470,7 @@
           "type": "array"
         },
         "repositoryDocument": {
-          "$ref": "#/definitions/RepositoryDocument",
-          "description": "Information of CORE harvesting"
+          "$ref": "#/definitions/RepositoryDocument"
         },
         "similarities": {
           "description": "Similar articles",
@@ -1555,8 +1558,7 @@
     "ArticleResponse": {
       "properties": {
         "data": {
-          "$ref": "#/definitions/Article",
-          "description": "The fetched article"
+          "$ref": "#/definitions/Article"
         },
         "status": {
           "description": "Operation status",
@@ -1699,8 +1701,7 @@
     "JournalResponse": {
       "properties": {
         "data": {
-          "$ref": "#/definitions/Journal",
-          "description": "The fetched journal"
+          "$ref": "#/definitions/Journal"
         },
         "status": {
           "description": "Operation status",
@@ -1843,12 +1844,10 @@
           "type": "integer"
         },
         "repositoryLocation": {
-          "$ref": "#/definitions/RepositoryLocation",
-          "description": "Location of the repository"
+          "$ref": "#/definitions/RepositoryLocation"
         },
         "repositoryStats": {
-          "$ref": "#/definitions/RepositoryStats",
-          "description": "Statistics about the repository"
+          "$ref": "#/definitions/RepositoryStats"
         },
         "uri": {
           "description": "Repository URI",
@@ -1894,8 +1893,7 @@
     "RepositoryResponse": {
       "properties": {
         "data": {
-          "$ref": "#/definitions/Repository",
-          "description": "The fetched repository"
+          "$ref": "#/definitions/Repository"
         },
         "status": {
           "description": "Operation status",

--- a/apis/openapi/corecampus.com/corecampus-sis-api/1.0.0/openapi.json
+++ b/apis/openapi/corecampus.com/corecampus-sis-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CoreCampus SIS Integration API",
     "version": "1.0.0",
     "description": "CoreCampus (Campus Cafe) Student Information System third-party integration API for managing student data, enrollment, and academic records.",
-    "x-jentic-source-url": "https://corecampus.com/api-integration/"
+    "x-jentic-source-url": "https://corecampus.com/api-integration/",
+    "contact": {}
   },
   "servers": [
     {
@@ -66,7 +67,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Students"
       },
       "post": {
         "operationId": "createStudent",
@@ -115,7 +117,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Student"
       }
     },
     "/students/{studentId}": {
@@ -166,7 +169,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Student"
       },
       "put": {
         "operationId": "updateStudent",
@@ -225,7 +229,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update Student"
       }
     },
     "/enrollments": {
@@ -282,7 +287,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Enrollments"
       }
     },
     "/courses": {
@@ -339,7 +345,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Courses"
       }
     },
     "/grades": {
@@ -396,7 +403,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Grades"
       }
     }
   },
@@ -554,6 +562,20 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Courses"
+    },
+    {
+      "name": "Enrollments"
+    },
+    {
+      "name": "Grades"
+    },
+    {
+      "name": "Students"
     }
   ]
 }

--- a/apis/openapi/coro.net/coro/1.0.0/openapi.json
+++ b/apis/openapi/coro.net/coro/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Coro API",
     "version": "1.0.0",
     "description": "Coro cybersecurity platform API. Manage security policies, threats, devices, and compliance.",
-    "x-jentic-source-url": "https://developers.coro.net/openapi/reference/overview/"
+    "x-jentic-source-url": "https://developers.coro.net/openapi/reference/overview/",
+    "contact": {}
   },
   "servers": [
     {
@@ -38,7 +39,9 @@
   "paths": {
     "/devices": {
       "get": {
-        "tags": ["Devices"],
+        "tags": [
+          "Devices"
+        ],
         "summary": "List devices",
         "operationId": "listDevices",
         "parameters": [
@@ -47,7 +50,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["active", "inactive", "quarantined"]
+              "enum": [
+                "active",
+                "inactive",
+                "quarantined"
+              ]
             }
           }
         ],
@@ -65,12 +72,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List devices"
       }
     },
     "/devices/{deviceId}": {
       "get": {
-        "tags": ["Devices"],
+        "tags": [
+          "Devices"
+        ],
         "summary": "Get device",
         "operationId": "getDevice",
         "parameters": [
@@ -94,12 +104,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get device"
       }
     },
     "/threats": {
       "get": {
-        "tags": ["Threats"],
+        "tags": [
+          "Threats"
+        ],
         "summary": "List threats",
         "operationId": "listThreats",
         "parameters": [
@@ -108,7 +121,12 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["low", "medium", "high", "critical"]
+              "enum": [
+                "low",
+                "medium",
+                "high",
+                "critical"
+              ]
             }
           },
           {
@@ -116,7 +134,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["active", "resolved", "investigating"]
+              "enum": [
+                "active",
+                "resolved",
+                "investigating"
+              ]
             }
           }
         ],
@@ -134,12 +156,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List threats"
       }
     },
     "/threats/{threatId}": {
       "get": {
-        "tags": ["Threats"],
+        "tags": [
+          "Threats"
+        ],
         "summary": "Get threat",
         "operationId": "getThreat",
         "parameters": [
@@ -163,10 +188,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get threat"
       },
       "patch": {
-        "tags": ["Threats"],
+        "tags": [
+          "Threats"
+        ],
         "summary": "Update threat status",
         "operationId": "updateThreat",
         "parameters": [
@@ -188,7 +216,11 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": ["resolved", "investigating", "false_positive"]
+                    "enum": [
+                      "resolved",
+                      "investigating",
+                      "false_positive"
+                    ]
                   },
                   "notes": {
                     "type": "string"
@@ -202,12 +234,15 @@
           "200": {
             "description": "Threat updated"
           }
-        }
+        },
+        "description": "Update threat status"
       }
     },
     "/policies": {
       "get": {
-        "tags": ["Policies"],
+        "tags": [
+          "Policies"
+        ],
         "summary": "List policies",
         "operationId": "listPolicies",
         "responses": {
@@ -224,10 +259,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List policies"
       },
       "post": {
-        "tags": ["Policies"],
+        "tags": [
+          "Policies"
+        ],
         "summary": "Create policy",
         "operationId": "createPolicy",
         "requestBody": {
@@ -236,14 +274,22 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["name", "type"],
+                "required": [
+                  "name",
+                  "type"
+                ],
                 "properties": {
                   "name": {
                     "type": "string"
                   },
                   "type": {
                     "type": "string",
-                    "enum": ["firewall", "antivirus", "data_loss_prevention", "access_control"]
+                    "enum": [
+                      "firewall",
+                      "antivirus",
+                      "data_loss_prevention",
+                      "access_control"
+                    ]
                   },
                   "rules": {
                     "type": "array",
@@ -271,12 +317,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create policy"
       }
     },
     "/policies/{policyId}": {
       "get": {
-        "tags": ["Policies"],
+        "tags": [
+          "Policies"
+        ],
         "summary": "Get policy",
         "operationId": "getPolicy",
         "parameters": [
@@ -300,10 +349,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get policy"
       },
       "put": {
-        "tags": ["Policies"],
+        "tags": [
+          "Policies"
+        ],
         "summary": "Update policy",
         "operationId": "updatePolicy",
         "parameters": [
@@ -344,10 +396,13 @@
           "200": {
             "description": "Policy updated"
           }
-        }
+        },
+        "description": "Update policy"
       },
       "delete": {
-        "tags": ["Policies"],
+        "tags": [
+          "Policies"
+        ],
         "summary": "Delete policy",
         "operationId": "deletePolicy",
         "parameters": [
@@ -364,12 +419,15 @@
           "204": {
             "description": "Policy deleted"
           }
-        }
+        },
+        "description": "Delete policy"
       }
     },
     "/users": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List users",
         "operationId": "listUsers",
         "responses": {
@@ -386,12 +444,15 @@
               }
             }
           }
-        }
+        },
+        "description": "List users"
       }
     },
     "/users/{userId}": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "Get user",
         "operationId": "getUser",
         "parameters": [
@@ -415,17 +476,12 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer"
-      }
-    },
     "schemas": {
       "Device": {
         "type": "object",
@@ -519,17 +575,6 @@
             "type": "string"
           },
           "role": {
-            "type": "string"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
             "type": "string"
           }
         }

--- a/apis/openapi/coro.net/coro/1.0.0/openapi.json
+++ b/apis/openapi/coro.net/coro/1.0.0/openapi.json
@@ -579,6 +579,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   }
 }

--- a/apis/openapi/correios.com.br/correios/1.11.5/openapi.json
+++ b/apis/openapi/correios.com.br/correios/1.11.5/openapi.json
@@ -30,7 +30,9 @@
         "operationId": "authenticate",
         "summary": "Authenticate",
         "description": "Generate an authentication token for accessing Correios APIs. Uses Basic Auth with username and access code.",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [
           {
             "BasicAuth": []
@@ -74,7 +76,9 @@
         "operationId": "authenticateByPostageCard",
         "summary": "Authenticate by Postage Card",
         "description": "Generate an authentication token using a postage card number.",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "security": [
           {
             "BasicAuth": []
@@ -86,7 +90,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["numero"],
+                "required": [
+                  "numero"
+                ],
                 "properties": {
                   "numero": {
                     "type": "string",
@@ -119,7 +125,9 @@
         "operationId": "getAddressByCep",
         "summary": "Get Address by CEP",
         "description": "Look up address information for a Brazilian postal code (CEP).",
-        "tags": ["CEP"],
+        "tags": [
+          "CEP"
+        ],
         "parameters": [
           {
             "name": "cep",
@@ -157,7 +165,9 @@
         "operationId": "calculateNationalPrice",
         "summary": "Calculate National Shipping Price",
         "description": "Calculate the price for national shipping based on origin, destination, dimensions, and service type.",
-        "tags": ["Price"],
+        "tags": [
+          "Price"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -193,7 +203,9 @@
         "operationId": "calculateNationalDeliveryTime",
         "summary": "Calculate National Delivery Time",
         "description": "Calculate the estimated delivery time for national shipments.",
-        "tags": ["Delivery Time"],
+        "tags": [
+          "Delivery Time"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -229,7 +241,9 @@
         "operationId": "getDeliveryTimeByParams",
         "summary": "Get Delivery Time by Parameters",
         "description": "Get delivery time estimate using path parameters for service code, origin, and destination CEPs.",
-        "tags": ["Delivery Time"],
+        "tags": [
+          "Delivery Time"
+        ],
         "parameters": [
           {
             "name": "coServico",
@@ -280,7 +294,9 @@
         "operationId": "trackObject",
         "summary": "Track Shipment",
         "description": "Track a shipment by its tracking code.",
-        "tags": ["Tracking"],
+        "tags": [
+          "Tracking"
+        ],
         "parameters": [
           {
             "name": "codigoObjeto",
@@ -298,7 +314,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["T", "U"],
+              "enum": [
+                "T",
+                "U"
+              ],
               "default": "T"
             }
           }
@@ -325,7 +344,9 @@
         "operationId": "trackMultipleObjects",
         "summary": "Track Multiple Shipments",
         "description": "Track multiple shipments by their tracking codes.",
-        "tags": ["Tracking"],
+        "tags": [
+          "Tracking"
+        ],
         "parameters": [
           {
             "name": "codigosObjetos",
@@ -343,7 +364,10 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["T", "U"],
+              "enum": [
+                "T",
+                "U"
+              ],
               "default": "T"
             }
           }
@@ -370,7 +394,9 @@
         "operationId": "createPrePostage",
         "summary": "Create Pre-Postage",
         "description": "Create a pre-postage entry to prepare a shipment for posting.",
-        "tags": ["Pre-Postage"],
+        "tags": [
+          "Pre-Postage"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -401,7 +427,9 @@
         "operationId": "listPrePostages",
         "summary": "List Pre-Postages",
         "description": "List pre-postage entries.",
-        "tags": ["Pre-Postage"],
+        "tags": [
+          "Pre-Postage"
+        ],
         "parameters": [
           {
             "name": "pagina",
@@ -463,7 +491,9 @@
         "operationId": "getPrePostage",
         "summary": "Get Pre-Postage",
         "description": "Retrieve a specific pre-postage entry by ID.",
-        "tags": ["Pre-Postage"],
+        "tags": [
+          "Pre-Postage"
+        ],
         "parameters": [
           {
             "name": "idPrePostagem",
@@ -495,7 +525,9 @@
         "operationId": "cancelPrePostage",
         "summary": "Cancel Pre-Postage",
         "description": "Cancel a pre-postage entry.",
-        "tags": ["Pre-Postage"],
+        "tags": [
+          "Pre-Postage"
+        ],
         "parameters": [
           {
             "name": "idPrePostagem",
@@ -522,7 +554,9 @@
         "operationId": "getShippingLabel",
         "summary": "Get Shipping Label",
         "description": "Generate and retrieve the shipping label for a pre-postage entry.",
-        "tags": ["Pre-Postage"],
+        "tags": [
+          "Pre-Postage"
+        ],
         "parameters": [
           {
             "name": "idPrePostagem",
@@ -557,7 +591,9 @@
         "operationId": "getContract",
         "summary": "Get Contract Details",
         "description": "Retrieve contract details for a company.",
-        "tags": ["Contract"],
+        "tags": [
+          "Contract"
+        ],
         "parameters": [
           {
             "name": "cnpj",
@@ -600,7 +636,9 @@
         "operationId": "getPostageCards",
         "summary": "Get Postage Cards",
         "description": "List postage cards associated with a contract.",
-        "tags": ["Contract"],
+        "tags": [
+          "Contract"
+        ],
         "parameters": [
           {
             "name": "cnpj",
@@ -756,7 +794,11 @@
       },
       "PriceRequest": {
         "type": "object",
-        "required": ["cepOrigem", "cepDestino", "servicos"],
+        "required": [
+          "cepOrigem",
+          "cepDestino",
+          "servicos"
+        ],
         "properties": {
           "cepOrigem": {
             "type": "string",
@@ -770,7 +812,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["coServico"],
+              "required": [
+                "coServico"
+              ],
               "properties": {
                 "coServico": {
                   "type": "string",
@@ -860,7 +904,11 @@
       },
       "DeliveryTimeRequest": {
         "type": "object",
-        "required": ["cepOrigem", "cepDestino", "servicos"],
+        "required": [
+          "cepOrigem",
+          "cepDestino",
+          "servicos"
+        ],
         "properties": {
           "cepOrigem": {
             "type": "string",
@@ -874,7 +922,9 @@
             "type": "array",
             "items": {
               "type": "object",
-              "required": ["coServico"],
+              "required": [
+                "coServico"
+              ],
               "properties": {
                 "coServico": {
                   "type": "string",
@@ -1025,19 +1075,23 @@
       },
       "PrePostageRequest": {
         "type": "object",
-        "required": ["remetente", "destinatario", "servico"],
+        "required": [
+          "remetente",
+          "destinatario",
+          "servico"
+        ],
         "properties": {
           "remetente": {
-            "$ref": "#/components/schemas/Participant",
-            "description": "Sender information."
+            "$ref": "#/components/schemas/Participant"
           },
           "destinatario": {
-            "$ref": "#/components/schemas/Participant",
-            "description": "Recipient information."
+            "$ref": "#/components/schemas/Participant"
           },
           "servico": {
             "type": "object",
-            "required": ["coServico"],
+            "required": [
+              "coServico"
+            ],
             "properties": {
               "coServico": {
                 "type": "string",
@@ -1144,7 +1198,10 @@
       },
       "Participant": {
         "type": "object",
-        "required": ["nome", "cep"],
+        "required": [
+          "nome",
+          "cep"
+        ],
         "properties": {
           "nome": {
             "type": "string",
@@ -1264,5 +1321,28 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "CEP"
+    },
+    {
+      "name": "Contract"
+    },
+    {
+      "name": "Delivery Time"
+    },
+    {
+      "name": "Pre-Postage"
+    },
+    {
+      "name": "Price"
+    },
+    {
+      "name": "Tracking"
+    }
+  ]
 }

--- a/apis/openapi/corrently.io/corrently-energy-api/2.0.0/openapi.json
+++ b/apis/openapi/corrently.io/corrently-energy-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Corrently Energy API",
     "version": "2.0.0",
     "description": "Corrently Energy API provides real-time data about renewable energy availability, CO2 emissions, electricity pricing, and solar energy predictions for German zip codes. The Gr\u00fcnstromIndex (Green Power Index) helps optimize energy consumption for sustainability.",
-    "x-jentic-source-url": "https://api.corrently.io"
+    "x-jentic-source-url": "https://api.corrently.io",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/count.ly/countly-server-api/24.0.0/openapi.json
+++ b/apis/openapi/count.ly/countly-server-api/24.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Countly Server API",
     "version": "24.0.0",
     "description": "Countly is an open-source analytics platform. The REST API provides endpoints for data ingestion (/i), data reading (/o), and management. Authentication uses API keys passed as query parameters.",
-    "x-jentic-source-url": "https://api.count.ly/reference"
+    "x-jentic-source-url": "https://api.count.ly/reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -784,7 +785,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a dashboard"
       }
     },
     "/i/alert/save": {
@@ -842,7 +844,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create or update an alert"
       }
     },
     "/o/alert/list": {
@@ -900,7 +903,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all alerts"
       }
     },
     "/o/system/overall": {
@@ -951,7 +955,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get overall system status"
       }
     },
     "/o/system/healthcheck": {
@@ -1006,7 +1011,8 @@
               }
             }
           }
-        }
+        },
+        "description": "System health check"
       }
     },
     "/o/tasks/all": {
@@ -1086,7 +1092,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all tasks"
       }
     },
     "/o/groups": {
@@ -1144,7 +1151,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all groups"
       }
     },
     "/i/groups/create": {
@@ -1215,7 +1223,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a group"
       }
     },
     "/o/export/db": {
@@ -1311,7 +1320,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Export database data"
       }
     },
     "/o/slipping": {
@@ -1385,7 +1395,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get slipping away users"
       }
     },
     "/o/flows": {
@@ -1475,7 +1486,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user flows"
       }
     }
   },

--- a/apis/openapi/coupontools.com/coupontools-api/3.0.0/openapi.json
+++ b/apis/openapi/coupontools.com/coupontools-api/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Coupontools API",
     "version": "3.0.0",
     "description": "Coupontools provides a REST API for managing digital coupons, campaigns, and customer engagement. Create, distribute, and validate digital coupons programmatically.",
-    "x-jentic-source-url": "https://docs.coupontools.com/api"
+    "x-jentic-source-url": "https://docs.coupontools.com/api",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/coursesight.com/coursesight/1.0.0/openapi.json
+++ b/apis/openapi/coursesight.com/coursesight/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Coursesight API",
     "version": "1.0.0",
     "description": "Coursesight learning management and course tracking API. Manage courses, students, enrollments, and assessments.",
-    "x-jentic-source-url": "https://rpl.developer.azure-api.net/api-details#api=coursesight-api"
+    "x-jentic-source-url": "https://rpl.developer.azure-api.net/api-details#api=coursesight-api",
+    "contact": {}
   },
   "servers": [
     {
@@ -38,7 +39,9 @@
   "paths": {
     "/courses": {
       "get": {
-        "tags": ["Courses"],
+        "tags": [
+          "Courses"
+        ],
         "summary": "List courses",
         "operationId": "listCourses",
         "parameters": [
@@ -47,7 +50,11 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["active", "archived", "draft"]
+              "enum": [
+                "active",
+                "archived",
+                "draft"
+              ]
             }
           }
         ],
@@ -65,10 +72,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List courses"
       },
       "post": {
-        "tags": ["Courses"],
+        "tags": [
+          "Courses"
+        ],
         "summary": "Create course",
         "operationId": "createCourse",
         "requestBody": {
@@ -92,12 +102,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create course"
       }
     },
     "/courses/{courseId}": {
       "get": {
-        "tags": ["Courses"],
+        "tags": [
+          "Courses"
+        ],
         "summary": "Get course",
         "operationId": "getCourse",
         "parameters": [
@@ -121,10 +134,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get course"
       },
       "put": {
-        "tags": ["Courses"],
+        "tags": [
+          "Courses"
+        ],
         "summary": "Update course",
         "operationId": "updateCourse",
         "parameters": [
@@ -151,10 +167,13 @@
           "200": {
             "description": "Course updated"
           }
-        }
+        },
+        "description": "Update course"
       },
       "delete": {
-        "tags": ["Courses"],
+        "tags": [
+          "Courses"
+        ],
         "summary": "Delete course",
         "operationId": "deleteCourse",
         "parameters": [
@@ -171,12 +190,15 @@
           "204": {
             "description": "Course deleted"
           }
-        }
+        },
+        "description": "Delete course"
       }
     },
     "/students": {
       "get": {
-        "tags": ["Students"],
+        "tags": [
+          "Students"
+        ],
         "summary": "List students",
         "operationId": "listStudents",
         "parameters": [
@@ -202,10 +224,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List students"
       },
       "post": {
-        "tags": ["Students"],
+        "tags": [
+          "Students"
+        ],
         "summary": "Create student",
         "operationId": "createStudent",
         "requestBody": {
@@ -229,12 +254,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create student"
       }
     },
     "/students/{studentId}": {
       "get": {
-        "tags": ["Students"],
+        "tags": [
+          "Students"
+        ],
         "summary": "Get student",
         "operationId": "getStudent",
         "parameters": [
@@ -258,10 +286,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get student"
       },
       "put": {
-        "tags": ["Students"],
+        "tags": [
+          "Students"
+        ],
         "summary": "Update student",
         "operationId": "updateStudent",
         "parameters": [
@@ -288,12 +319,15 @@
           "200": {
             "description": "Student updated"
           }
-        }
+        },
+        "description": "Update student"
       }
     },
     "/enrollments": {
       "get": {
-        "tags": ["Enrollments"],
+        "tags": [
+          "Enrollments"
+        ],
         "summary": "List enrollments",
         "operationId": "listEnrollments",
         "parameters": [
@@ -326,10 +360,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List enrollments"
       },
       "post": {
-        "tags": ["Enrollments"],
+        "tags": [
+          "Enrollments"
+        ],
         "summary": "Create enrollment",
         "operationId": "createEnrollment",
         "requestBody": {
@@ -338,7 +375,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["course_id", "student_id"],
+                "required": [
+                  "course_id",
+                  "student_id"
+                ],
                 "properties": {
                   "course_id": {
                     "type": "string"
@@ -366,12 +406,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create enrollment"
       }
     },
     "/enrollments/{enrollmentId}": {
       "get": {
-        "tags": ["Enrollments"],
+        "tags": [
+          "Enrollments"
+        ],
         "summary": "Get enrollment",
         "operationId": "getEnrollment",
         "parameters": [
@@ -395,10 +438,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get enrollment"
       },
       "delete": {
-        "tags": ["Enrollments"],
+        "tags": [
+          "Enrollments"
+        ],
         "summary": "Delete enrollment",
         "operationId": "deleteEnrollment",
         "parameters": [
@@ -415,12 +461,15 @@
           "204": {
             "description": "Enrollment deleted"
           }
-        }
+        },
+        "description": "Delete enrollment"
       }
     },
     "/assessments": {
       "get": {
-        "tags": ["Assessments"],
+        "tags": [
+          "Assessments"
+        ],
         "summary": "List assessments",
         "operationId": "listAssessments",
         "parameters": [
@@ -446,10 +495,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List assessments"
       },
       "post": {
-        "tags": ["Assessments"],
+        "tags": [
+          "Assessments"
+        ],
         "summary": "Create assessment",
         "operationId": "createAssessment",
         "requestBody": {
@@ -458,7 +510,11 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["course_id", "title", "max_score"],
+                "required": [
+                  "course_id",
+                  "title",
+                  "max_score"
+                ],
                 "properties": {
                   "course_id": {
                     "type": "string"
@@ -492,12 +548,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create assessment"
       }
     },
     "/assessments/{assessmentId}/submissions": {
       "post": {
-        "tags": ["Assessments"],
+        "tags": [
+          "Assessments"
+        ],
         "summary": "Submit assessment",
         "operationId": "submitAssessment",
         "parameters": [
@@ -516,7 +575,10 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["student_id", "score"],
+                "required": [
+                  "student_id",
+                  "score"
+                ],
                 "properties": {
                   "student_id": {
                     "type": "string"
@@ -536,18 +598,12 @@
           "201": {
             "description": "Assessment submitted"
           }
-        }
+        },
+        "description": "Submit assessment"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key"
-      }
-    },
     "schemas": {
       "Course": {
         "type": "object",
@@ -579,7 +635,9 @@
       },
       "CourseInput": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "title": {
             "type": "string"
@@ -627,7 +685,11 @@
       },
       "StudentInput": {
         "type": "object",
-        "required": ["email", "first_name", "last_name"],
+        "required": [
+          "email",
+          "first_name",
+          "last_name"
+        ],
         "properties": {
           "email": {
             "type": "string",
@@ -659,7 +721,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["active", "completed", "dropped"]
+            "enum": [
+              "active",
+              "completed",
+              "dropped"
+            ]
           }
         }
       },
@@ -684,17 +750,6 @@
           "due_date": {
             "type": "string",
             "format": "date-time"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
           }
         }
       }

--- a/apis/openapi/coursesight.com/coursesight/1.0.0/openapi.json
+++ b/apis/openapi/coursesight.com/coursesight/1.0.0/openapi.json
@@ -753,6 +753,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   }
 }

--- a/apis/openapi/cowin.gov.cin/co-win-certificate-api/1.0.0/openapi.json
+++ b/apis/openapi/cowin.gov.cin/co-win-certificate-api/1.0.0/openapi.json
@@ -55,6 +55,9 @@
           "400": {
             "content": {},
             "description": "Bad request"
+          },
+          "200": {
+            "description": "Successful operation"
           }
         },
         "security": [
@@ -68,7 +71,8 @@
         "tags": [
           "certificate"
         ],
-        "x-codegen-request-body-name": "body"
+        "x-codegen-request-body-name": "body",
+        "description": "Download the certificate in pdf format"
       }
     }
   },

--- a/apis/openapi/cradl.ai/api-v1/1.0.0/openapi.json
+++ b/apis/openapi/cradl.ai/api-v1/1.0.0/openapi.json
@@ -50,7 +50,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/agents/{agentId}/runs": {
@@ -96,7 +99,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "agents"
+        ]
       }
     },
     "/documents": {
@@ -139,7 +145,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "documents"
+        ]
       }
     }
   },
@@ -212,5 +221,13 @@
         "description": "OAuth2 client credentials flow. Use grant_type=client_credentials with audience=https://api.cradl.ai/v1"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "agents"
+    },
+    {
+      "name": "documents"
+    }
+  ]
 }

--- a/apis/openapi/craftgate.io/craftgate/1.0.0/openapi.json
+++ b/apis/openapi/craftgate.io/craftgate/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Craftgate Payment API",
     "description": "Craftgate API for alternative payment methods including Kaspi, PayPal, Klarna, and others",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://developer.craftgate.io/en/alternative-payment-methods/kaspi/"
+    "x-jentic-source-url": "https://developer.craftgate.io/en/alternative-payment-methods/kaspi/",
+    "contact": {}
   },
   "servers": [
     {
@@ -22,7 +23,9 @@
         "summary": "Initialize APM payment",
         "description": "Initiates a payment using an alternative payment method (APM) such as Kaspi, PayPal, Klarna, etc.",
         "operationId": "initApmPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []
@@ -34,36 +37,63 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["apmType", "price", "paidPrice", "currency", "paymentGroup", "items"],
+                "required": [
+                  "apmType",
+                  "price",
+                  "paidPrice",
+                  "currency",
+                  "paymentGroup",
+                  "items"
+                ],
                 "properties": {
                   "apmType": {
                     "type": "string",
                     "description": "Alternative payment method type",
-                    "enum": ["PAYONEER", "SODEXO", "EDENRED", "ALIPAY", "PAYPAL", "KLARNA", "AFTERPAY", "STRIPE", "KASPI", "BIZUM"],
+                    "enum": [
+                      "PAYONEER",
+                      "SODEXO",
+                      "EDENRED",
+                      "ALIPAY",
+                      "PAYPAL",
+                      "KLARNA",
+                      "AFTERPAY",
+                      "STRIPE",
+                      "KASPI",
+                      "BIZUM"
+                    ],
                     "example": "KASPI"
                   },
                   "price": {
                     "type": "number",
                     "format": "decimal",
                     "description": "Total basket amount",
-                    "example": 100.00
+                    "example": 100.0
                   },
                   "paidPrice": {
                     "type": "number",
                     "format": "decimal",
                     "description": "Final amount to be collected",
-                    "example": 100.00
+                    "example": 100.0
                   },
                   "currency": {
                     "type": "string",
                     "description": "Payment currency",
-                    "enum": ["TRY", "USD", "EUR", "GBP", "CNY"],
+                    "enum": [
+                      "TRY",
+                      "USD",
+                      "EUR",
+                      "GBP",
+                      "CNY"
+                    ],
                     "example": "USD"
                   },
                   "paymentGroup": {
                     "type": "string",
                     "description": "Payment group type",
-                    "enum": ["PRODUCT", "LISTING_OR_SUBSCRIPTION"],
+                    "enum": [
+                      "PRODUCT",
+                      "LISTING_OR_SUBSCRIPTION"
+                    ],
                     "example": "PRODUCT"
                   },
                   "callbackUrl": {
@@ -83,7 +113,10 @@
                     "minItems": 1,
                     "items": {
                       "type": "object",
-                      "required": ["name", "price"],
+                      "required": [
+                        "name",
+                        "price"
+                      ],
                       "properties": {
                         "name": {
                           "type": "string",
@@ -94,7 +127,7 @@
                           "type": "number",
                           "format": "decimal",
                           "description": "Item price",
-                          "example": 100.00
+                          "example": 100.0
                         }
                       }
                     }
@@ -123,12 +156,22 @@
                     "paymentStatus": {
                       "type": "string",
                       "description": "Payment status",
-                      "enum": ["FAILURE", "SUCCESS", "INIT_THREEDS", "CALLBACK_THREEDS", "WAITING"]
+                      "enum": [
+                        "FAILURE",
+                        "SUCCESS",
+                        "INIT_THREEDS",
+                        "CALLBACK_THREEDS",
+                        "WAITING"
+                      ]
                     },
                     "additionalAction": {
                       "type": "string",
                       "description": "Action required",
-                      "enum": ["REDIRECT_TO_URL", "OTP_REQUIRED", "NONE"]
+                      "enum": [
+                        "REDIRECT_TO_URL",
+                        "OTP_REQUIRED",
+                        "NONE"
+                      ]
                     },
                     "redirectUrl": {
                       "type": "string",
@@ -171,7 +214,9 @@
         "summary": "Complete APM payment",
         "description": "Completes an alternative payment method transaction",
         "operationId": "completeApmPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []
@@ -183,7 +228,9 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["paymentId"],
+                "required": [
+                  "paymentId"
+                ],
                 "properties": {
                   "paymentId": {
                     "type": "string",
@@ -216,7 +263,10 @@
                     "paymentStatus": {
                       "type": "string",
                       "description": "Final payment status",
-                      "enum": ["SUCCESS", "FAILURE"]
+                      "enum": [
+                        "SUCCESS",
+                        "FAILURE"
+                      ]
                     },
                     "conversationId": {
                       "type": "string",
@@ -255,7 +305,9 @@
         "summary": "Retrieve APM payment",
         "description": "Retrieves details of an alternative payment method transaction",
         "operationId": "getApmPayment",
-        "tags": ["Payments"],
+        "tags": [
+          "Payments"
+        ],
         "security": [
           {
             "apiKey": []

--- a/apis/openapi/craftmypdf.com/craftmypdf-api/1.0.0/openapi.json
+++ b/apis/openapi/craftmypdf.com/craftmypdf-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CraftMyPDF API",
     "version": "1.0.0",
     "description": "CraftMyPDF provides a REST API for generating PDF documents and images from templates. Create, manage, and merge PDF documents programmatically using JSON data and customizable templates.",
-    "x-jentic-source-url": "https://craftmypdf.com/docs/"
+    "x-jentic-source-url": "https://craftmypdf.com/docs/",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/cratedb.com/cratedb-http-api/2.0.0/openapi.json
+++ b/apis/openapi/cratedb.com/cratedb-http-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CrateDB HTTP API",
     "version": "2.0.0",
     "description": "CrateDB provides an HTTP endpoint for executing SQL queries. The HTTP API accepts SQL statements as JSON and returns results in JSON format. This is the primary programmatic interface to CrateDB.",
-    "x-jentic-source-url": "https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html"
+    "x-jentic-source-url": "https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/crawlbase.com/crawling-api/1.0.0/openapi.json
+++ b/apis/openapi/crawlbase.com/crawling-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Crawlbase Crawling API",
     "version": "1.0.0",
     "description": "Crawlbase provides a web scraping and crawling API that handles proxies, CAPTCHAs, and browser rendering. Send a URL and receive the HTML content. Supports JavaScript rendering via the JS token.",
-    "x-jentic-source-url": "https://crawlbase.com/docs/crawling-api/"
+    "x-jentic-source-url": "https://crawlbase.com/docs/crawling-api/",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/crewtraka.com/crewtraka-api/1.0.0/openapi.json
+++ b/apis/openapi/crewtraka.com/crewtraka-api/1.0.0/openapi.json
@@ -4,329 +4,1167 @@
     "title": "CrewTraka API",
     "version": "1.0.0",
     "description": "CrewTraka is a workforce management platform API for scheduling, tracking, and managing construction crews and projects. Supports allowances, attachments, budgets, claims, clients, companies, day cards, defects, diaries, employees, and more.",
-    "x-jentic-source-url": "https://api.dash.crewtraka.com/schema/swagger"
+    "x-jentic-source-url": "https://api.dash.crewtraka.com/schema/swagger",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://api.dash.crewtraka.com" }
+    {
+      "url": "https://api.dash.crewtraka.com"
+    }
   ],
   "paths": {
-    "/api/allowance/": {
+    "/api/allowance": {
       "get": {
         "operationId": "listAllowances",
         "summary": "List allowances",
-        "tags": ["Allowances"],
+        "tags": [
+          "Allowances"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List allowances"
       },
       "post": {
         "operationId": "createAllowance",
         "summary": "Create allowance",
-        "tags": ["Allowances"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Allowances"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create allowance"
       }
     },
-    "/api/allowance/{id}/": {
+    "/api/allowance/{id}": {
       "put": {
         "operationId": "updateAllowance",
         "summary": "Update allowance",
-        "tags": ["Allowances"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Allowances"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update allowance"
       },
       "patch": {
         "operationId": "partialUpdateAllowance",
         "summary": "Partially update allowance",
-        "tags": ["Allowances"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Allowances"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Partially update allowance"
       },
       "delete": {
         "operationId": "deleteAllowance",
         "summary": "Delete allowance",
-        "tags": ["Allowances"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Allowances"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete allowance"
       }
     },
-    "/api/client/": {
+    "/api/client": {
       "get": {
         "operationId": "listClients",
         "summary": "List clients",
-        "tags": ["Clients"],
+        "tags": [
+          "Clients"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List clients"
       },
       "post": {
         "operationId": "createClient",
         "summary": "Create client",
-        "tags": ["Clients"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Clients"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create client"
       }
     },
-    "/api/client/{id}/": {
+    "/api/client/{id}": {
       "put": {
         "operationId": "updateClient",
         "summary": "Update client",
-        "tags": ["Clients"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update client"
       },
       "delete": {
         "operationId": "deleteClient",
         "summary": "Delete client",
-        "tags": ["Clients"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Clients"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete client"
       }
     },
-    "/api/company/": {
+    "/api/company": {
       "get": {
         "operationId": "listCompanies",
         "summary": "List companies",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List companies"
       },
       "post": {
         "operationId": "createCompany",
         "summary": "Create company",
-        "tags": ["Companies"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Companies"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create company"
       }
     },
-    "/api/company/current/": {
+    "/api/company/current": {
       "get": {
         "operationId": "getCurrentCompany",
         "summary": "Get current company",
-        "tags": ["Companies"],
+        "tags": [
+          "Companies"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get current company"
       }
     },
-    "/api/daycard/": {
+    "/api/daycard": {
       "get": {
         "operationId": "listDayCards",
         "summary": "List day cards",
-        "tags": ["Day Cards"],
+        "tags": [
+          "Day Cards"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List day cards"
       },
       "post": {
         "operationId": "createDayCard",
         "summary": "Create day card",
-        "tags": ["Day Cards"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Day Cards"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create day card"
       }
     },
-    "/api/daycard/{id}/": {
+    "/api/daycard/{id}": {
       "get": {
         "operationId": "getDayCard",
         "summary": "Retrieve day card",
-        "tags": ["Day Cards"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Day Cards"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve day card"
       },
       "put": {
         "operationId": "updateDayCard",
         "summary": "Update day card",
-        "tags": ["Day Cards"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Day Cards"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update day card"
       },
       "delete": {
         "operationId": "deleteDayCard",
         "summary": "Delete day card",
-        "tags": ["Day Cards"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Day Cards"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete day card"
       }
     },
-    "/api/employee/": {
+    "/api/employee": {
       "get": {
         "operationId": "listEmployees",
         "summary": "List employees",
-        "tags": ["Employees"],
+        "tags": [
+          "Employees"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List employees"
       },
       "post": {
         "operationId": "createEmployee",
         "summary": "Create employee",
-        "tags": ["Employees"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Employees"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create employee"
       }
     },
-    "/api/defect/": {
+    "/api/defect": {
       "get": {
         "operationId": "listDefects",
         "summary": "List defects",
-        "tags": ["Defects"],
+        "tags": [
+          "Defects"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List defects"
       },
       "post": {
         "operationId": "createDefect",
         "summary": "Create defect",
-        "tags": ["Defects"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Defects"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create defect"
       }
     },
-    "/api/defect/{id}/": {
+    "/api/defect/{id}": {
       "get": {
         "operationId": "getDefect",
         "summary": "Retrieve defect",
-        "tags": ["Defects"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Defects"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve defect"
       },
       "put": {
         "operationId": "updateDefect",
         "summary": "Update defect",
-        "tags": ["Defects"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Defects"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update defect"
       },
       "delete": {
         "operationId": "deleteDefect",
         "summary": "Delete defect",
-        "tags": ["Defects"],
-        "parameters": [ { "name": "id", "in": "path", "required": true, "schema": { "type": "integer" } } ],
+        "tags": [
+          "Defects"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete defect"
       }
     },
-    "/api/diary/": {
+    "/api/diary": {
       "get": {
         "operationId": "listDiary",
         "summary": "List diary notes",
-        "tags": ["Diary"],
+        "tags": [
+          "Diary"
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List diary notes"
       },
       "post": {
         "operationId": "createDiary",
         "summary": "Create diary note",
-        "tags": ["Diary"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } },
+        "tags": [
+          "Diary"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create diary note"
       }
     },
-    "/api/7-day-summary/export-csv/": {
+    "/api/7-day-summary/export-csv": {
       "get": {
         "operationId": "exportSevenDaySummary",
         "summary": "Export 7-day summary as CSV",
-        "tags": ["Reports"],
+        "tags": [
+          "Reports"
+        ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "text/csv": { "schema": { "type": "string" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Export 7-day summary as CSV"
       }
     }
   },
@@ -335,7 +1173,9 @@
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "detail": { "type": "string" }
+          "detail": {
+            "type": "string"
+          }
         }
       }
     },
@@ -349,6 +1189,34 @@
     }
   },
   "security": [
-    { "tokenAuth": [] }
+    {
+      "tokenAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Allowances"
+    },
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "Companies"
+    },
+    {
+      "name": "Day Cards"
+    },
+    {
+      "name": "Defects"
+    },
+    {
+      "name": "Diary"
+    },
+    {
+      "name": "Employees"
+    },
+    {
+      "name": "Reports"
+    }
   ]
 }

--- a/apis/openapi/cribl.io/cribl-api/1.0.0/openapi.json
+++ b/apis/openapi/cribl.io/cribl-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cribl API",
     "version": "1.0.0",
     "description": "Cribl API provides programmatic access to Cribl Stream, Edge, and Search configurations. Manage system settings, outputs, workers, and search jobs.",
-    "x-jentic-source-url": "https://docs.cribl.io/cribl-as-code/api/"
+    "x-jentic-source-url": "https://docs.cribl.io/cribl-as-code/api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -59,7 +60,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve git settings for organization"
       }
     },
     "/system/outputs": {
@@ -110,7 +112,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a destination"
       }
     },
     "/master/workers": {
@@ -152,7 +155,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all Worker and Edge Nodes"
       }
     },
     "/edge/metadata": {
@@ -194,7 +198,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get host metadata for edge node"
       }
     },
     "/search/jobs": {
@@ -236,7 +241,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List search jobs"
       }
     },
     "/version": {
@@ -278,7 +284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get version and commit history"
       }
     }
   },
@@ -405,6 +412,20 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Edge"
+    },
+    {
+      "name": "Search"
+    },
+    {
+      "name": "System"
+    },
+    {
+      "name": "Workers"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Spectral-lint clean **50** OpenAPI specs. All specs now pass `spectral lint` with the default `spectral:oas` ruleset with zero warnings and zero errors.

### Fixes Applied

| Rule | Specs Fixed |
|------|-------------|
| info-contact | 35 |
| operation-tag-defined | 27 |
| operation-description | 25 |
| unused-components | 7 |
| path-keys-no-trailing-slash | 6 |
| operation-operationId | 5 |
| operation-tags | 4 |
| no-$ref-siblings | 3 |
| operation-success-response | 1 |

### APIs Fixed

- code-scan.com/codescan-api
- codeclimate.com/quality-api
- cognisantmd.com/ocean-health-api
- cognitivefashion.github.io/ibm-ai-for-fashion-api
- cohere.com/cohere-api
- coindcx.com/coindcx-api
- coinigy.com/coinigy-api
- coinlayer.com/coinlayer-api
- coinlib.io/coinlib-api
- coinlore.com/coinlore-api
- coinmarketcap.com/coinmarketcap-api
- coinranking.com/coinranking-api
- coinremitter.com/coinremitter-api
- comet.com/comet-ml-rest-api
- cometapi.com/comet-api
- cometly.com/cometly-api
- commissioncrowd.com/commissioncrowd-api
- commmune.com/commune
- commpeak.com/commpeak-api
- commpeak.com/sms-streams-api
- communitiesuk.github.io/waste-services-api
- computop.com/computop
- conekta.com/conekta-api
- confluence.dimagi.com/commcare-api
- congress.gov/congress-api
- consumerfinance.gov/the-consumer-financial-protection-bureau
- context-link.ai/context-link-api
- contlo.com/contlo-api
- controller.kloudfox.com/controller
- conturs.com/conturs-api
- convertapi.com/file-conversion-api
- convertkit.com/convertkit-kit-api-v3
- coordinatehq.com/coordinatehq-api
- copper.com/copper-crm-api
- core.ac.uk/core-api-v2
- corecampus.com/corecampus-sis-api
- coro.net/coro
- correios.com.br/correios
- corrently.io/corrently-energy-api
- count.ly/countly-server-api
- coupontools.com/coupontools-api
- coursesight.com/coursesight
- cowin.gov.cin/co-win-certificate-api
- cradl.ai/api-v1
- craftgate.io/craftgate
- craftmypdf.com/craftmypdf-api
- cratedb.com/cratedb-http-api
- crawlbase.com/crawling-api
- crewtraka.com/crewtraka-api
- cribl.io/cribl-api

## Test plan
- [x] All 50 specs pass `spectral lint` after fixes
