### PR TITLE
Spectral-lint clean 50 OpenAPI specs (batch 009)

### DIFF
--- a/apis/openapi/crisp.chat/crisp-rest-api/1.0.0/openapi.json
+++ b/apis/openapi/crisp.chat/crisp-rest-api/1.0.0/openapi.json
@@ -1182,5 +1182,13 @@
         "description": "Generate a file upload URL"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
   }
 }

--- a/apis/openapi/crisp.chat/crisp-rest-api/1.0.0/openapi.json
+++ b/apis/openapi/crisp.chat/crisp-rest-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Crisp REST API",
     "version": "1.0.0",
     "description": "Crisp is a customer messaging platform. The REST API v1 provides endpoints for managing websites, conversations, people/contacts, and messaging operations.",
-    "x-jentic-source-url": "https://docs.crisp.chat/references/rest-api/v1/"
+    "x-jentic-source-url": "https://docs.crisp.chat/references/rest-api/v1/",
+    "contact": {}
   },
   "servers": [
     {
@@ -75,7 +76,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a new website"
       }
     },
     "/website/{website_id}": {
@@ -105,7 +107,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get website details"
       },
       "delete": {
         "operationId": "deleteWebsite",
@@ -133,7 +136,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a website"
       }
     },
     "/website/{website_id}/settings": {
@@ -163,7 +167,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get website settings"
       },
       "patch": {
         "operationId": "updateWebsiteSettings",
@@ -201,7 +206,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update website settings"
       }
     },
     "/website/{website_id}/operators": {
@@ -231,7 +237,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List website operators"
       }
     },
     "/website/{website_id}/conversations": {
@@ -269,7 +276,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List conversations"
       }
     },
     "/website/{website_id}/conversation": {
@@ -309,7 +317,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a new conversation"
       }
     },
     "/website/{website_id}/conversation/{session_id}": {
@@ -347,7 +356,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a conversation"
       },
       "delete": {
         "operationId": "removeConversation",
@@ -383,7 +393,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Remove a conversation"
       }
     },
     "/website/{website_id}/conversation/{session_id}/meta": {
@@ -421,7 +432,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get conversation meta"
       },
       "patch": {
         "operationId": "updateConversationMeta",
@@ -467,7 +479,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update conversation meta"
       }
     },
     "/website/{website_id}/conversation/{session_id}/state": {
@@ -525,7 +538,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Change conversation state"
       }
     },
     "/website/{website_id}/conversation/{session_id}/routing": {
@@ -578,7 +592,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Assign conversation routing"
       }
     },
     "/website/{website_id}/conversation/{session_id}/messages": {
@@ -624,7 +639,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get conversation messages"
       }
     },
     "/website/{website_id}/conversation/{session_id}/message": {
@@ -699,7 +715,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Send a message in conversation"
       }
     },
     "/website/{website_id}/conversation/{session_id}/compose": {
@@ -756,7 +773,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update compose indicator (typing)"
       }
     },
     "/website/{website_id}/people/profiles": {
@@ -802,7 +820,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List people profiles"
       }
     },
     "/website/{website_id}/people/profile/{people_id}": {
@@ -840,7 +859,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a people profile"
       },
       "patch": {
         "operationId": "updatePeopleProfile",
@@ -886,7 +906,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a people profile"
       },
       "delete": {
         "operationId": "removePeopleProfile",
@@ -922,7 +943,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Remove a people profile"
       }
     },
     "/website/{website_id}/people/profile/{people_id}/conversations": {
@@ -968,7 +990,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get conversations for a person"
       }
     },
     "/website/{website_id}/people/data/{people_id}": {
@@ -1006,7 +1029,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get people data"
       },
       "patch": {
         "operationId": "updatePeopleData",
@@ -1057,7 +1081,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update people data"
       }
     },
     "/website/{website_id}/people/events/{people_id}": {
@@ -1103,7 +1128,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get people events"
       }
     },
     "/bucket/url/upload": {
@@ -1152,32 +1178,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "basicAuth": {
-        "type": "http",
-        "scheme": "basic",
-        "description": "HTTP Basic Auth with identifier and key from your Crisp API token"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "boolean"
-          },
-          "reason": {
-            "type": "string"
-          },
-          "data": {
-            "type": "object"
-          }
-        }
+        },
+        "description": "Generate a file upload URL"
       }
     }
   }

--- a/apis/openapi/crossbrowsertesting.com/crossbrowsertesting.com-screenshot-comparisons-api/3.0.0/openapi.json
+++ b/apis/openapi/crossbrowsertesting.com/crossbrowsertesting.com-screenshot-comparisons-api/3.0.0/openapi.json
@@ -110,7 +110,11 @@
             "basicAuth": []
           }
         ],
-        "summary": "Compare Screenshot Test Versions"
+        "summary": "Compare Screenshot Test Versions",
+        "tags": [
+          "screenshots"
+        ],
+        "operationId": "get-screenshots-by-target-screenshot-test-id-by-target-version-id-comparison-parallel-by-base-version-id"
       }
     },
     "/screenshots/{target_screenshot_test_id}/{target_version_id}/comparison/{base_result_id}": {
@@ -191,7 +195,11 @@
             "basicAuth": []
           }
         ],
-        "summary": "Compare Full Screenshot Test"
+        "summary": "Compare Full Screenshot Test",
+        "tags": [
+          "screenshots"
+        ],
+        "operationId": "get-screenshots-by-target-screenshot-test-id-by-target-version-id-comparison-by-base-result-id"
       }
     },
     "/screenshots/{target_screenshot_test_id}/{target_version_id}/{target_result_id}/comparison/{base_result_id}": {
@@ -281,7 +289,11 @@
             "basicAuth": []
           }
         ],
-        "summary": "Compare Single Screenshot"
+        "summary": "Compare Single Screenshot",
+        "tags": [
+          "screenshots"
+        ],
+        "operationId": "get-screenshots-by-target-screenshot-test-id-by-target-version-id-by-target-result-id-comparison-by-base-result-id"
       }
     }
   },
@@ -398,5 +410,10 @@
         "type": "http"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "screenshots"
+    }
+  ]
 }

--- a/apis/openapi/crossmint.com/crossmint-api/1.0.0/openapi.json
+++ b/apis/openapi/crossmint.com/crossmint-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Crossmint API",
     "version": "1.0.0",
     "description": "Crossmint provides APIs for creating and managing wallets, minting NFTs and SFTs, managing collections, handling orders and payments, verifiable credentials, IP assets, and user management across multiple blockchain chains.",
-    "x-jentic-source-url": "https://docs.crossmint.com/api-reference"
+    "x-jentic-source-url": "https://docs.crossmint.com/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -117,10 +118,11 @@
             },
             "description": "Action ID"
           }
-        ]
+        ],
+        "description": "Get Action Status"
       }
     },
-    "/2022-06-09/collections/": {
+    "/2022-06-09/collections": {
       "post": {
         "operationId": "createCollection",
         "summary": "Create Collection",
@@ -178,7 +180,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Collection"
       },
       "get": {
         "operationId": "getAllCollections",
@@ -217,7 +220,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get All Collections"
       }
     },
     "/2022-06-09/collections/{collectionId}": {
@@ -272,7 +276,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Collection (Idempotent)"
       },
       "get": {
         "operationId": "getCollection",
@@ -322,7 +327,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Collection Info"
       },
       "patch": {
         "operationId": "updateCollection",
@@ -375,7 +381,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update Collection"
       }
     },
     "/2022-06-09/collections/{collectionId}/nfts": {
@@ -448,7 +455,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Mint NFT"
       },
       "get": {
         "operationId": "getAllNfts",
@@ -491,7 +499,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get All NFTs"
       }
     },
     "/2022-06-09/collections/{collectionId}/nfts/{id}": {
@@ -562,7 +571,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Mint NFT with ID"
       },
       "get": {
         "operationId": "getMintStatus",
@@ -621,7 +631,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Mint Status"
       },
       "patch": {
         "operationId": "editNft",
@@ -683,7 +694,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Edit NFT"
       },
       "delete": {
         "operationId": "burnNft",
@@ -735,7 +747,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Burn NFT"
       }
     },
     "/2022-06-09/collections/{collectionId}/sfts": {
@@ -790,7 +803,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Mint SFT"
       }
     },
     "/2022-06-09/collections/{collectionId}/templates": {
@@ -845,7 +859,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Template"
       },
       "get": {
         "operationId": "getAllTemplates",
@@ -888,7 +903,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get All Templates"
       }
     },
     "/2022-06-09/collections/{collectionId}/templates/{templateId}": {
@@ -952,7 +968,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Template with ID"
       },
       "get": {
         "operationId": "getTemplate",
@@ -1004,7 +1021,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Template"
       },
       "patch": {
         "operationId": "editTemplate",
@@ -1066,7 +1084,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Edit Template"
       },
       "delete": {
         "operationId": "deleteTemplate",
@@ -1118,7 +1137,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Delete Template"
       }
     },
     "/2025-06-09/wallets": {
@@ -1177,7 +1197,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Wallet"
       }
     },
     "/2025-06-09/wallets/{walletLocator}": {
@@ -1229,7 +1250,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Wallet By Locator"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/balances": {
@@ -1292,7 +1314,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Wallet Balance"
       },
       "post": {
         "operationId": "fundWallet",
@@ -1353,7 +1376,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Fund Wallet"
       }
     },
     "/2022-06-09/wallets/{identifier}/nfts": {
@@ -1425,7 +1449,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get NFTs from Wallet"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/transactions": {
@@ -1480,7 +1505,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Transaction"
       },
       "get": {
         "operationId": "getWalletTransactions",
@@ -1523,7 +1549,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Wallet Transactions"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/transactions/{transactionId}": {
@@ -1577,7 +1604,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Transaction"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/transactions/{transactionId}/approvals": {
@@ -1641,7 +1669,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Approve Transaction"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/signatures": {
@@ -1696,7 +1725,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Signature"
       },
       "get": {
         "operationId": "getAllSignatures",
@@ -1739,7 +1769,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get All Signatures"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/signatures/{signatureId}": {
@@ -1793,7 +1824,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Signature"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/signatures/{signatureId}/approvals": {
@@ -1857,7 +1889,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Approve Signature"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/signers": {
@@ -1912,7 +1945,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Delegated Signer"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/signers/{signer}": {
@@ -1966,7 +2000,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Delegated Signer"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/tokens/{tokenLocator}/transfers": {
@@ -2038,7 +2073,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Transfer Token"
       }
     },
     "/2025-06-09/wallets/{walletLocator}/tokens/{tokenLocator}/transfers/{transactionId}": {
@@ -2101,7 +2137,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Transfer Transaction"
       }
     },
     "/2022-06-09/orders": {
@@ -2152,7 +2189,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Order"
       }
     },
     "/2022-06-09/orders/{orderId}": {
@@ -2204,7 +2242,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Order"
       },
       "patch": {
         "operationId": "editOrder",
@@ -2257,7 +2296,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Edit Order"
       }
     },
     "/2022-06-09/orders/{orderId}/payment": {
@@ -2312,7 +2352,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Process Payment"
       }
     },
     "/v1-alpha2/tokens": {
@@ -2346,7 +2387,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get All Tokens"
       }
     },
     "/v1-alpha2/tokens/{tokenLocator}": {
@@ -2391,7 +2433,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Check Token Support"
       }
     },
     "/2025-06-09/users/{userLocator}": {
@@ -2436,7 +2479,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get a User"
       },
       "put": {
         "operationId": "upsertUser",
@@ -2489,7 +2533,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create or Update User"
       }
     },
     "/2025-06-09/users/{userLocator}/legal-documents": {
@@ -2544,7 +2589,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Accept Legal Document"
       }
     },
     "/2025-06-09/users/{userLocator}/identity-verification": {
@@ -2589,7 +2635,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Identity Verification Status"
       },
       "put": {
         "operationId": "triggerIdentityVerification",
@@ -2632,7 +2679,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Trigger Identity Verification"
       }
     },
     "/2025-06-09/users/{userLocator}/linked-wallets/{address}": {
@@ -2686,7 +2734,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Linked External Wallet"
       },
       "put": {
         "operationId": "linkWallet",
@@ -2748,7 +2797,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Link External Wallet to User"
       }
     },
     "/2025-06-09/documents": {
@@ -2792,7 +2842,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload a User Document"
       }
     },
     "/2025-06-09/documents/{documentId}": {
@@ -2837,7 +2888,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get a User Document by ID"
       }
     },
     "/v1-alpha1/credentials/templates/{templateId}/vcs": {
@@ -2899,7 +2951,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Issue Credential"
       }
     },
     "/v1-alpha1/credentials/{id}": {
@@ -2951,7 +3004,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Credential by ID"
       },
       "delete": {
         "operationId": "revokeCredential",
@@ -2994,7 +3048,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Revoke Credential"
       }
     },
     "/v1-alpha1/credentials/templates/{collectionId}/nfts/{id}/credentials": {
@@ -3048,7 +3103,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Credential by NFT ID"
       }
     },
     "/v1-alpha1/nfts/{nftLocator}/credentials": {
@@ -3093,7 +3149,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Credential by NFT Locator"
       }
     },
     "/v1-alpha1/credentials/verification/verify": {
@@ -3142,10 +3199,11 @@
               }
             }
           }
-        }
+        },
+        "description": "Verify Credential"
       }
     },
-    "/v1-alpha1/credentials/templates/": {
+    "/v1-alpha1/credentials/templates": {
       "post": {
         "operationId": "createCredentialTemplate",
         "summary": "Create Credential Template",
@@ -3186,7 +3244,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Credential Template"
       }
     },
     "/v1-alpha1/credentials/types": {
@@ -3230,7 +3289,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Credential Type"
       }
     },
     "/v1-alpha1/credentials/types/{typeName}": {
@@ -3285,7 +3345,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create Credential Type with Name"
       },
       "get": {
         "operationId": "getCredentialType",
@@ -3328,7 +3389,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get a Credential Type"
       }
     },
     "/v1/ip/collections": {
@@ -3372,7 +3434,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create IP Collection"
       },
       "get": {
         "operationId": "getAllIpCollections",
@@ -3404,7 +3467,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get All IP Collections"
       }
     },
     "/v1/ip/collections/{collectionId}": {
@@ -3459,7 +3523,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create IP Collection (Idempotent)"
       },
       "get": {
         "operationId": "getIpCollection",
@@ -3502,7 +3567,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Collection"
       }
     },
     "/v1/ip/collections/{collectionId}/ipassets": {
@@ -3557,7 +3623,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create IP Asset"
       },
       "get": {
         "operationId": "getIpAssets",
@@ -3600,7 +3667,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Assets in Collection"
       }
     },
     "/v1/ip/collections/{collectionId}/ipassets/{customerFacingId}": {
@@ -3664,7 +3732,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create IP Asset (Idempotent)"
       },
       "get": {
         "operationId": "getIpAsset",
@@ -3716,7 +3785,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Asset"
       },
       "patch": {
         "operationId": "updateIpAsset",
@@ -3778,7 +3848,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update IP Asset"
       }
     },
     "/v1/ip/actions/{actionId}": {
@@ -3823,7 +3894,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Action"
       }
     },
     "/v1/ip/graph/{ipAssetId}": {
@@ -3877,7 +3949,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Asset Graph"
       }
     },
     "/v1/ip/licenses/{ipassetId}": {
@@ -3922,7 +3995,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get IP Asset License"
       }
     },
     "/v1-alpha1/minting/collections/{collectionId}/base-uri": {
@@ -3967,7 +4041,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Base URI"
       },
       "put": {
         "operationId": "setBaseUri",
@@ -4025,7 +4100,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set Base URI"
       }
     },
     "/v1-alpha1/minting/collections/{collectionId}/royalties": {
@@ -4070,7 +4146,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Royalties Configuration"
       },
       "put": {
         "operationId": "setRoyalties",
@@ -4123,7 +4200,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set Royalties"
       },
       "delete": {
         "operationId": "removeRoyalties",
@@ -4166,7 +4244,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Remove Royalties"
       }
     },
     "/v1-alpha1/minting/collections/{collectionId}/transferable": {
@@ -4211,7 +4290,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Transferability"
       },
       "put": {
         "operationId": "setTransferability",
@@ -4264,7 +4344,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Set Transferability"
       }
     },
     "/v1-alpha1/projects/{projectId}/usage": {
@@ -4309,7 +4390,8 @@
             },
             "description": ""
           }
-        ]
+        ],
+        "description": "Get Usage"
       }
     }
   },

--- a/apis/openapi/crove.app/crove-api/1.0.0/openapi.json
+++ b/apis/openapi/crove.app/crove-api/1.0.0/openapi.json
@@ -42,7 +42,7 @@
     }
   ],
   "paths": {
-    "/api/integrations/webhook/": {
+    "/api/integrations/webhook": {
       "get": {
         "operationId": "getWebhook",
         "summary": "Retrieve webhook configuration",
@@ -70,7 +70,7 @@
         }
       }
     },
-    "/api/integrations/webhook/create/": {
+    "/api/integrations/webhook/create": {
       "post": {
         "operationId": "createWebhook",
         "summary": "Create a webhook",
@@ -108,7 +108,7 @@
         }
       }
     },
-    "/api/integrations/webhook/update/": {
+    "/api/integrations/webhook/update": {
       "post": {
         "operationId": "updateWebhook",
         "summary": "Update a webhook",
@@ -146,7 +146,7 @@
         }
       }
     },
-    "/api/integrations/zapier/api-key/": {
+    "/api/integrations/zapier/api-key": {
       "get": {
         "operationId": "getZapierApiKey",
         "summary": "Retrieve Zapier API key",
@@ -170,10 +170,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Retrieve Zapier API key"
       }
     },
-    "/api/integrations/zapier/api-key/create/": {
+    "/api/integrations/zapier/api-key/create": {
       "post": {
         "operationId": "createZapierApiKey",
         "summary": "Create Zapier API key",
@@ -197,10 +198,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create Zapier API key"
       }
     },
-    "/api/integrations/zapier/api-key/test/": {
+    "/api/integrations/zapier/api-key/test": {
       "get": {
         "operationId": "testZapierApiKey",
         "summary": "Test Zapier API key",
@@ -214,10 +216,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Test Zapier API key"
       }
     },
-    "/api/integrations/zapier/data/templates/": {
+    "/api/integrations/zapier/data/templates": {
       "get": {
         "operationId": "listZapierTemplates",
         "summary": "List templates for Zapier",
@@ -241,10 +244,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List templates for Zapier"
       }
     },
-    "/api/integrations/zapier/data/template-document-created-sample/": {
+    "/api/integrations/zapier/data/template-document-created-sample": {
       "get": {
         "operationId": "getTemplateDocumentCreatedSample",
         "summary": "Get sample data for template document created trigger",
@@ -258,10 +262,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get sample data for template document created trigger"
       }
     },
-    "/api/integrations/zapier/subscriptions/template-document-created/": {
+    "/api/integrations/zapier/subscriptions/template-document-created": {
       "post": {
         "operationId": "createTemplateDocumentSubscription",
         "summary": "Subscribe to template document created events",
@@ -295,10 +300,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Subscribe to template document created events"
       }
     },
-    "/api/integrations/zapier/subscriptions/template-document-created/{subscription_id}/": {
+    "/api/integrations/zapier/subscriptions/template-document-created/{subscription_id}": {
       "delete": {
         "operationId": "deleteTemplateDocumentSubscription",
         "summary": "Unsubscribe from template document created events",
@@ -325,10 +331,11 @@
           "404": {
             "description": "Subscription not found"
           }
-        }
+        },
+        "description": "Unsubscribe from template document created events"
       }
     },
-    "/api/users/": {
+    "/api/users": {
       "get": {
         "operationId": "listUsers",
         "summary": "List users",
@@ -352,10 +359,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List users"
       }
     },
-    "/api/users/me/": {
+    "/api/users/me": {
       "get": {
         "operationId": "getCurrentUser",
         "summary": "Get current user",
@@ -376,10 +384,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get current user"
       }
     },
-    "/api/users/{id}/": {
+    "/api/users/{id}": {
       "get": {
         "operationId": "getUser",
         "summary": "Get user by ID",
@@ -414,7 +423,8 @@
           "404": {
             "description": "User not found"
           }
-        }
+        },
+        "description": "Get user by ID"
       },
       "put": {
         "operationId": "updateUser",
@@ -459,7 +469,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update user"
       },
       "patch": {
         "operationId": "patchUser",
@@ -504,10 +515,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Partially update user"
       }
     },
-    "/auth/login/": {
+    "/auth/login": {
       "post": {
         "operationId": "login",
         "summary": "Login",
@@ -535,7 +547,7 @@
         }
       }
     },
-    "/auth/logout/": {
+    "/auth/logout": {
       "get": {
         "operationId": "logoutGet",
         "summary": "Logout (GET)",
@@ -546,7 +558,8 @@
           "200": {
             "description": "Logged out"
           }
-        }
+        },
+        "description": "Logout (GET)"
       },
       "post": {
         "operationId": "logoutPost",
@@ -558,10 +571,11 @@
           "200": {
             "description": "Logged out"
           }
-        }
+        },
+        "description": "Logout (POST)"
       }
     },
-    "/auth/password/change/": {
+    "/auth/password/change": {
       "post": {
         "operationId": "changePassword",
         "summary": "Change password",
@@ -588,10 +602,11 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Change password"
       }
     },
-    "/auth/password/reset/": {
+    "/auth/password/reset": {
       "post": {
         "operationId": "resetPassword",
         "summary": "Request password reset",
@@ -615,10 +630,11 @@
           "400": {
             "description": "Invalid request"
           }
-        }
+        },
+        "description": "Request password reset"
       }
     },
-    "/auth/password/reset/confirm/": {
+    "/auth/password/reset/confirm": {
       "post": {
         "operationId": "confirmPasswordReset",
         "summary": "Confirm password reset",
@@ -642,10 +658,11 @@
           "400": {
             "description": "Invalid request"
           }
-        }
+        },
+        "description": "Confirm password reset"
       }
     },
-    "/auth/registration/": {
+    "/auth/registration": {
       "post": {
         "operationId": "register",
         "summary": "Register new user",
@@ -669,10 +686,11 @@
           "400": {
             "description": "Invalid request"
           }
-        }
+        },
+        "description": "Register new user"
       }
     },
-    "/auth/registration/verify-email/": {
+    "/auth/registration/verify-email": {
       "post": {
         "operationId": "verifyEmail",
         "summary": "Verify email address",
@@ -696,10 +714,11 @@
           "400": {
             "description": "Invalid key"
           }
-        }
+        },
+        "description": "Verify email address"
       }
     },
-    "/auth/user/": {
+    "/auth/user": {
       "get": {
         "operationId": "getAuthUser",
         "summary": "Get authenticated user details",
@@ -720,7 +739,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get authenticated user details"
       },
       "put": {
         "operationId": "updateAuthUser",
@@ -752,7 +772,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update authenticated user"
       },
       "patch": {
         "operationId": "patchAuthUser",
@@ -784,7 +805,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Partially update authenticated user"
       }
     }
   },

--- a/apis/openapi/crowd.dev/crowd-dev-api/1.0.0/openapi.json
+++ b/apis/openapi/crowd.dev/crowd-dev-api/1.0.0/openapi.json
@@ -1394,6 +1394,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   }
 }

--- a/apis/openapi/crowd.dev/crowd-dev-api/1.0.0/openapi.json
+++ b/apis/openapi/crowd.dev/crowd-dev-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "crowd.dev API",
     "version": "1.0.0",
     "description": "crowd.dev is a developer-first community and go-to-market data platform. The API provides access to members, activities, organizations, tasks, notes, tags, and automation management.",
-    "x-jentic-source-url": "https://docs.crowd.dev"
+    "x-jentic-source-url": "https://docs.crowd.dev",
+    "contact": {}
   },
   "servers": [
     {
@@ -112,7 +113,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a member"
       }
     },
     "/member/{id}": {
@@ -149,7 +151,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a member"
       },
       "put": {
         "operationId": "updateMember",
@@ -187,7 +190,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a member"
       },
       "delete": {
         "operationId": "deleteMember",
@@ -215,7 +219,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a member"
       }
     },
     "/member/query": {
@@ -333,7 +338,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an activity"
       }
     },
     "/activity/{id}": {
@@ -370,7 +376,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get an activity"
       },
       "put": {
         "operationId": "updateActivity",
@@ -408,7 +415,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an activity"
       },
       "delete": {
         "operationId": "deleteActivity",
@@ -436,7 +444,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an activity"
       }
     },
     "/activity/query": {
@@ -498,7 +507,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Query activities"
       }
     },
     "/organization": {
@@ -539,7 +549,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an organization"
       }
     },
     "/organization/{id}": {
@@ -569,7 +580,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get an organization"
       },
       "put": {
         "operationId": "updateOrganization",
@@ -607,7 +619,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an organization"
       },
       "delete": {
         "operationId": "deleteOrganization",
@@ -635,7 +648,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an organization"
       }
     },
     "/organization/query": {
@@ -679,7 +693,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Query organizations"
       }
     },
     "/task": {
@@ -736,7 +751,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a task"
       }
     },
     "/task/{id}": {
@@ -766,7 +782,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a task"
       },
       "put": {
         "operationId": "updateTask",
@@ -804,7 +821,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a task"
       },
       "delete": {
         "operationId": "deleteTask",
@@ -832,7 +850,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a task"
       }
     },
     "/task/query": {
@@ -876,7 +895,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Query tasks"
       }
     },
     "/note": {
@@ -917,7 +937,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a note"
       }
     },
     "/note/{id}": {
@@ -947,7 +968,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a note"
       },
       "put": {
         "operationId": "updateNote",
@@ -985,7 +1007,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a note"
       },
       "delete": {
         "operationId": "deleteNote",
@@ -1013,7 +1036,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a note"
       }
     },
     "/tag": {
@@ -1048,7 +1072,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a tag"
       }
     },
     "/tag/{id}": {
@@ -1078,7 +1103,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a tag"
       },
       "put": {
         "operationId": "updateTag",
@@ -1116,7 +1142,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a tag"
       },
       "delete": {
         "operationId": "deleteTag",
@@ -1144,7 +1171,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a tag"
       }
     },
     "/automation": {
@@ -1185,7 +1213,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an automation"
       }
     },
     "/automation/{id}": {
@@ -1215,7 +1244,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get an automation"
       },
       "put": {
         "operationId": "updateAutomation",
@@ -1253,7 +1283,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an automation"
       },
       "delete": {
         "operationId": "deleteAutomation",
@@ -1281,18 +1312,12 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an automation"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "Bearer token from crowd.dev dashboard"
-      }
-    },
     "schemas": {
       "Member": {
         "type": "object",
@@ -1365,17 +1390,6 @@
             "type": "string"
           },
           "channel": {
-            "type": "string"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
             "type": "string"
           }
         }

--- a/apis/openapi/crucible.local/crucible/1.0.0/openapi.json
+++ b/apis/openapi/crucible.local/crucible/1.0.0/openapi.json
@@ -29,7 +29,8 @@
       }
     ],
     "x-providerName": "crucible.local",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/crucible.local/1.0.0/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/crucible.local/1.0.0/swagger.yaml",
+    "description": "Crucible"
   },
   "paths": {
     "/rest-service/auth-v1/login": {
@@ -56,7 +57,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [],
       "post": {
@@ -67,7 +71,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/projects-v1": {
@@ -88,7 +95,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -109,7 +119,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -168,7 +181,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -180,7 +196,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -207,7 +226,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -272,7 +294,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -299,7 +324,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -333,7 +361,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -366,7 +397,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Getrepositorydetails"
       },
       "parameters": [
         {
@@ -386,7 +421,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -405,7 +443,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Details"
       },
       "parameters": [
         {
@@ -447,7 +489,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Getallreviews"
       },
       "parameters": [],
       "post": {
@@ -457,7 +503,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Createreview"
       }
     },
     "/rest-service/reviews-v1/details": {
@@ -477,7 +527,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -577,7 +630,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [],
       "post": {
@@ -588,7 +644,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/filter/details": {
@@ -687,7 +746,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [],
       "post": {
@@ -698,7 +760,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/filter/{filter}": {
@@ -709,7 +774,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -729,7 +797,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -749,7 +820,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -778,7 +852,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -807,7 +884,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -827,7 +907,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -839,7 +922,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "get": {
         "description": "Get a single review by its permId (e.g. \"CR-45\").\n If the review does not exist, a 404 is returned.\n \n The moderator element may not exist if the review does not have a Moderator.",
@@ -848,7 +934,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -868,7 +957,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -897,7 +989,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Addchangesettoreview"
       }
     },
     "/rest-service/reviews-v1/{id}/addFile": {
@@ -916,7 +1012,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Addfile"
       }
     },
     "/rest-service/reviews-v1/{id}/addPatch": {
@@ -936,7 +1036,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/close": {
@@ -957,7 +1060,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments": {
@@ -978,7 +1084,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -997,7 +1106,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/general": {
@@ -1017,7 +1129,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Getgeneralcomments"
       },
       "parameters": [
         {
@@ -1046,7 +1162,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/versioned": {
@@ -1066,7 +1185,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Getversionedcomments"
       },
       "parameters": [
         {
@@ -1086,7 +1209,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "get": {
         "description": "Gets the given comment.",
@@ -1105,7 +1231,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1131,7 +1260,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/{cId}/markAsLeaveUnread": {
@@ -1158,7 +1290,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/{cId}/markAsRead": {
@@ -1185,7 +1320,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/{cId}/replies": {
@@ -1206,7 +1344,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1232,7 +1373,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/comments/{cId}/replies/{rId}": {
@@ -1243,7 +1387,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1276,7 +1423,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/complete": {
@@ -1306,7 +1456,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/details": {
@@ -1317,7 +1470,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1337,7 +1493,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1356,7 +1515,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/patch/{patchId}": {
@@ -1367,7 +1529,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1404,7 +1569,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/publish/{cId}": {
@@ -1431,7 +1599,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/remind": {
@@ -1452,7 +1623,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewers": {
@@ -1463,7 +1637,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1482,7 +1659,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewers/completed": {
@@ -1493,7 +1673,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1513,7 +1696,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1533,7 +1719,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1560,7 +1749,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1579,7 +1771,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewitems/details": {
@@ -1600,7 +1795,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewitems/revisions": {
@@ -1621,7 +1819,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewitems/{riId}": {
@@ -1632,7 +1833,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "get": {
         "description": "Returns detailed information for a specific review item.",
@@ -1641,7 +1845,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1677,7 +1884,11 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ],
+        "description": "Getreviewitemscomments"
       },
       "parameters": [
         {
@@ -1703,7 +1914,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewitems/{riId}/details": {
@@ -1731,7 +1945,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/reviewitems/{riId}/revisions": {
@@ -1742,7 +1959,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1774,7 +1994,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/transition": {
@@ -1811,7 +2034,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/reviews-v1/{id}/transitions": {
@@ -1822,7 +2048,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1861,7 +2090,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       }
     },
     "/rest-service/search-v1/reviews": {
@@ -1888,7 +2120,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -1916,7 +2151,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -1937,7 +2175,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": []
     },
@@ -1949,7 +2190,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1976,7 +2220,10 @@
           "200": {
             "description": "Successful Response"
           }
-        }
+        },
+        "tags": [
+          "rest-service"
+        ]
       },
       "parameters": [
         {
@@ -1988,5 +2235,10 @@
         }
       ]
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "rest-service"
+    }
+  ]
 }

--- a/apis/openapi/cruisen.com/cruisen-api/1.0.0/openapi.json
+++ b/apis/openapi/cruisen.com/cruisen-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cruisen API",
     "version": "1.0.0",
     "description": "Public API for cruise travel advisors to manage users, profiles, bookings, and trips.",
-    "x-jentic-source-url": "https://cruisen-preview.firebaseapp.com/public-api-docs.html"
+    "x-jentic-source-url": "https://cruisen-preview.firebaseapp.com/public-api-docs.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -309,6 +310,20 @@
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Bookings"
+    },
+    {
+      "name": "Profiles"
+    },
+    {
+      "name": "Trips"
+    },
+    {
+      "name": "Users"
     }
   ]
 }

--- a/apis/openapi/crustdata.com/crustdata-api/1.0.0/openapi.json
+++ b/apis/openapi/crustdata.com/crustdata-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Crustdata API",
     "version": "1.0.0",
     "description": "Crustdata provides company and person data enrichment and search APIs. Access company profiles, headcount data, funding information, and person/people search capabilities.",
-    "x-jentic-source-url": "https://docs.crustdata.com"
+    "x-jentic-source-url": "https://docs.crustdata.com",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/cryptolens.io/cryptolens/3.0.0/openapi.json
+++ b/apis/openapi/cryptolens.io/cryptolens/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cryptolens Web API",
     "version": "3.0.0",
     "description": "API for license key management, customer management, and product operations in Cryptolens. All methods require an access token for authentication.",
-    "x-jentic-source-url": "https://app.cryptolens.io/docs/api"
+    "x-jentic-source-url": "https://app.cryptolens.io/docs/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -29,7 +30,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -64,7 +69,10 @@
                   "SignMethod": {
                     "type": "integer",
                     "default": 0,
-                    "enum": [0, 1],
+                    "enum": [
+                      0,
+                      1
+                    ],
                     "description": "Signature format: 0=Linq, 1=String"
                   },
                   "Metadata": {
@@ -87,7 +95,11 @@
                   "ModelVersion": {
                     "type": "integer",
                     "default": 1,
-                    "enum": [1, 2, 3],
+                    "enum": [
+                      1,
+                      2,
+                      3
+                    ],
                     "description": "Response model version"
                   },
                   "v": {
@@ -121,7 +133,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/GetKey": {
@@ -135,7 +150,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -162,7 +181,10 @@
                   "SignMethod": {
                     "type": "integer",
                     "default": 0,
-                    "enum": [0, 1],
+                    "enum": [
+                      0,
+                      1
+                    ],
                     "description": "Format/signing method: 0=JSON, 1=Base64 string"
                   },
                   "Metadata": {
@@ -178,7 +200,11 @@
                   "ModelVersion": {
                     "type": "integer",
                     "default": 1,
-                    "enum": [1, 2, 3],
+                    "enum": [
+                      1,
+                      2,
+                      3
+                    ],
                     "description": "Response model version"
                   },
                   "v": {
@@ -212,7 +238,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/CreateKey": {
@@ -226,7 +255,10 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "token"],
+                "required": [
+                  "ProductId",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -329,7 +361,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/Deactivate": {
@@ -343,7 +378,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -387,7 +426,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/BlockKey": {
@@ -401,7 +443,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -441,7 +487,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/UnblockKey": {
@@ -455,7 +504,11 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -495,7 +548,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/key/ExtendLicense": {
@@ -509,7 +565,12 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["ProductId", "Key", "token", "NoOfDays"],
+                "required": [
+                  "ProductId",
+                  "Key",
+                  "token",
+                  "NoOfDays"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -553,7 +614,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "key"
+        ]
       }
     },
     "/customer/AddCustomer": {
@@ -567,7 +631,9 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["token"],
+                "required": [
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -612,7 +678,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "customer"
+        ]
       }
     },
     "/customer/GetCustomers": {
@@ -626,7 +695,9 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["token"],
+                "required": [
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -662,7 +733,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "customer"
+        ]
       }
     },
     "/product/GetProducts": {
@@ -676,7 +750,9 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["token"],
+                "required": [
+                  "token"
+                ],
                 "properties": {
                   "token": {
                     "type": "string",
@@ -712,7 +788,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "product"
+        ]
       }
     }
   },
@@ -969,5 +1048,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "customer"
+    },
+    {
+      "name": "key"
+    },
+    {
+      "name": "product"
+    }
+  ]
 }

--- a/apis/openapi/cs-cart.com/rest-api/2.0/openapi.json
+++ b/apis/openapi/cs-cart.com/rest-api/2.0/openapi.json
@@ -28,29 +28,37 @@
       "get": {
         "summary": "List products",
         "operationId": "getProducts",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "responses": {
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "List products"
       },
       "post": {
         "summary": "Create product",
         "operationId": "createProduct",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "responses": {
           "201": {
             "description": "Product created"
           }
-        }
+        },
+        "description": "Create product"
       }
     },
     "/products/{id}": {
       "get": {
         "summary": "Get product",
         "operationId": "getProduct",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -65,12 +73,15 @@
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "Get product"
       },
       "put": {
         "summary": "Update product",
         "operationId": "updateProduct",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -85,12 +96,15 @@
           "200": {
             "description": "Product updated"
           }
-        }
+        },
+        "description": "Update product"
       },
       "delete": {
         "summary": "Delete product",
         "operationId": "deleteProduct",
-        "tags": ["Products"],
+        "tags": [
+          "Products"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -105,43 +119,53 @@
           "204": {
             "description": "Product deleted"
           }
-        }
+        },
+        "description": "Delete product"
       }
     },
     "/orders": {
       "get": {
         "summary": "List orders",
         "operationId": "getOrders",
-        "tags": ["Orders"],
+        "tags": [
+          "Orders"
+        ],
         "responses": {
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "List orders"
       }
     },
     "/users": {
       "get": {
         "summary": "List users",
         "operationId": "getUsers",
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "responses": {
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "List users"
       }
     },
     "/categories": {
       "get": {
         "summary": "List categories",
         "operationId": "getCategories",
-        "tags": ["Categories"],
+        "tags": [
+          "Categories"
+        ],
         "responses": {
           "200": {
             "description": "Successful response"
           }
-        }
+        },
+        "description": "List categories"
       }
     }
   },
@@ -152,5 +176,19 @@
         "scheme": "basic"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Categories"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "Products"
+    },
+    {
+      "name": "Users"
+    }
+  ]
 }

--- a/apis/openapi/cube.dev/cube-rest-api/1.0.0/openapi.json
+++ b/apis/openapi/cube.dev/cube-rest-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cube.js REST API",
     "version": "1.0.0",
     "description": "Cube.js REST API provides endpoints for loading data via Cube JSON queries and retrieving metadata about the data model. The API uses JWT bearer authentication.",
-    "x-jentic-source-url": "https://cube.dev/docs/product/apis-integrations/rest-api"
+    "x-jentic-source-url": "https://cube.dev/docs/product/apis-integrations/rest-api",
+    "contact": {}
   },
   "servers": [
     {
@@ -39,7 +40,9 @@
         "operationId": "getMetadata",
         "summary": "Load Metadata",
         "description": "Returns metadata about the available cubes, including their measures, dimensions, segments, and joins.",
-        "tags": ["Metadata"],
+        "tags": [
+          "Metadata"
+        ],
         "responses": {
           "200": {
             "description": "Successful operation",
@@ -79,7 +82,9 @@
         "operationId": "loadData",
         "summary": "Load data via Cube JSON Query",
         "description": "Executes a Cube JSON query and returns the result data with annotations.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -150,7 +155,13 @@
       },
       "V1CubeMeta": {
         "type": "object",
-        "required": ["name", "type", "measures", "dimensions", "segments"],
+        "required": [
+          "name",
+          "type",
+          "measures",
+          "dimensions",
+          "segments"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -160,7 +171,10 @@
           },
           "type": {
             "type": "string",
-            "enum": ["cube", "view"],
+            "enum": [
+              "cube",
+              "view"
+            ],
             "description": "Type of cube"
           },
           "meta": {
@@ -197,7 +211,10 @@
       },
       "V1CubeMetaMeasure": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -224,7 +241,10 @@
       },
       "V1CubeMetaDimension": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -248,7 +268,11 @@
       },
       "V1CubeMetaSegment": {
         "type": "object",
-        "required": ["name", "title", "shortTitle"],
+        "required": [
+          "name",
+          "title",
+          "shortTitle"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -269,7 +293,10 @@
       },
       "V1CubeMetaJoin": {
         "type": "object",
-        "required": ["name", "relationship"],
+        "required": [
+          "name",
+          "relationship"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -287,7 +314,12 @@
           },
           "cache": {
             "type": "string",
-            "enum": ["stale-if-slow", "stale-while-revalidate", "must-revalidate", "no-cache"]
+            "enum": [
+              "stale-if-slow",
+              "stale-while-revalidate",
+              "must-revalidate",
+              "no-cache"
+            ]
           },
           "query": {
             "$ref": "#/components/schemas/V1LoadRequestQuery"
@@ -354,7 +386,9 @@
       },
       "V1TimeDimension": {
         "type": "object",
-        "required": ["dimension"],
+        "required": [
+          "dimension"
+        ],
         "properties": {
           "dimension": {
             "type": "string"
@@ -398,7 +432,9 @@
       },
       "V1LoadResponse": {
         "type": "object",
-        "required": ["results"],
+        "required": [
+          "results"
+        ],
         "properties": {
           "pivotQuery": {
             "type": "object"
@@ -419,7 +455,10 @@
       },
       "V1LoadResult": {
         "type": "object",
-        "required": ["annotation", "data"],
+        "required": [
+          "annotation",
+          "data"
+        ],
         "properties": {
           "dataSource": {
             "type": "string"
@@ -454,7 +493,9 @@
       },
       "V1Error": {
         "type": "object",
-        "required": ["error"],
+        "required": [
+          "error"
+        ],
         "properties": {
           "error": {
             "type": "string"

--- a/apis/openapi/cupixworks.com/cupixworks/1.0.0/openapi.json
+++ b/apis/openapi/cupixworks.com/cupixworks/1.0.0/openapi.json
@@ -3,7 +3,8 @@
   "info": {
     "title": "CupixWorks API",
     "description": "CupixWorks API for managing annotation layers, categories, progress tracking, statuses, workflows, and review processes",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "contact": {}
   },
   "servers": [
     {
@@ -36,7 +37,8 @@
           "200": {
             "description": "List of annotation layers"
           }
-        }
+        },
+        "operationId": "get-annotation-layers"
       },
       "post": {
         "summary": "Create annotation layer",
@@ -58,7 +60,8 @@
           "201": {
             "description": "Annotation layer created"
           }
-        }
+        },
+        "operationId": "post-annotation-layers"
       }
     },
     "/annotation-layers/{id}": {
@@ -82,7 +85,8 @@
           "200": {
             "description": "Annotation layer details"
           }
-        }
+        },
+        "operationId": "get-annotation-layers-by-id"
       },
       "put": {
         "summary": "Update annotation layer",
@@ -114,7 +118,8 @@
           "200": {
             "description": "Annotation layer updated"
           }
-        }
+        },
+        "operationId": "put-annotation-layers-by-id"
       },
       "delete": {
         "summary": "Delete annotation layer",
@@ -136,7 +141,8 @@
           "204": {
             "description": "Annotation layer deleted"
           }
-        }
+        },
+        "operationId": "delete-annotation-layers-by-id"
       }
     },
     "/annotation-layers/{id}/publish": {
@@ -160,7 +166,8 @@
           "200": {
             "description": "Annotation layer published"
           }
-        }
+        },
+        "operationId": "put-annotation-layers-by-id-publish"
       }
     },
     "/annotation-layers/{id}/unpublish": {
@@ -184,7 +191,8 @@
           "200": {
             "description": "Annotation layer unpublished"
           }
-        }
+        },
+        "operationId": "put-annotation-layers-by-id-unpublish"
       }
     },
     "/annotation-layers/{id}/metadata": {
@@ -208,7 +216,8 @@
           "200": {
             "description": "Layer metadata"
           }
-        }
+        },
+        "operationId": "get-annotation-layers-by-id-metadata"
       },
       "put": {
         "summary": "Update layer metadata",
@@ -240,7 +249,8 @@
           "200": {
             "description": "Metadata updated"
           }
-        }
+        },
+        "operationId": "put-annotation-layers-by-id-metadata"
       }
     },
     "/categories": {
@@ -254,7 +264,8 @@
           "200": {
             "description": "List of categories"
           }
-        }
+        },
+        "operationId": "get-categories"
       },
       "post": {
         "summary": "Create category",
@@ -276,7 +287,8 @@
           "201": {
             "description": "Category created"
           }
-        }
+        },
+        "operationId": "post-categories"
       }
     },
     "/categories/{id}": {
@@ -300,7 +312,8 @@
           "200": {
             "description": "Category details"
           }
-        }
+        },
+        "operationId": "get-categories-by-id"
       },
       "put": {
         "summary": "Update category",
@@ -332,7 +345,8 @@
           "200": {
             "description": "Category updated"
           }
-        }
+        },
+        "operationId": "put-categories-by-id"
       },
       "delete": {
         "summary": "Delete category",
@@ -354,7 +368,8 @@
           "204": {
             "description": "Category deleted"
           }
-        }
+        },
+        "operationId": "delete-categories-by-id"
       }
     },
     "/progress": {
@@ -368,7 +383,8 @@
           "200": {
             "description": "List of progress items"
           }
-        }
+        },
+        "operationId": "get-progress"
       },
       "post": {
         "summary": "Create progress",
@@ -390,7 +406,8 @@
           "201": {
             "description": "Progress created"
           }
-        }
+        },
+        "operationId": "post-progress"
       }
     },
     "/progress/{id}": {
@@ -414,7 +431,8 @@
           "200": {
             "description": "Progress details"
           }
-        }
+        },
+        "operationId": "get-progress-by-id"
       },
       "put": {
         "summary": "Update progress",
@@ -446,7 +464,8 @@
           "200": {
             "description": "Progress updated"
           }
-        }
+        },
+        "operationId": "put-progress-by-id"
       },
       "delete": {
         "summary": "Delete progress",
@@ -468,7 +487,8 @@
           "204": {
             "description": "Progress deleted"
           }
-        }
+        },
+        "operationId": "delete-progress-by-id"
       }
     },
     "/statuses": {
@@ -482,7 +502,8 @@
           "200": {
             "description": "List of statuses"
           }
-        }
+        },
+        "operationId": "get-statuses"
       },
       "post": {
         "summary": "Create status",
@@ -504,7 +525,8 @@
           "201": {
             "description": "Status created"
           }
-        }
+        },
+        "operationId": "post-statuses"
       }
     },
     "/statuses/{id}": {
@@ -528,7 +550,8 @@
           "200": {
             "description": "Status details"
           }
-        }
+        },
+        "operationId": "get-statuses-by-id"
       },
       "put": {
         "summary": "Update status",
@@ -560,7 +583,8 @@
           "200": {
             "description": "Status updated"
           }
-        }
+        },
+        "operationId": "put-statuses-by-id"
       },
       "delete": {
         "summary": "Delete status",
@@ -582,7 +606,8 @@
           "204": {
             "description": "Status deleted"
           }
-        }
+        },
+        "operationId": "delete-statuses-by-id"
       }
     },
     "/workflows": {
@@ -596,7 +621,8 @@
           "200": {
             "description": "List of workflows"
           }
-        }
+        },
+        "operationId": "get-workflows"
       },
       "post": {
         "summary": "Create workflow",
@@ -618,7 +644,8 @@
           "201": {
             "description": "Workflow created"
           }
-        }
+        },
+        "operationId": "post-workflows"
       }
     },
     "/workflows/{id}": {
@@ -642,7 +669,8 @@
           "200": {
             "description": "Workflow details"
           }
-        }
+        },
+        "operationId": "get-workflows-by-id"
       },
       "put": {
         "summary": "Update workflow",
@@ -674,7 +702,8 @@
           "200": {
             "description": "Workflow updated"
           }
-        }
+        },
+        "operationId": "put-workflows-by-id"
       },
       "delete": {
         "summary": "Delete workflow",
@@ -696,7 +725,8 @@
           "204": {
             "description": "Workflow deleted"
           }
-        }
+        },
+        "operationId": "delete-workflows-by-id"
       }
     },
     "/reviews": {
@@ -710,7 +740,8 @@
           "200": {
             "description": "List of reviews"
           }
-        }
+        },
+        "operationId": "get-reviews"
       },
       "post": {
         "summary": "Create review",
@@ -732,8 +763,29 @@
           "201": {
             "description": "Review created"
           }
-        }
+        },
+        "operationId": "post-reviews"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "AnnotationLayer"
+    },
+    {
+      "name": "Category"
+    },
+    {
+      "name": "Progress"
+    },
+    {
+      "name": "Review"
+    },
+    {
+      "name": "Status"
+    },
+    {
+      "name": "Workflow"
+    }
+  ]
 }

--- a/apis/openapi/currencyapi.com/currency-api/3.0.0/openapi.json
+++ b/apis/openapi/currencyapi.com/currency-api/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CurrencyAPI",
     "version": "3.0.0",
     "description": "CurrencyAPI provides reliable exchange rates and currency conversion. Delivers JSON data for latest and historical exchange rates, currency conversion, and a list of supported currencies.",
-    "x-jentic-source-url": "https://currencyapi.com/docs"
+    "x-jentic-source-url": "https://currencyapi.com/docs",
+    "contact": {}
   },
   "servers": [
     {
@@ -37,7 +38,9 @@
         "operationId": "getLatestRates",
         "summary": "Get latest exchange rates",
         "description": "Returns the latest exchange rates. Updated every 60 seconds for paid plans.",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "base_currency",
@@ -108,7 +111,9 @@
         "operationId": "getHistoricalRates",
         "summary": "Get historical exchange rates",
         "description": "Returns historical exchange rates for a specific date.",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "date",
@@ -179,7 +184,9 @@
         "operationId": "getRangeRates",
         "summary": "Get exchange rates for a date range",
         "description": "Returns daily exchange rates between two dates for time-series analysis.",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "datetime_start",
@@ -208,7 +215,12 @@
             "description": "Accuracy of the returned data (day, hour, quarter_hour, minute)",
             "schema": {
               "type": "string",
-              "enum": ["day", "hour", "quarter_hour", "minute"]
+              "enum": [
+                "day",
+                "hour",
+                "quarter_hour",
+                "minute"
+              ]
             }
           },
           {
@@ -270,7 +282,9 @@
         "operationId": "listCurrencies",
         "summary": "List supported currencies",
         "description": "Returns a list of all supported currencies with their details.",
-        "tags": ["Currencies"],
+        "tags": [
+          "Currencies"
+        ],
         "parameters": [
           {
             "name": "currencies",
@@ -288,7 +302,11 @@
             "description": "Filter by currency type",
             "schema": {
               "type": "string",
-              "enum": ["fiat", "crypto", "metal"]
+              "enum": [
+                "fiat",
+                "crypto",
+                "metal"
+              ]
             }
           }
         ],
@@ -331,7 +349,9 @@
         "operationId": "getAccountStatus",
         "summary": "Get API account status",
         "description": "Returns the current status of your API account including quotas and usage.",
-        "tags": ["Status"],
+        "tags": [
+          "Status"
+        ],
         "responses": {
           "200": {
             "description": "Successful response with account status",
@@ -496,7 +516,11 @@
           },
           "type": {
             "type": "string",
-            "enum": ["fiat", "crypto", "metal"]
+            "enum": [
+              "fiat",
+              "crypto",
+              "metal"
+            ]
           }
         }
       },

--- a/apis/openapi/currencyfreaks.com/currencyfreaks-api/2.0.0/openapi.json
+++ b/apis/openapi/currencyfreaks.com/currencyfreaks-api/2.0.0/openapi.json
@@ -39,7 +39,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "supported-currencies"
+        ]
       }
     },
     "/currency-symbols": {
@@ -60,7 +63,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "currency-symbols"
+        ]
       }
     },
     "/historical-data-limits": {
@@ -81,7 +87,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "historical-data-limits"
+        ]
       }
     },
     "/rates/latest": {
@@ -143,7 +152,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "rates"
+        ]
       }
     },
     "/convert/latest": {
@@ -215,7 +227,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "convert"
+        ]
       }
     },
     "/rates/historical": {
@@ -290,7 +305,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "rates"
+        ]
       }
     },
     "/timeseries": {
@@ -371,7 +389,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "timeseries"
+        ]
       }
     },
     "/fluctuation": {
@@ -452,7 +473,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "fluctuation"
+        ]
       }
     },
     "/convert/historical": {
@@ -535,7 +559,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "convert"
+        ]
       }
     },
     "/iptocurrency": {
@@ -605,7 +632,10 @@
           "429": {
             "description": "Request quota exceeded"
           }
-        }
+        },
+        "tags": [
+          "iptocurrency"
+        ]
       }
     }
   },
@@ -835,5 +865,31 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "convert"
+    },
+    {
+      "name": "currency-symbols"
+    },
+    {
+      "name": "fluctuation"
+    },
+    {
+      "name": "historical-data-limits"
+    },
+    {
+      "name": "iptocurrency"
+    },
+    {
+      "name": "rates"
+    },
+    {
+      "name": "supported-currencies"
+    },
+    {
+      "name": "timeseries"
+    }
+  ]
 }

--- a/apis/openapi/currencylayer.com/currencylayer-api/1.0.0/openapi.json
+++ b/apis/openapi/currencylayer.com/currencylayer-api/1.0.0/openapi.json
@@ -66,7 +66,9 @@
             "description": "Set to 1 for cleaner JSON formatting.",
             "schema": {
               "type": "integer",
-              "enum": [1]
+              "enum": [
+                1
+              ]
             }
           }
         ],
@@ -81,7 +83,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "live"
+        ]
       }
     },
     "/historical": {
@@ -140,7 +145,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "historical"
+        ]
       }
     },
     "/convert": {
@@ -207,7 +215,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "convert"
+        ]
       }
     },
     "/timeframe": {
@@ -276,7 +287,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "timeframe"
+        ]
       }
     },
     "/change": {
@@ -345,7 +359,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "change"
+        ]
       }
     },
     "/list": {
@@ -375,19 +392,14 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "list"
+        ]
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "query",
-        "name": "access_key",
-        "description": "API access key obtained from your Currencylayer account dashboard."
-      }
-    },
     "schemas": {
       "LiveResponse": {
         "type": "object",
@@ -599,30 +611,27 @@
             "description": "Object mapping currency codes to currency names."
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "example": false
-          },
-          "error": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "integer"
-              },
-              "type": {
-                "type": "string"
-              },
-              "info": {
-                "type": "string"
-              }
-            }
-          }
-        }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "change"
+    },
+    {
+      "name": "convert"
+    },
+    {
+      "name": "historical"
+    },
+    {
+      "name": "list"
+    },
+    {
+      "name": "live"
+    },
+    {
+      "name": "timeframe"
+    }
+  ]
 }

--- a/apis/openapi/currencylayer.com/currencylayer-api/1.0.0/openapi.json
+++ b/apis/openapi/currencylayer.com/currencylayer-api/1.0.0/openapi.json
@@ -612,6 +612,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "tags": [

--- a/apis/openapi/currencyscoop.com/currencybeacon-api/1.0.0/openapi.json
+++ b/apis/openapi/currencyscoop.com/currencybeacon-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CurrencyBeacon API",
     "version": "1.0.0",
     "description": "CurrencyBeacon (formerly CurrencyScoop) provides a RESTful interface for accessing real-time and historical exchange rates for over 168 world currencies and more than 2,000 cryptocurrencies. Data is aggregated from multiple commercial sources and banks.",
-    "x-jentic-source-url": "https://currencyscoop.com/api-documentation"
+    "x-jentic-source-url": "https://currencyscoop.com/api-documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -44,7 +45,9 @@
         "operationId": "getLatestRates",
         "summary": "Get latest exchange rates",
         "description": "Returns real-time exchange rate data for all available currencies. Data is updated based on subscription plan frequency (e.g., every 60 seconds).",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "base",
@@ -105,7 +108,9 @@
         "operationId": "getHistoricalRates",
         "summary": "Get historical exchange rates",
         "description": "Retrieve historical exchange rates for any specific date in the past. Database goes back to January 1, 1996.",
-        "tags": ["Exchange Rates"],
+        "tags": [
+          "Exchange Rates"
+        ],
         "parameters": [
           {
             "name": "date",
@@ -176,7 +181,9 @@
         "operationId": "convertCurrency",
         "summary": "Convert currency",
         "description": "Convert any amount from one currency to another using real-time mid-market exchange rates.",
-        "tags": ["Conversion"],
+        "tags": [
+          "Conversion"
+        ],
         "parameters": [
           {
             "name": "from",
@@ -255,7 +262,9 @@
         "operationId": "getTimeSeries",
         "summary": "Get time-series exchange rate data",
         "description": "Returns daily historical exchange rates between two specified dates. Designed for plotting charts or analyzing volatility. Available on Startup and Pro plans only.",
-        "tags": ["Time Series"],
+        "tags": [
+          "Time Series"
+        ],
         "parameters": [
           {
             "name": "start_date",
@@ -337,7 +346,9 @@
         "operationId": "listCurrencies",
         "summary": "List supported currencies",
         "description": "Returns a list of all supported currencies, including their full names, symbols, and ISO codes.",
-        "tags": ["Currencies"],
+        "tags": [
+          "Currencies"
+        ],
         "responses": {
           "200": {
             "description": "Successful response with currencies list",

--- a/apis/openapi/customerbase.com/customerbase-api/1.0.0/openapi.json
+++ b/apis/openapi/customerbase.com/customerbase-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CustomerBase API",
     "version": "1.0.0",
     "description": "CustomerBase public API for managing customers, appointments, estimates, jobs, reviews, users, roles, and work requests.",
-    "x-jentic-source-url": "https://app.customerbase.com/docs/api/public/v1/"
+    "x-jentic-source-url": "https://app.customerbase.com/docs/api/public/v1/",
+    "contact": {}
   },
   "servers": [
     {
@@ -94,7 +95,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List customers"
       },
       "post": {
         "operationId": "createCustomers",
@@ -143,7 +145,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create customer"
       }
     },
     "/customers/{id}": {
@@ -194,7 +197,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get customer"
       },
       "put": {
         "operationId": "updateCustomers",
@@ -253,7 +257,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update customer"
       },
       "delete": {
         "operationId": "deleteCustomers",
@@ -295,7 +300,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete customer"
       }
     },
     "/appointments": {
@@ -380,7 +386,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List appointments"
       },
       "post": {
         "operationId": "createAppointments",
@@ -429,7 +436,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create appointment"
       }
     },
     "/appointments/{id}": {
@@ -480,7 +488,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get appointment"
       }
     },
     "/estimates": {
@@ -565,7 +574,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List estimates"
       },
       "post": {
         "operationId": "createEstimates",
@@ -614,7 +624,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create estimate"
       }
     },
     "/estimates/{id}": {
@@ -665,7 +676,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get estimate"
       }
     },
     "/jobs": {
@@ -750,7 +762,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List jobs"
       },
       "post": {
         "operationId": "createJobs",
@@ -799,7 +812,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create job"
       }
     },
     "/jobs/{id}": {
@@ -850,7 +864,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get job"
       }
     },
     "/reviews": {
@@ -935,7 +950,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List reviews"
       }
     },
     "/reviews/{id}": {
@@ -986,7 +1002,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get review"
       }
     },
     "/roles": {
@@ -1071,7 +1088,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List roles"
       }
     },
     "/roles/{id}": {
@@ -1122,7 +1140,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get role"
       }
     },
     "/users": {
@@ -1207,7 +1226,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List users"
       },
       "post": {
         "operationId": "createUsers",
@@ -1256,7 +1276,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create user"
       }
     },
     "/users/{id}": {
@@ -1307,7 +1328,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get user"
       },
       "put": {
         "operationId": "updateUsers",
@@ -1366,7 +1388,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update user"
       },
       "delete": {
         "operationId": "deleteUsers",
@@ -1408,7 +1431,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete user"
       }
     },
     "/work_requests": {
@@ -1493,7 +1517,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List work requests"
       },
       "post": {
         "operationId": "createWorkRequests",
@@ -1542,7 +1567,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create work_request"
       }
     },
     "/work_requests/{id}": {
@@ -1593,7 +1619,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get work_request"
       }
     }
   },
@@ -1793,6 +1820,32 @@
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Appointments"
+    },
+    {
+      "name": "Customers"
+    },
+    {
+      "name": "Estimates"
+    },
+    {
+      "name": "Jobs"
+    },
+    {
+      "name": "Reviews"
+    },
+    {
+      "name": "Roles"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Work Requests"
     }
   ]
 }

--- a/apis/openapi/customjs.space/customjs-api/1.0.0/openapi.json
+++ b/apis/openapi/customjs.space/customjs-api/1.0.0/openapi.json
@@ -455,6 +455,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/customjs.space/customjs-api/1.0.0/openapi.json
+++ b/apis/openapi/customjs.space/customjs-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CustomJS API",
     "version": "1.0.0",
     "description": "CustomJS provides APIs for HTML to PDF conversion, markdown to PDF conversion, web screenshots, HTML scraping, JavaScript execution, and hosted HTML page management.",
-    "x-jentic-source-url": "https://www.customjs.space/integration/native-api/documentation"
+    "x-jentic-source-url": "https://www.customjs.space/integration/native-api/documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -72,7 +73,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Convert HTML to PDF"
       }
     },
     "/markdown2pdf": {
@@ -118,7 +120,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Convert Markdown to PDF"
       }
     },
     "/screenshot": {
@@ -187,7 +190,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Capture a web page screenshot"
       }
     },
     "/scraper": {
@@ -238,7 +242,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Scrape HTML from a web page"
       }
     },
     "/__js1-": {
@@ -287,7 +292,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Execute custom JavaScript code"
       }
     },
     "/pages/page/upsert-html": {
@@ -339,7 +345,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create or update an HTML page"
       }
     },
     "/pages/api/page": {
@@ -366,7 +373,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Retrieve all HTML pages"
       }
     },
     "/pages/api/page/id/{pageId}": {
@@ -400,7 +408,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Retrieve a single page"
       },
       "delete": {
         "operationId": "deletePage",
@@ -425,7 +434,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an HTML page"
       }
     }
   },
@@ -444,27 +454,29 @@
             "type": "string"
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "x-api-key"
       }
     }
   },
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Conversion"
+    },
+    {
+      "name": "Execution"
+    },
+    {
+      "name": "Pages"
+    },
+    {
+      "name": "Scraping"
+    },
+    {
+      "name": "Screenshots"
     }
   ]
 }

--- a/apis/openapi/cutt.ly/cuttly-team-api/1.0.0/openapi.json
+++ b/apis/openapi/cutt.ly/cuttly-team-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cutt.ly Team API",
     "version": "1.0.0",
     "description": "Cutt.ly Team API provides URL shortening, link editing, and analytics capabilities for team plans. Supports custom domains, A/B testing, mobile deep linking, and comprehensive click statistics.",
-    "x-jentic-source-url": "https://cutt.ly/api-documentation/team-api"
+    "x-jentic-source-url": "https://cutt.ly/api-documentation/team-api",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,181 +18,261 @@
         "operationId": "shortenLink",
         "summary": "Shorten a URL",
         "description": "Create a shortened URL with optional customization for aliases, custom domains, and metadata.",
-        "tags": ["Links"],
+        "tags": [
+          "Links"
+        ],
         "parameters": [
           {
             "name": "key",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "API authentication key"
           },
           {
             "name": "action",
             "in": "query",
             "required": true,
-            "schema": { "type": "string", "enum": ["shorten", "edit", "stats"] },
+            "schema": {
+              "type": "string",
+              "enum": [
+                "shorten",
+                "edit",
+                "stats"
+              ]
+            },
             "description": "Action to perform"
           },
           {
             "name": "url",
             "in": "query",
             "required": true,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Target URL (must be URL-encoded)"
           },
           {
             "name": "name",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Custom alias/short link name"
           },
           {
             "name": "domain",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Custom domain (e.g., your-domain.co)"
           },
           {
             "name": "noTitle",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "enum": [0, 1] },
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            },
             "description": "Set to 1 to skip page title retrieval (Enterprise only)"
           },
           {
             "name": "public",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "enum": [0, 1] },
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            },
             "description": "Set to 1 for public click statistics"
           },
           {
             "name": "header",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "TRAI SMS compliance header"
           },
           {
             "name": "tag",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Tag for the link (used with edit action)"
           },
           {
             "name": "source",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Source metadata (used with edit action)"
           },
           {
             "name": "title",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Title metadata (used with edit action)"
           },
           {
             "name": "mobile",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Mobile redirect URL (used with edit action)"
           },
           {
             "name": "destination",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Mobile destination (used with edit action)"
           },
           {
             "name": "package_id",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Mobile package ID (used with edit action)"
           },
           {
             "name": "referrer",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Referrer (used with edit action)"
           },
           {
             "name": "abtest",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "enum": [0, 1] },
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            },
             "description": "Enable A/B testing (used with edit action)"
           },
           {
             "name": "abtest_b",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "A/B test variant B URL"
           },
           {
             "name": "abtest_bvariation",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "A/B test B variation percentage"
           },
           {
             "name": "expire",
             "in": "query",
             "required": false,
-            "schema": { "type": "string", "format": "date" },
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
             "description": "Expiration date"
           },
           {
             "name": "expireCond",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Expiration condition"
           },
           {
             "name": "expireRedirect",
             "in": "query",
             "required": false,
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Redirect URL after expiration"
           },
           {
             "name": "password",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "enum": [0, 1] },
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            },
             "description": "Set to 1 to enable password protection"
           },
           {
             "name": "delete",
             "in": "query",
             "required": false,
-            "schema": { "type": "integer", "enum": [0, 1] },
+            "schema": {
+              "type": "integer",
+              "enum": [
+                0,
+                1
+              ]
+            },
             "description": "Set to 1 to delete the link"
           },
           {
             "name": "date_from",
             "in": "query",
             "required": false,
-            "schema": { "type": "string", "format": "date" },
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
             "description": "Start date for stats (YYYY-MM-DD)"
           },
           {
             "name": "date_to",
             "in": "query",
             "required": false,
-            "schema": { "type": "string", "format": "date" },
+            "schema": {
+              "type": "string",
+              "format": "date"
+            },
             "description": "End date for stats (YYYY-MM-DD)"
           }
         ],
@@ -235,48 +316,53 @@
       "LinkResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "integer", "description": "Status code (1=success, 2=database error, 3=invalid URL, 4=validation failure)" },
-          "url": { "type": "object", "properties": {
-            "shortLink": { "type": "string" },
-            "title": { "type": "string" },
-            "date": { "type": "string" }
-          }}
-        }
-      },
-      "StatsResponse": {
-        "type": "object",
-        "properties": {
-          "clicks": { "type": "integer" },
-          "referrers": { "type": "object" },
-          "geolocation": { "type": "object" },
-          "devices": { "type": "object" },
-          "operating_systems": { "type": "object" },
-          "browsers": { "type": "object" },
-          "brands": { "type": "object" },
-          "languages": { "type": "object" },
-          "bots": { "type": "object" }
+          "status": {
+            "type": "integer",
+            "description": "Status code (1=success, 2=database error, 3=invalid URL, 4=validation failure)"
+          },
+          "url": {
+            "type": "object",
+            "properties": {
+              "shortLink": {
+                "type": "string"
+              },
+              "title": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string"
+              }
+            }
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "enum": ["error"] },
-          "code": { "type": "string" },
-          "message": { "type": "string" }
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "query",
-        "name": "key"
       }
     }
   },
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Links"
     }
   ]
 }

--- a/apis/openapi/cutt.ly/cuttly-team-api/1.0.0/openapi.json
+++ b/apis/openapi/cutt.ly/cuttly-team-api/1.0.0/openapi.json
@@ -353,6 +353,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/cvr.dev/cvr-api/6.0.0/openapi.json
+++ b/apis/openapi/cvr.dev/cvr-api/6.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CVR API",
     "version": "6.0.0",
     "description": "Danish CVR (Central Business Register) API for looking up company information by CVR number, P-number, company name, or phone number. Supports Denmark and Norway.",
-    "x-jentic-source-url": "https://cvrapi.dk/documentation"
+    "x-jentic-source-url": "https://cvrapi.dk/documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,7 +19,9 @@
         "operationId": "searchCompany",
         "summary": "Search for company information",
         "description": "Search for Danish or Norwegian company information by CVR number, P-number, company name, or phone number. Returns company details including address, owners, production units, and credit information.",
-        "tags": ["Company Lookup"],
+        "tags": [
+          "Company Lookup"
+        ],
         "parameters": [
           {
             "name": "search",
@@ -36,7 +39,10 @@
             "description": "Country code to search in. Available countries: dk (Denmark), no (Norway).",
             "schema": {
               "type": "string",
-              "enum": ["dk", "no"]
+              "enum": [
+                "dk",
+                "no"
+              ]
             }
           },
           {
@@ -56,7 +62,10 @@
             "description": "Response format. Default is JSON.",
             "schema": {
               "type": "string",
-              "enum": ["json", "xml"],
+              "enum": [
+                "json",
+                "xml"
+              ],
               "default": "json"
             }
           },
@@ -163,7 +172,9 @@
         "operationId": "searchCompanyPost",
         "summary": "Search for company information (POST)",
         "description": "Same as GET but using POST method. Search for Danish or Norwegian company information.",
-        "tags": ["Company Lookup"],
+        "tags": [
+          "Company Lookup"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -227,7 +238,10 @@
     "schemas": {
       "CompanySearchRequest": {
         "type": "object",
-        "required": ["search", "country"],
+        "required": [
+          "search",
+          "country"
+        ],
         "properties": {
           "search": {
             "type": "string",
@@ -235,7 +249,10 @@
           },
           "country": {
             "type": "string",
-            "enum": ["dk", "no"],
+            "enum": [
+              "dk",
+              "no"
+            ],
             "description": "Country to search in"
           },
           "version": {
@@ -244,7 +261,10 @@
           },
           "format": {
             "type": "string",
-            "enum": ["json", "xml"]
+            "enum": [
+              "json",
+              "xml"
+            ]
           },
           "token": {
             "type": "string",

--- a/apis/openapi/cyberark.com/cyberark/1.0.0/openapi.json
+++ b/apis/openapi/cyberark.com/cyberark/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "CyberArk Conjur API",
     "version": "1.0.0",
     "description": "CyberArk Conjur secrets management REST API for privileged access security",
-    "x-jentic-source-url": "https://docs.cyberark.com/conjur-open-source/latest/en/content/developer/lp_rest_api.htm"
+    "x-jentic-source-url": "https://docs.cyberark.com/conjur-open-source/latest/en/content/developer/lp_rest_api.htm",
+    "contact": {}
   },
   "servers": [
     {
@@ -240,5 +241,16 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Policies"
+    },
+    {
+      "name": "Roles"
+    },
+    {
+      "name": "Secrets"
+    }
+  ]
 }

--- a/apis/openapi/cyberimpact.com/cyberimpact-api/3.0.0/openapi.json
+++ b/apis/openapi/cyberimpact.com/cyberimpact-api/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cyberimpact API",
     "version": "3.0.0",
     "description": "Cyberimpact is an email marketing platform. The API allows managing groups, contacts, mailings, and templates programmatically.",
-    "x-jentic-source-url": "https://www.cyberimpact.com/en/developers/api-documentation"
+    "x-jentic-source-url": "https://www.cyberimpact.com/en/developers/api-documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,7 +19,9 @@
         "operationId": "listGroups",
         "summary": "List all groups",
         "description": "Retrieve a list of all contact groups in your account.",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -91,7 +94,9 @@
         "operationId": "createGroup",
         "summary": "Create a new group",
         "description": "Create a new contact group.",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -146,7 +151,9 @@
         "operationId": "getGroup",
         "summary": "Get a group",
         "description": "Retrieve details of a specific group.",
-        "tags": ["Groups"],
+        "tags": [
+          "Groups"
+        ],
         "parameters": [
           {
             "name": "groupId",
@@ -211,7 +218,9 @@
         "operationId": "listContacts",
         "summary": "List all contacts",
         "description": "Retrieve a list of all contacts.",
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -291,7 +300,9 @@
         "operationId": "createContact",
         "summary": "Create or update a contact",
         "description": "Add a new contact or update an existing one.",
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -346,7 +357,9 @@
         "operationId": "getContact",
         "summary": "Get a contact",
         "description": "Retrieve details of a specific contact.",
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "parameters": [
           {
             "name": "contactId",
@@ -409,7 +422,9 @@
         "operationId": "deleteContact",
         "summary": "Delete a contact",
         "description": "Remove a contact from your account.",
-        "tags": ["Contacts"],
+        "tags": [
+          "Contacts"
+        ],
         "parameters": [
           {
             "name": "contactId",
@@ -467,7 +482,9 @@
         "operationId": "listMailings",
         "summary": "List mailings",
         "description": "Retrieve a list of mailings.",
-        "tags": ["Mailings"],
+        "tags": [
+          "Mailings"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -540,7 +557,9 @@
         "operationId": "listTemplates",
         "summary": "List email templates",
         "description": "Retrieve a list of available email templates.",
-        "tags": ["Templates"],
+        "tags": [
+          "Templates"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -601,10 +620,22 @@
     }
   },
   "tags": [
-    {"name": "Groups", "description": "Manage contact groups"},
-    {"name": "Contacts", "description": "Manage contacts"},
-    {"name": "Mailings", "description": "Manage email mailings"},
-    {"name": "Templates", "description": "Manage email templates"}
+    {
+      "name": "Groups",
+      "description": "Manage contact groups"
+    },
+    {
+      "name": "Contacts",
+      "description": "Manage contacts"
+    },
+    {
+      "name": "Mailings",
+      "description": "Manage email mailings"
+    },
+    {
+      "name": "Templates",
+      "description": "Manage email templates"
+    }
   ],
   "components": {
     "securitySchemes": {
@@ -618,33 +649,84 @@
       "Group": {
         "type": "object",
         "properties": {
-          "id": {"type": "string", "description": "Group ID"},
-          "title": {"type": "string", "description": "Group title"},
-          "is_default": {"type": "boolean", "description": "Whether this is the default group"},
-          "contacts_count": {"type": "integer", "description": "Number of contacts in the group"},
-          "created_at": {"type": "string", "format": "date-time"},
-          "updated_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string",
+            "description": "Group ID"
+          },
+          "title": {
+            "type": "string",
+            "description": "Group title"
+          },
+          "is_default": {
+            "type": "boolean",
+            "description": "Whether this is the default group"
+          },
+          "contacts_count": {
+            "type": "integer",
+            "description": "Number of contacts in the group"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "GroupCreateRequest": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
-          "title": {"type": "string", "description": "Group title"}
+          "title": {
+            "type": "string",
+            "description": "Group title"
+          }
         }
       },
       "Contact": {
         "type": "object",
         "properties": {
-          "id": {"type": "string", "description": "Contact ID"},
-          "email": {"type": "string", "format": "email", "description": "Email address"},
-          "first_name": {"type": "string", "description": "First name"},
-          "last_name": {"type": "string", "description": "Last name"},
-          "company": {"type": "string", "description": "Company name"},
-          "language": {"type": "string", "description": "Language preference"},
-          "status": {"type": "string", "description": "Contact status"},
-          "created_at": {"type": "string", "format": "date-time"},
-          "updated_at": {"type": "string", "format": "date-time"},
+          "id": {
+            "type": "string",
+            "description": "Contact ID"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Email address"
+          },
+          "first_name": {
+            "type": "string",
+            "description": "First name"
+          },
+          "last_name": {
+            "type": "string",
+            "description": "Last name"
+          },
+          "company": {
+            "type": "string",
+            "description": "Company name"
+          },
+          "language": {
+            "type": "string",
+            "description": "Language preference"
+          },
+          "status": {
+            "type": "string",
+            "description": "Contact status"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time"
+          },
           "groups": {
             "type": "array",
             "items": {
@@ -655,16 +737,31 @@
       },
       "ContactCreateRequest": {
         "type": "object",
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "properties": {
-          "email": {"type": "string", "format": "email"},
-          "first_name": {"type": "string"},
-          "last_name": {"type": "string"},
-          "company": {"type": "string"},
-          "language": {"type": "string"},
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "company": {
+            "type": "string"
+          },
+          "language": {
+            "type": "string"
+          },
           "groups": {
             "type": "array",
-            "items": {"type": "string"},
+            "items": {
+              "type": "string"
+            },
             "description": "Group IDs to add contact to"
           }
         }
@@ -672,29 +769,63 @@
       "Mailing": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "subject": {"type": "string", "description": "Email subject"},
-          "status": {"type": "string", "description": "Mailing status"},
-          "sent_at": {"type": "string", "format": "date-time", "nullable": true},
-          "created_at": {"type": "string", "format": "date-time"},
-          "opens_count": {"type": "integer"},
-          "clicks_count": {"type": "integer"},
-          "recipients_count": {"type": "integer"}
+          "id": {
+            "type": "string"
+          },
+          "subject": {
+            "type": "string",
+            "description": "Email subject"
+          },
+          "status": {
+            "type": "string",
+            "description": "Mailing status"
+          },
+          "sent_at": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "opens_count": {
+            "type": "integer"
+          },
+          "clicks_count": {
+            "type": "integer"
+          },
+          "recipients_count": {
+            "type": "integer"
+          }
         }
       },
       "Template": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "created_at": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "message": {"type": "string", "description": "Error message"},
-          "status_code": {"type": "integer", "description": "HTTP status code"}
+          "message": {
+            "type": "string",
+            "description": "Error message"
+          },
+          "status_code": {
+            "type": "integer",
+            "description": "HTTP status code"
+          }
         }
       }
     }

--- a/apis/openapi/cybertaxonomy.eu/eu-bon-utis/1.0/openapi.json
+++ b/apis/openapi/cybertaxonomy.eu/eu-bon-utis/1.0/openapi.json
@@ -300,8 +300,7 @@
           "type": "array"
         },
         "taxon": {
-          "$ref": "#/definitions/Taxon",
-          "description": "The accepted taxon"
+          "$ref": "#/definitions/Taxon"
         },
         "vernacularNames": {
           "description": "A common or vernacular name.",

--- a/apis/openapi/cyfe.com/cyfe-push-api/1.0.0/openapi.json
+++ b/apis/openapi/cyfe.com/cyfe-push-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Cyfe Push API",
     "version": "1.0.0",
     "description": "Cyfe Push API for pushing data into dashboard widgets from external applications.",
-    "x-jentic-source-url": "https://www.cyfe.com/api"
+    "x-jentic-source-url": "https://www.cyfe.com/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -64,7 +65,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Push data to a dashboard widget"
       }
     }
   },
@@ -117,5 +119,10 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Push Data"
+    }
+  ]
 }

--- a/apis/openapi/dacast.com/dacast-api/2.0.0/openapi.json
+++ b/apis/openapi/dacast.com/dacast-api/2.0.0/openapi.json
@@ -580,6 +580,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/dacast.com/dacast-api/2.0.0/openapi.json
+++ b/apis/openapi/dacast.com/dacast-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dacast API",
     "version": "2.0.0",
     "description": "Dacast video streaming platform API for managing live streams, video on demand (VOD) content, channels, and playlists.",
-    "x-jentic-source-url": "https://www.dacast.com/video-api-documentation/"
+    "x-jentic-source-url": "https://www.dacast.com/video-api-documentation/",
+    "contact": {}
   },
   "servers": [
     {
@@ -75,7 +76,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List VOD content"
       },
       "post": {
         "operationId": "createVod",
@@ -103,7 +105,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create VOD content"
       }
     },
     "/vod/{contentId}": {
@@ -140,7 +143,8 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "description": "Get VOD content details"
       },
       "put": {
         "operationId": "updateVod",
@@ -178,7 +182,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update VOD content"
       },
       "delete": {
         "operationId": "deleteVod",
@@ -206,7 +211,8 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "description": "Delete VOD content"
       }
     },
     "/live": {
@@ -239,7 +245,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List live streams"
       },
       "post": {
         "operationId": "createLiveStream",
@@ -267,7 +274,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create live stream"
       }
     },
     "/live/{contentId}": {
@@ -297,7 +305,8 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "description": "Get live stream details"
       },
       "put": {
         "operationId": "updateLiveStream",
@@ -335,7 +344,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update live stream"
       },
       "delete": {
         "operationId": "deleteLiveStream",
@@ -360,7 +370,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete live stream"
       }
     },
     "/channel": {
@@ -386,7 +397,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List channels"
       },
       "post": {
         "operationId": "createChannel",
@@ -414,7 +426,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create channel"
       }
     },
     "/channel/{contentId}": {
@@ -444,7 +457,8 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "description": "Get channel details"
       },
       "delete": {
         "operationId": "deleteChannel",
@@ -469,19 +483,12 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete channel"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Api-Key",
-        "description": "Dacast API key from account settings"
-      }
-    },
     "schemas": {
       "VodItem": {
         "type": "object",
@@ -569,17 +576,6 @@
             "type": "string"
           },
           "description": {
-            "type": "string"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
             "type": "string"
           }
         }

--- a/apis/openapi/dagpi.xyz/dagpi/1.0.0/openapi.json
+++ b/apis/openapi/dagpi.xyz/dagpi/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dagpi API",
     "description": "A powerful and fast API for image manipulation, filters, effects, meme generation, and serving datasets. Provides endpoints for processing images with various effects and retrieving fun data like jokes, facts, and pickup lines.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://dagpi.xyz"
+    "x-jentic-source-url": "https://dagpi.xyz",
+    "contact": {}
   },
   "servers": [
     {
@@ -44,12 +45,14 @@
     }
   ],
   "paths": {
-    "/image/pixel/": {
+    "/image/pixel": {
       "get": {
         "operationId": "pixelImage",
         "summary": "Pixelate an image",
         "description": "Apply a pixelation effect to the provided image.",
-        "tags": ["Image Manipulation"],
+        "tags": [
+          "Image Manipulation"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -82,12 +85,14 @@
         }
       }
     },
-    "/image/mirror/": {
+    "/image/mirror": {
       "get": {
         "operationId": "mirrorImage",
         "summary": "Mirror an image",
         "description": "Horizontally mirror/flip the provided image.",
-        "tags": ["Image Manipulation"],
+        "tags": [
+          "Image Manipulation"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -106,12 +111,14 @@
         }
       }
     },
-    "/image/flip/": {
+    "/image/flip": {
       "get": {
         "operationId": "flipImage",
         "summary": "Flip an image",
         "description": "Vertically flip the provided image.",
-        "tags": ["Image Manipulation"],
+        "tags": [
+          "Image Manipulation"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -130,12 +137,14 @@
         }
       }
     },
-    "/image/colors/": {
+    "/image/colors": {
       "get": {
         "operationId": "imageColors",
         "summary": "Extract colors from an image",
         "description": "Get the dominant colors from the provided image.",
-        "tags": ["Image Manipulation"],
+        "tags": [
+          "Image Manipulation"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -161,12 +170,14 @@
         }
       }
     },
-    "/image/invert/": {
+    "/image/invert": {
       "get": {
         "operationId": "invertImage",
         "summary": "Invert image colors",
         "description": "Invert the colors of the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -185,12 +196,14 @@
         }
       }
     },
-    "/image/sobel/": {
+    "/image/sobel": {
       "get": {
         "operationId": "sobelImage",
         "summary": "Apply Sobel edge detection",
         "description": "Apply Sobel edge detection filter to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -209,12 +222,14 @@
         }
       }
     },
-    "/image/blur/": {
+    "/image/blur": {
       "get": {
         "operationId": "blurImage",
         "summary": "Blur an image",
         "description": "Apply a blur effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -233,12 +248,14 @@
         }
       }
     },
-    "/image/rgb/": {
+    "/image/rgb": {
       "get": {
         "operationId": "rgbImage",
         "summary": "RGB channel manipulation",
         "description": "Manipulate the RGB channels of the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -257,12 +274,14 @@
         }
       }
     },
-    "/image/deepfry/": {
+    "/image/deepfry": {
       "get": {
         "operationId": "deepfryImage",
         "summary": "Deep fry an image",
         "description": "Apply a deep fry effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -281,12 +300,14 @@
         }
       }
     },
-    "/image/ascii/": {
+    "/image/ascii": {
       "get": {
         "operationId": "asciiImage",
         "summary": "Convert image to ASCII art",
         "description": "Convert the provided image to ASCII art representation.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -305,12 +326,14 @@
         }
       }
     },
-    "/image/charcoal/": {
+    "/image/charcoal": {
       "get": {
         "operationId": "charcoalImage",
         "summary": "Apply charcoal effect",
         "description": "Apply a charcoal drawing effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -329,12 +352,14 @@
         }
       }
     },
-    "/image/poster/": {
+    "/image/poster": {
       "get": {
         "operationId": "posterImage",
         "summary": "Apply posterize effect",
         "description": "Apply a posterize effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -353,12 +378,14 @@
         }
       }
     },
-    "/image/sepia/": {
+    "/image/sepia": {
       "get": {
         "operationId": "sepiaImage",
         "summary": "Apply sepia tone",
         "description": "Apply a sepia tone filter to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -377,12 +404,14 @@
         }
       }
     },
-    "/image/polaroid/": {
+    "/image/polaroid": {
       "get": {
         "operationId": "polaroidImage",
         "summary": "Apply polaroid frame",
         "description": "Apply a polaroid frame effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -401,12 +430,14 @@
         }
       }
     },
-    "/image/paint/": {
+    "/image/paint": {
       "get": {
         "operationId": "paintImage",
         "summary": "Apply oil paint effect",
         "description": "Apply an oil paint artistic effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -425,12 +456,14 @@
         }
       }
     },
-    "/image/sketch/": {
+    "/image/sketch": {
       "get": {
         "operationId": "sketchImage",
         "summary": "Convert to pencil sketch",
         "description": "Convert the provided image to a pencil sketch style.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -449,12 +482,14 @@
         }
       }
     },
-    "/image/neon/": {
+    "/image/neon": {
       "get": {
         "operationId": "neonImage",
         "summary": "Apply neon glow effect",
         "description": "Apply a neon glow effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -473,12 +508,14 @@
         }
       }
     },
-    "/image/solar/": {
+    "/image/solar": {
       "get": {
         "operationId": "solarImage",
         "summary": "Apply solarize effect",
         "description": "Apply a solarize effect to the provided image.",
-        "tags": ["Image Filters"],
+        "tags": [
+          "Image Filters"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -497,12 +534,14 @@
         }
       }
     },
-    "/image/wanted/": {
+    "/image/wanted": {
       "get": {
         "operationId": "wantedImage",
         "summary": "Create wanted poster",
         "description": "Place the provided image into a wanted poster template.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -521,12 +560,14 @@
         }
       }
     },
-    "/image/triggered/": {
+    "/image/triggered": {
       "get": {
         "operationId": "triggeredImage",
         "summary": "Create triggered GIF",
         "description": "Generate a triggered meme GIF from the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -553,12 +594,14 @@
         }
       }
     },
-    "/image/wasted/": {
+    "/image/wasted": {
       "get": {
         "operationId": "wastedImage",
         "summary": "Apply GTA wasted overlay",
         "description": "Apply a GTA-style wasted overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -577,12 +620,14 @@
         }
       }
     },
-    "/image/jail/": {
+    "/image/jail": {
       "get": {
         "operationId": "jailImage",
         "summary": "Apply jail bars overlay",
         "description": "Apply prison/jail bars overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -601,12 +646,14 @@
         }
       }
     },
-    "/image/delete/": {
+    "/image/delete": {
       "get": {
         "operationId": "deleteImage",
         "summary": "Create delete button meme",
         "description": "Generate a delete button meme with the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -625,12 +672,14 @@
         }
       }
     },
-    "/image/trash/": {
+    "/image/trash": {
       "get": {
         "operationId": "trashImage",
         "summary": "Create trash meme",
         "description": "Generate a trash meme with the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -649,12 +698,14 @@
         }
       }
     },
-    "/image/fedora/": {
+    "/image/fedora": {
       "get": {
         "operationId": "fedoraImage",
         "summary": "Add fedora hat overlay",
         "description": "Add a fedora hat overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -673,12 +724,14 @@
         }
       }
     },
-    "/image/shatter/": {
+    "/image/shatter": {
       "get": {
         "operationId": "shatterImage",
         "summary": "Apply shattered glass effect",
         "description": "Apply a shattered/broken glass effect to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -697,12 +750,14 @@
         }
       }
     },
-    "/image/bonk/": {
+    "/image/bonk": {
       "get": {
         "operationId": "bonkImage",
         "summary": "Create bonk meme",
         "description": "Generate a bonk meme with the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -721,12 +776,14 @@
         }
       }
     },
-    "/image/bomb/": {
+    "/image/bomb": {
       "get": {
         "operationId": "bombImage",
         "summary": "Apply bomb/explosion overlay",
         "description": "Apply a bomb explosion overlay effect to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -745,12 +802,14 @@
         }
       }
     },
-    "/image/angel/": {
+    "/image/angel": {
       "get": {
         "operationId": "angelImage",
         "summary": "Apply angel overlay",
         "description": "Apply an angel halo overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -769,12 +828,14 @@
         }
       }
     },
-    "/image/america/": {
+    "/image/america": {
       "get": {
         "operationId": "americaImage",
         "summary": "Apply American flag overlay",
         "description": "Apply a waving American flag overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -793,12 +854,14 @@
         }
       }
     },
-    "/image/communism/": {
+    "/image/communism": {
       "get": {
         "operationId": "communismImage",
         "summary": "Apply communist flag overlay",
         "description": "Apply a communist flag overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -817,12 +880,14 @@
         }
       }
     },
-    "/image/gay/": {
+    "/image/gay": {
       "get": {
         "operationId": "gayImage",
         "summary": "Apply rainbow pride overlay",
         "description": "Apply a rainbow pride flag overlay to the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -841,12 +906,14 @@
         }
       }
     },
-    "/image/glitch/": {
+    "/image/glitch": {
       "get": {
         "operationId": "glitchImage",
         "summary": "Apply animated glitch effect",
         "description": "Apply an animated glitch distortion effect to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -873,12 +940,14 @@
         }
       }
     },
-    "/image/swirl/": {
+    "/image/swirl": {
       "get": {
         "operationId": "swirlImage",
         "summary": "Apply swirl distortion",
         "description": "Apply a swirl distortion effect to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -897,12 +966,14 @@
         }
       }
     },
-    "/image/spin/": {
+    "/image/spin": {
       "get": {
         "operationId": "spinImage",
         "summary": "Create spinning GIF",
         "description": "Create a spinning animated GIF from the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -929,12 +1000,14 @@
         }
       }
     },
-    "/image/dissolve/": {
+    "/image/dissolve": {
       "get": {
         "operationId": "dissolveImage",
         "summary": "Apply dissolve effect",
         "description": "Apply a dissolve transition effect to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -953,12 +1026,14 @@
         }
       }
     },
-    "/image/rain/": {
+    "/image/rain": {
       "get": {
         "operationId": "rainImage",
         "summary": "Apply rain overlay",
         "description": "Apply a rain animation overlay to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -977,12 +1052,14 @@
         }
       }
     },
-    "/image/magik/": {
+    "/image/magik": {
       "get": {
         "operationId": "magikImage",
         "summary": "Apply content-aware scale (magik)",
         "description": "Apply a content-aware scale distortion effect to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1001,12 +1078,14 @@
         }
       }
     },
-    "/image/cube/": {
+    "/image/cube": {
       "get": {
         "operationId": "cubeImage",
         "summary": "Map image onto 3D cube",
         "description": "Map the provided image onto a 3D cube.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1025,12 +1104,14 @@
         }
       }
     },
-    "/image/lego/": {
+    "/image/lego": {
       "get": {
         "operationId": "legoImage",
         "summary": "Convert to LEGO mosaic",
         "description": "Convert the provided image into a LEGO brick mosaic.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1049,12 +1130,14 @@
         }
       }
     },
-    "/image/expand/": {
+    "/image/expand": {
       "get": {
         "operationId": "expandImage",
         "summary": "Expand/stretch image",
         "description": "Apply an expanding/stretching animation effect to the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1073,12 +1156,14 @@
         }
       }
     },
-    "/image/mosaic/": {
+    "/image/mosaic": {
       "get": {
         "operationId": "mosaicImage",
         "summary": "Create photo mosaic",
         "description": "Create a photo mosaic from the provided image.",
-        "tags": ["Image Effects"],
+        "tags": [
+          "Image Effects"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1097,12 +1182,14 @@
         }
       }
     },
-    "/image/tweet/": {
+    "/image/tweet": {
       "get": {
         "operationId": "tweetImage",
         "summary": "Generate fake tweet image",
         "description": "Generate a fake tweet image with customizable text and username.",
-        "tags": ["Image Social"],
+        "tags": [
+          "Image Social"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1139,12 +1226,14 @@
         }
       }
     },
-    "/image/discord/": {
+    "/image/discord": {
       "get": {
         "operationId": "discordImage",
         "summary": "Generate fake Discord message",
         "description": "Generate a fake Discord message image with customizable text and username.",
-        "tags": ["Image Social"],
+        "tags": [
+          "Image Social"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1181,12 +1270,14 @@
         }
       }
     },
-    "/image/youtube/": {
+    "/image/youtube": {
       "get": {
         "operationId": "youtubeImage",
         "summary": "Generate fake YouTube comment",
         "description": "Generate a fake YouTube comment image with customizable text and username.",
-        "tags": ["Image Social"],
+        "tags": [
+          "Image Social"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1223,12 +1314,14 @@
         }
       }
     },
-    "/image/captcha/": {
+    "/image/captcha": {
       "get": {
         "operationId": "captchaImage",
         "summary": "Generate captcha-style image",
         "description": "Generate a captcha-style image selection meme with the provided image.",
-        "tags": ["Image Social"],
+        "tags": [
+          "Image Social"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1256,12 +1349,14 @@
         }
       }
     },
-    "/image/retromeme/": {
+    "/image/retromeme": {
       "get": {
         "operationId": "retroMemeImage",
         "summary": "Generate retro-style meme",
         "description": "Generate a retro-style meme with top and bottom text.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1298,12 +1393,14 @@
         }
       }
     },
-    "/image/modernmeme/": {
+    "/image/modernmeme": {
       "get": {
         "operationId": "modernMemeImage",
         "summary": "Generate modern-style meme",
         "description": "Generate a modern-style meme with text above the image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1331,12 +1428,14 @@
         }
       }
     },
-    "/image/motiv/": {
+    "/image/motiv": {
       "get": {
         "operationId": "motivImage",
         "summary": "Generate motivational poster",
         "description": "Generate a motivational poster meme with the provided image and text.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1373,12 +1472,14 @@
         }
       }
     },
-    "/image/slap/": {
+    "/image/slap": {
       "get": {
         "operationId": "slapImage",
         "summary": "Create slap meme with two images",
         "description": "Generate a slap meme using the provided image URL and a second image URL.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1407,12 +1508,14 @@
         }
       }
     },
-    "/image/thought/": {
+    "/image/thought": {
       "get": {
         "operationId": "thoughtImage",
         "summary": "Create thought image meme",
         "description": "Generate an image showing a person thinking of the provided image.",
-        "tags": ["Image Memes"],
+        "tags": [
+          "Image Memes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/ImageUrl"
@@ -1441,12 +1544,14 @@
         }
       }
     },
-    "/data/wtp/": {
+    "/data/wtp": {
       "get": {
         "operationId": "whosThatPokemon",
         "summary": "Who's That Pokemon",
         "description": "Get a random Who's That Pokemon challenge with question and answer.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Pokemon data returned",
@@ -1467,12 +1572,14 @@
         }
       }
     },
-    "/data/roast/": {
+    "/data/roast": {
       "get": {
         "operationId": "getRoast",
         "summary": "Get a random roast",
         "description": "Get a random roast/insult text.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Roast text returned",
@@ -1493,12 +1600,14 @@
         }
       }
     },
-    "/data/yomama/": {
+    "/data/yomama": {
       "get": {
         "operationId": "getYoMama",
         "summary": "Get a Yo Mama joke",
         "description": "Get a random Yo Mama joke.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Joke text returned",
@@ -1519,12 +1628,14 @@
         }
       }
     },
-    "/data/joke/": {
+    "/data/joke": {
       "get": {
         "operationId": "getJoke",
         "summary": "Get a random joke",
         "description": "Get a random joke.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Joke returned",
@@ -1545,12 +1656,14 @@
         }
       }
     },
-    "/data/fact/": {
+    "/data/fact": {
       "get": {
         "operationId": "getFact",
         "summary": "Get a random fact",
         "description": "Get a random interesting fact.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Fact returned",
@@ -1571,12 +1684,14 @@
         }
       }
     },
-    "/data/8ball/": {
+    "/data/8ball": {
       "get": {
         "operationId": "getEightBall",
         "summary": "Get Magic 8-Ball response",
         "description": "Get a random Magic 8-Ball style response.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "8-ball response returned",
@@ -1597,12 +1712,14 @@
         }
       }
     },
-    "/data/pickupline/": {
+    "/data/pickupline": {
       "get": {
         "operationId": "getPickupLine",
         "summary": "Get a random pickup line",
         "description": "Get a random pickup line.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Pickup line returned",
@@ -1623,12 +1740,14 @@
         }
       }
     },
-    "/data/headline/": {
+    "/data/headline": {
       "get": {
         "operationId": "getHeadline",
         "summary": "Get a random headline",
         "description": "Get a random news headline. Can be real or fake.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Headline data returned",
@@ -1649,12 +1768,14 @@
         }
       }
     },
-    "/data/logo/": {
+    "/data/logo": {
       "get": {
         "operationId": "getLogo",
         "summary": "Get a random logo",
         "description": "Get a random company/brand logo for guessing games.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Logo data returned",
@@ -1675,12 +1796,14 @@
         }
       }
     },
-    "/data/waifu/": {
+    "/data/waifu": {
       "get": {
         "operationId": "getWaifu",
         "summary": "Get random waifu data",
         "description": "Get random anime waifu character data.",
-        "tags": ["Data"],
+        "tags": [
+          "Data"
+        ],
         "responses": {
           "200": {
             "description": "Waifu data returned",
@@ -1736,7 +1859,10 @@
             "description": "HTTP status code."
           }
         },
-        "required": ["message", "status"]
+        "required": [
+          "message",
+          "status"
+        ]
       },
       "ColorsResponse": {
         "type": "object",

--- a/apis/openapi/daktela.com/daktela-api/6.0.0/openapi.json
+++ b/apis/openapi/daktela.com/daktela-api/6.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Daktela API",
     "version": "6.0.0",
     "description": "Daktela REST API v6 provides access to call center and communication platform functionality. All API operations use the built-in ACL engine, meaning every API call requires an access token. The API supports CRUD operations on activities, contacts, tickets, users, and other resources.",
-    "x-jentic-source-url": "https://customer.daktela.com/apihelp/v6/global/general-information"
+    "x-jentic-source-url": "https://customer.daktela.com/apihelp/v6/global/general-information",
+    "contact": {}
   },
   "servers": [
     {
@@ -23,17 +24,28 @@
         "operationId": "login",
         "summary": "Login and get access token",
         "description": "Authenticates with username and password to obtain an access token.",
-        "tags": ["Authentication"],
+        "tags": [
+          "Authentication"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user", "password"],
+                "required": [
+                  "user",
+                  "password"
+                ],
                 "properties": {
-                  "user": { "type": "string", "description": "Username" },
-                  "password": { "type": "string", "description": "Password" }
+                  "user": {
+                    "type": "string",
+                    "description": "Username"
+                  },
+                  "password": {
+                    "type": "string",
+                    "description": "Password"
+                  }
                 }
               }
             }
@@ -47,15 +59,37 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "result": { "type": "object" },
-                    "error": { "type": "object" }
+                    "result": {
+                      "type": "object"
+                    },
+                    "error": {
+                      "type": "object"
+                    }
                   }
                 }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -64,15 +98,58 @@
         "operationId": "listActivities",
         "summary": "List activities",
         "description": "Returns a list of all activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -81,15 +158,58 @@
         "operationId": "listCallActivities",
         "summary": "List call activities",
         "description": "Returns a list of call activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -98,15 +218,58 @@
         "operationId": "listEmailActivities",
         "summary": "List email activities",
         "description": "Returns a list of email activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -115,15 +278,58 @@
         "operationId": "listSmsActivities",
         "summary": "List SMS activities",
         "description": "Returns a list of SMS activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -132,15 +338,58 @@
         "operationId": "listFacebookMessengerActivities",
         "summary": "List Facebook Messenger activities",
         "description": "Returns a list of Facebook Messenger activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -149,15 +398,58 @@
         "operationId": "listInstagramDmActivities",
         "summary": "List Instagram DM activities",
         "description": "Returns a list of Instagram direct message activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -166,15 +458,58 @@
         "operationId": "listViberActivities",
         "summary": "List Viber activities",
         "description": "Returns a list of Viber activities.",
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "parameters": [
-          { "name": "skip", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to skip" },
-          { "name": "take", "in": "query", "schema": { "type": "integer" }, "description": "Number of records to return" }
+          {
+            "name": "skip",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to skip"
+          },
+          {
+            "name": "take",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of records to return"
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ActivityListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActivityListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -184,13 +519,34 @@
       "Activity": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "description": "Activity identifier" },
-          "title": { "type": "string", "description": "Activity title" },
-          "type": { "type": "string", "description": "Activity type" },
-          "direction": { "type": "string", "description": "Direction of the activity (inbound/outbound)" },
-          "status": { "type": "string", "description": "Activity status" },
-          "created": { "type": "string", "format": "date-time" },
-          "edited": { "type": "string", "format": "date-time" }
+          "name": {
+            "type": "string",
+            "description": "Activity identifier"
+          },
+          "title": {
+            "type": "string",
+            "description": "Activity title"
+          },
+          "type": {
+            "type": "string",
+            "description": "Activity type"
+          },
+          "direction": {
+            "type": "string",
+            "description": "Direction of the activity (inbound/outbound)"
+          },
+          "status": {
+            "type": "string",
+            "description": "Activity status"
+          },
+          "created": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "edited": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "ActivityListResponse": {
@@ -201,23 +557,35 @@
             "properties": {
               "data": {
                 "type": "array",
-                "items": { "$ref": "#/components/schemas/Activity" }
+                "items": {
+                  "$ref": "#/components/schemas/Activity"
+                }
               },
-              "total": { "type": "integer" }
+              "total": {
+                "type": "integer"
+              }
             }
           },
-          "error": { "type": "object" }
+          "error": {
+            "type": "object"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "result": { "type": "object" },
+          "result": {
+            "type": "object"
+          },
           "error": {
             "type": "object",
             "properties": {
-              "code": { "type": "integer" },
-              "message": { "type": "string" }
+              "code": {
+                "type": "integer"
+              },
+              "message": {
+                "type": "string"
+              }
             }
           }
         }
@@ -239,6 +607,16 @@
     }
   },
   "security": [
-    { "apiKeyHeader": [] }
+    {
+      "apiKeyHeader": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Activities"
+    },
+    {
+      "name": "Authentication"
+    }
   ]
 }

--- a/apis/openapi/dana.id/dashboarddana/1.0.0/openapi.json
+++ b/apis/openapi/dana.id/dashboarddana/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "DANA API",
     "version": "1.0.0",
     "description": "DANA digital wallet API for payments, disbursements and billers in Indonesia",
-    "x-jentic-source-url": "https://dashboard.dana.id/api-docs-v2/"
+    "x-jentic-source-url": "https://dashboard.dana.id/api-docs-v2/",
+    "contact": {}
   },
   "servers": [
     {
@@ -188,5 +189,16 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Billers"
+    },
+    {
+      "name": "Disbursements"
+    },
+    {
+      "name": "Payments"
+    }
+  ]
 }

--- a/apis/openapi/dandelion.events/dandelion-events-api/1.0.0/openapi.json
+++ b/apis/openapi/dandelion.events/dandelion-events-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dandelion Events API",
     "version": "1.0.0",
     "description": "API for accessing events, followers, and ticket orders from the Dandelion events platform.",
-    "x-jentic-source-url": "https://dandelion.events/docs/zapier"
+    "x-jentic-source-url": "https://dandelion.events/docs/zapier",
+    "contact": {}
   },
   "servers": [
     {
@@ -346,6 +347,20 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Followers"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "User"
     }
   ]
 }

--- a/apis/openapi/dante-ai.com/dante-ai-api/1.0.0/openapi.json
+++ b/apis/openapi/dante-ai.com/dante-ai-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dante AI API",
     "version": "1.0.0",
     "description": "AI chatbot and knowledge base management API for creating, querying, and managing conversational AI agents powered by custom knowledge bases.",
-    "x-jentic-source-url": "https://api.dante-ai.com/docs"
+    "x-jentic-source-url": "https://api.dante-ai.com/docs",
+    "contact": {}
   },
   "servers": [
     {
@@ -43,7 +44,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Status check"
       }
     },
     "/knowledge-bases": {
@@ -77,7 +79,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List knowledge bases"
       }
     },
     "/knowledge-bases/files": {
@@ -111,7 +114,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create KB from file"
       }
     },
     "/knowledge-bases/all": {
@@ -145,7 +149,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create KB from files and URLs"
       }
     },
     "/knowledge-bases/url": {
@@ -179,7 +184,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create KB from URLs"
       }
     },
     "/knowledge-bases/dashboard": {
@@ -213,7 +219,8 @@
               }
             }
           }
-        }
+        },
+        "description": "KB dashboard"
       }
     },
     "/knowledge-bases/{kb_id}": {
@@ -257,7 +264,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get KB details"
       },
       "delete": {
         "operationId": "deleteKnowledgeBase",
@@ -299,7 +307,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete KB"
       },
       "patch": {
         "operationId": "updateKnowledgeBase",
@@ -341,7 +350,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update KB"
       }
     },
     "/knowledge-bases/{kb_id}/search": {
@@ -385,7 +395,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search KB"
       }
     },
     "/knowledge-bases/{kb_id}/share": {
@@ -429,7 +440,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Generate sharing token"
       }
     },
     "/knowledge-bases/{kb_id}/files": {
@@ -473,7 +485,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add files to KB"
       },
       "delete": {
         "operationId": "deleteKBFiles",
@@ -515,7 +528,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete files from KB"
       }
     },
     "/knowledge-bases/{kb_id}/urls": {
@@ -559,7 +573,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add URLs to KB"
       }
     },
     "/model/query": {
@@ -593,7 +608,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Direct query (non-streaming)"
       }
     },
     "/model/query-stream": {
@@ -627,7 +643,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Streaming query"
       }
     },
     "/model/query-shared-stream": {
@@ -661,7 +678,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Shared KB streaming query"
       }
     },
     "/model/llms": {
@@ -695,7 +713,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List available LLMs"
       }
     },
     "/model/create_index": {
@@ -729,7 +748,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create indexes"
       }
     },
     "/conversations": {
@@ -763,7 +783,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List conversations"
       },
       "post": {
         "operationId": "createConversation",
@@ -795,7 +816,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create conversation"
       }
     },
     "/conversations/search": {
@@ -829,7 +851,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search conversations"
       }
     },
     "/conversations/{conversation_id}": {
@@ -873,7 +896,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get conversation"
       },
       "delete": {
         "operationId": "deleteConversation",
@@ -915,7 +939,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete conversation"
       },
       "patch": {
         "operationId": "updateConversation",
@@ -957,7 +982,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update conversation"
       }
     },
     "/conversations/shared/{kb_id}": {
@@ -1001,7 +1027,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List KB conversations"
       }
     },
     "/conversations/shared/{kb_id}/export": {
@@ -1045,7 +1072,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Export conversations"
       }
     },
     "/messages": {
@@ -1079,7 +1107,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List messages"
       }
     },
     "/messages/{message_id}": {
@@ -1123,7 +1152,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get message"
       },
       "delete": {
         "operationId": "deleteMessage",
@@ -1165,7 +1195,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete message"
       }
     },
     "/personalities": {
@@ -1199,7 +1230,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List personalities"
       }
     },
     "/personalities/init": {
@@ -1233,7 +1265,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Initialize personalities"
       }
     },
     "/personalities/{personality_id}/customize": {
@@ -1277,7 +1310,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Customize personality"
       }
     },
     "/tts/play": {
@@ -1311,7 +1345,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Log TTS playback"
       }
     },
     "/tts/token": {
@@ -1345,7 +1380,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get TTS authorization"
       }
     }
   },
@@ -1379,6 +1415,29 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Conversations"
+    },
+    {
+      "name": "Health"
+    },
+    {
+      "name": "Knowledge Bases"
+    },
+    {
+      "name": "Messages"
+    },
+    {
+      "name": "Models"
+    },
+    {
+      "name": "Personalities"
+    },
+    {
+      "name": "Text-to-Speech"
     }
   ]
 }

--- a/apis/openapi/dat.com/dat-freight-api/1.0.0/openapi.json
+++ b/apis/openapi/dat.com/dat-freight-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "DAT Freight API",
     "version": "1.0.0",
     "description": "DAT Freight & Analytics API for load board, rate lookup, freight posting, carrier qualification, and shipment tracking.",
-    "x-jentic-source-url": "https://www.dat.com/api-integration"
+    "x-jentic-source-url": "https://www.dat.com/api-integration",
+    "contact": {}
   },
   "servers": [
     {
@@ -148,7 +149,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Rate History"
       }
     },
     "/loads": {
@@ -199,7 +201,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Post Load"
       },
       "get": {
         "operationId": "searchLoads",
@@ -268,7 +271,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search Loads"
       }
     },
     "/loads/{loadId}": {
@@ -319,7 +323,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Load"
       },
       "delete": {
         "operationId": "deleteLoad",
@@ -361,7 +366,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete Load"
       }
     },
     "/trucks": {
@@ -412,7 +418,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Post Truck Availability"
       },
       "get": {
         "operationId": "searchTrucks",
@@ -467,7 +474,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search Available Trucks"
       }
     },
     "/carriers/{dotNumber}": {
@@ -519,7 +527,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Carrier Info"
       }
     }
   },
@@ -737,6 +746,20 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Carriers"
+    },
+    {
+      "name": "Load Board"
+    },
+    {
+      "name": "Rates"
+    },
+    {
+      "name": "Trucks"
     }
   ]
 }

--- a/apis/openapi/data.crunchbase.com/crunchbase-api/4.0.0/openapi.json
+++ b/apis/openapi/data.crunchbase.com/crunchbase-api/4.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Crunchbase API",
     "version": "4.0.0",
     "description": "Crunchbase API v4 provides access to company, people, funding, and acquisition data. The API supports searching and retrieving detailed information about organizations, people, funding rounds, and other business entities.",
-    "x-jentic-source-url": "https://data.crunchbase.com/docs"
+    "x-jentic-source-url": "https://data.crunchbase.com/docs",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/data.gov/regulations.gov/3.0/openapi.json
+++ b/apis/openapi/data.gov/regulations.gov/3.0/openapi.json
@@ -24,7 +24,8 @@
       }
     ],
     "x-providerName": "data.gov",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/data.gov/3.0/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/data.gov/3.0/swagger.yaml",
+    "contact": {}
   },
   "externalDocs": {
     "url": "http://regulationsgov.github.io/developers/"
@@ -96,7 +97,8 @@
         "summary": "Returns Docket information",
         "tags": [
           "dockets"
-        ]
+        ],
+        "description": "Returns Docket information"
       }
     },
     "/document.{response_format}": {
@@ -148,7 +150,8 @@
         "summary": "Returns Document information",
         "tags": [
           "documents"
-        ]
+        ],
+        "description": "Returns Document information"
       }
     },
     "/documents.{response_format}": {

--- a/apis/openapi/dataatwork.org/open-skills-api/1.0/openapi.json
+++ b/apis/openapi/dataatwork.org/open-skills-api/1.0/openapi.json
@@ -67,7 +67,11 @@
             }
           }
         },
-        "summary": "Job Titles and Descriptions"
+        "summary": "Job Titles and Descriptions",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs"
       }
     },
     "/jobs/autocomplete": {
@@ -110,7 +114,11 @@
             }
           }
         },
-        "summary": "Job Title Autocomplete"
+        "summary": "Job Title Autocomplete",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-autocomplete"
       }
     },
     "/jobs/normalize": {
@@ -140,7 +148,11 @@
             }
           }
         },
-        "summary": "Job Title Normalization"
+        "summary": "Job Title Normalization",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-normalize"
       }
     },
     "/jobs/unusual_titles": {
@@ -154,7 +166,11 @@
             }
           }
         },
-        "summary": "Unusual Job Titles"
+        "summary": "Unusual Job Titles",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-unusual-titles"
       }
     },
     "/jobs/{id}": {
@@ -189,7 +205,11 @@
             }
           }
         },
-        "summary": "Job Title and Description"
+        "summary": "Job Title and Description",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-by-id"
       }
     },
     "/jobs/{id}/related_jobs": {
@@ -218,7 +238,11 @@
             }
           }
         },
-        "summary": "Jobs Associated with a Job"
+        "summary": "Jobs Associated with a Job",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-by-id-related-jobs"
       }
     },
     "/jobs/{id}/related_skills": {
@@ -247,7 +271,11 @@
             }
           }
         },
-        "summary": "Skills Associated with a Job"
+        "summary": "Skills Associated with a Job",
+        "tags": [
+          "jobs"
+        ],
+        "operationId": "get-jobs-by-id-related-skills"
       }
     },
     "/skills": {
@@ -281,7 +309,11 @@
             }
           }
         },
-        "summary": "Skill Names and Descriptions"
+        "summary": "Skill Names and Descriptions",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills"
       }
     },
     "/skills/autocomplete": {
@@ -324,7 +356,11 @@
             }
           }
         },
-        "summary": "Skill Name Autocomplete"
+        "summary": "Skill Name Autocomplete",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills-autocomplete"
       }
     },
     "/skills/normalize": {
@@ -347,7 +383,11 @@
             }
           }
         },
-        "summary": "Skill Name Normalization"
+        "summary": "Skill Name Normalization",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills-normalize"
       }
     },
     "/skills/{id}": {
@@ -376,7 +416,11 @@
             }
           }
         },
-        "summary": "Skill Name and Description"
+        "summary": "Skill Name and Description",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills-by-id"
       }
     },
     "/skills/{id}/related_jobs": {
@@ -405,7 +449,11 @@
             }
           }
         },
-        "summary": "Jobs Associated with a Skill"
+        "summary": "Jobs Associated with a Skill",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills-by-id-related-jobs"
       }
     },
     "/skills/{id}/related_skills": {
@@ -434,7 +482,11 @@
             }
           }
         },
-        "summary": "Skills Associated with a Skill"
+        "summary": "Skills Associated with a Skill",
+        "tags": [
+          "skills"
+        ],
+        "operationId": "get-skills-by-id-related-skills"
       }
     }
   },
@@ -726,5 +778,13 @@
       },
       "type": "array"
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "jobs"
+    },
+    {
+      "name": "skills"
+    }
+  ]
 }

--- a/apis/openapi/datacite.org/datacite-rest-api/2.3.0/openapi.json
+++ b/apis/openapi/datacite.org/datacite-rest-api/2.3.0/openapi.json
@@ -431,6 +431,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
     }
   },
   "security": [

--- a/apis/openapi/datacite.org/datacite-rest-api/2.3.0/openapi.json
+++ b/apis/openapi/datacite.org/datacite-rest-api/2.3.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "DataCite REST API",
     "version": "2.3.0",
     "description": "The DataCite REST API is used for all API interactions with DataCite services including DOI management, metadata retrieval, and repository management. Official OpenAPI spec available at https://github.com/datacite/lupo/blob/master/openapi.yaml",
-    "x-jentic-source-url": "https://support.datacite.org/docs/api"
+    "x-jentic-source-url": "https://support.datacite.org/docs/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -133,7 +134,8 @@
           "404": {
             "description": "Not found"
           }
-        }
+        },
+        "description": "Get DOI"
       },
       "put": {
         "operationId": "updateDoi",
@@ -168,7 +170,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update DOI"
       },
       "delete": {
         "operationId": "deleteDoi",
@@ -193,7 +196,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete DOI"
       }
     },
     "/clients": {
@@ -217,7 +221,8 @@
           "200": {
             "description": "Client list"
           }
-        }
+        },
+        "description": "List clients"
       }
     },
     "/clients/{id}": {
@@ -241,7 +246,8 @@
           "200": {
             "description": "Client details"
           }
-        }
+        },
+        "description": "Get client"
       }
     },
     "/providers": {
@@ -255,7 +261,8 @@
           "200": {
             "description": "Provider list"
           }
-        }
+        },
+        "description": "List providers"
       }
     },
     "/providers/{id}": {
@@ -279,7 +286,8 @@
           "200": {
             "description": "Provider details"
           }
-        }
+        },
+        "description": "Get provider"
       }
     },
     "/activities": {
@@ -293,7 +301,8 @@
           "200": {
             "description": "Activity list"
           }
-        }
+        },
+        "description": "List activities"
       }
     },
     "/activities/{id}": {
@@ -317,7 +326,8 @@
           "200": {
             "description": "Activity details"
           }
-        }
+        },
+        "description": "Get activity"
       }
     },
     "/events": {
@@ -331,7 +341,8 @@
           "200": {
             "description": "Event list"
           }
-        }
+        },
+        "description": "List events"
       }
     },
     "/heartbeat": {
@@ -345,7 +356,8 @@
           "200": {
             "description": "Heartbeat response"
           }
-        }
+        },
+        "description": "Get heartbeat"
       }
     }
   },
@@ -418,29 +430,32 @@
             }
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "basicAuth": {
-        "type": "http",
-        "scheme": "basic"
       }
     }
   },
   "security": [
     {
       "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Activities"
+    },
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "DOIs"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Providers"
+    },
+    {
+      "name": "Status"
     }
   ]
 }

--- a/apis/openapi/datahubproject.io/datahub-metadata-service-api/1.0.0/openapi.json
+++ b/apis/openapi/datahubproject.io/datahub-metadata-service-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "DataHub Metadata Service API",
     "version": "1.0.0",
     "description": "DataHub's Metadata Service provides GraphQL and REST.li APIs for ingesting, retrieving, searching, and browsing metadata entities in the DataHub metadata graph.",
-    "x-jentic-source-url": "https://datahubproject.io/docs/metadata-service/"
+    "x-jentic-source-url": "https://datahubproject.io/docs/metadata-service/",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,27 +19,75 @@
         "operationId": "executeGraphQL",
         "summary": "Execute GraphQL query",
         "description": "Primary public API for fetching and mutating metadata using GraphQL.",
-        "tags": ["GraphQL"],
+        "tags": [
+          "GraphQL"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["query"],
+                "required": [
+                  "query"
+                ],
                 "properties": {
-                  "query": {"type": "string"},
-                  "variables": {"type": "object"},
-                  "operationName": {"type": "string"}
+                  "query": {
+                    "type": "string"
+                  },
+                  "variables": {
+                    "type": "object"
+                  },
+                  "operationName": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": {"description": "GraphQL response", "content": {"application/json": {"schema": {"type": "object", "properties": {"data": {"type": "object"}, "errors": {"type": "array", "items": {"type": "object"}}}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "GraphQL response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object"
+                    },
+                    "errors": {
+                      "type": "array",
+                      "items": {
+                        "type": "object"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -47,22 +96,65 @@
         "operationId": "ingestAspectProposal",
         "summary": "Ingest aspect proposal",
         "description": "Ingest individual aspects (metadata about an entity) into the metadata graph via action=ingestProposal.",
-        "tags": ["Ingestion"],
+        "tags": [
+          "Ingestion"
+        ],
         "parameters": [
-          {"name": "action", "in": "query", "description": "Action to perform", "required": true, "schema": {"type": "string", "enum": ["ingestProposal", "getTimeseriesAspectValues"]}}
+          {
+            "name": "action",
+            "in": "query",
+            "description": "Action to perform",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ingestProposal",
+                "getTimeseriesAspectValues"
+              ]
+            }
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"$ref": "#/components/schemas/AspectProposal"}
+              "schema": {
+                "$ref": "#/components/schemas/AspectProposal"
+              }
             }
           }
         },
         "responses": {
-          "200": {"description": "Aspect ingested", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Aspect ingested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -71,15 +163,60 @@
         "operationId": "getEntityV2",
         "summary": "Get entity by URN (v2)",
         "description": "Fetch the latest aspects for an entity given its URN.",
-        "tags": ["Entities"],
+        "tags": [
+          "Entities"
+        ],
         "parameters": [
-          {"name": "urn", "in": "path", "description": "URL-encoded entity URN", "required": true, "schema": {"type": "string"}},
-          {"name": "aspects", "in": "query", "description": "Comma-separated list of aspect names to return", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "urn",
+            "in": "path",
+            "description": "URL-encoded entity URN",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "aspects",
+            "in": "query",
+            "description": "Comma-separated list of aspect names to return",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Entity with aspects", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "404": {"description": "Entity not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Entity with aspects",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -88,13 +225,41 @@
         "operationId": "getEntity",
         "summary": "Get entity snapshot by URN (legacy)",
         "description": "Fetch entity snapshot by URN (legacy endpoint).",
-        "tags": ["Entities"],
+        "tags": [
+          "Entities"
+        ],
         "parameters": [
-          {"name": "urn", "in": "path", "description": "URL-encoded entity URN", "required": true, "schema": {"type": "string"}}
+          {
+            "name": "urn",
+            "in": "path",
+            "description": "URL-encoded entity URN",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Entity snapshot", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "404": {"description": "Entity not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Entity snapshot",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Entity not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -103,22 +268,67 @@
         "operationId": "entityAction",
         "summary": "Entity actions (ingest, browse, search, autocomplete)",
         "description": "Perform various actions on entities: ingest, browse, search, autocomplete.",
-        "tags": ["Entities"],
+        "tags": [
+          "Entities"
+        ],
         "parameters": [
-          {"name": "action", "in": "query", "description": "Action to perform", "required": true, "schema": {"type": "string", "enum": ["ingest", "browse", "search", "autocomplete"]}}
+          {
+            "name": "action",
+            "in": "query",
+            "description": "Action to perform",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "ingest",
+                "browse",
+                "search",
+                "autocomplete"
+              ]
+            }
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": {"type": "object"}
+              "schema": {
+                "type": "object"
+              }
             }
           }
         },
         "responses": {
-          "200": {"description": "Action result", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Action result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -127,15 +337,71 @@
         "operationId": "getRelationships",
         "summary": "Get entity relationships",
         "description": "Get relationships/edges between entities in the metadata graph.",
-        "tags": ["Relationships"],
+        "tags": [
+          "Relationships"
+        ],
         "parameters": [
-          {"name": "urn", "in": "query", "description": "URL-encoded entity URN", "required": true, "schema": {"type": "string"}},
-          {"name": "direction", "in": "query", "description": "Relationship direction", "required": true, "schema": {"type": "string", "enum": ["INCOMING", "OUTGOING"]}},
-          {"name": "types", "in": "query", "description": "Comma-separated relationship types", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "urn",
+            "in": "query",
+            "description": "URL-encoded entity URN",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Relationship direction",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "INCOMING",
+                "OUTGOING"
+              ]
+            }
+          },
+          {
+            "name": "types",
+            "in": "query",
+            "description": "Comma-separated relationship types",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Relationships", "content": {"application/json": {"schema": {"type": "object", "properties": {"entities": {"type": "array", "items": {"type": "string"}}}}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Relationships",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "entities": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -145,21 +411,54 @@
       "AspectProposal": {
         "type": "object",
         "properties": {
-          "entityType": {"type": "string"},
-          "entityUrn": {"type": "string"},
-          "changeType": {"type": "string"},
-          "aspectName": {"type": "string"},
-          "aspect": {"type": "object"}
+          "entityType": {
+            "type": "string"
+          },
+          "entityUrn": {
+            "type": "string"
+          },
+          "changeType": {
+            "type": "string"
+          },
+          "aspectName": {
+            "type": "string"
+          },
+          "aspect": {
+            "type": "object"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": {"type": "string", "enum": ["error"]},
-          "code": {"type": "string"},
-          "message": {"type": "string"}
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Entities"
+    },
+    {
+      "name": "GraphQL"
+    },
+    {
+      "name": "Ingestion"
+    },
+    {
+      "name": "Relationships"
+    }
+  ]
 }

--- a/apis/openapi/dataplatform.knmi.nl/knmi-data-platform-api/1.0.0/openapi.json
+++ b/apis/openapi/dataplatform.knmi.nl/knmi-data-platform-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "KNMI Data Platform API",
     "version": "1.0.0",
     "description": "KNMI (Royal Netherlands Meteorological Institute) Data Platform APIs for accessing open meteorological data, including dataset files, notifications, environmental data retrieval, WMS maps, and seismological web services.",
-    "x-jentic-source-url": "https://developer.dataplatform.knmi.nl/open-data-api"
+    "x-jentic-source-url": "https://developer.dataplatform.knmi.nl/open-data-api",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,19 +18,107 @@
         "operationId": "listDatasetFiles",
         "summary": "List files in a dataset",
         "description": "Retrieves a list of files within a specified dataset version",
-        "tags": ["Open Data"],
+        "tags": [
+          "Open Data"
+        ],
         "parameters": [
-          {"name": "datasetName", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Dataset name"},
-          {"name": "versionId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Dataset version ID"},
-          {"name": "maxKeys", "in": "query", "description": "Maximum number of files to return", "required": false, "schema": {"type": "integer"}},
-          {"name": "sorting", "in": "query", "description": "Sort direction", "required": false, "schema": {"type": "string", "enum": ["asc", "desc"], "default": "asc"}},
-          {"name": "orderBy", "in": "query", "description": "Sort attribute", "required": false, "schema": {"type": "string", "enum": ["filename", "lastModified", "created"], "default": "filename"}},
-          {"name": "begin", "in": "query", "description": "Start listing after this filename", "required": false, "schema": {"type": "string"}}
+          {
+            "name": "datasetName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Dataset name"
+          },
+          {
+            "name": "versionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Dataset version ID"
+          },
+          {
+            "name": "maxKeys",
+            "in": "query",
+            "description": "Maximum number of files to return",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "sorting",
+            "in": "query",
+            "description": "Sort direction",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "asc"
+            }
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "description": "Sort attribute",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "enum": [
+                "filename",
+                "lastModified",
+                "created"
+              ],
+              "default": "filename"
+            }
+          },
+          {
+            "name": "begin",
+            "in": "query",
+            "description": "Start listing after this filename",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/FileListResponse"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -38,16 +127,69 @@
         "operationId": "getFileDownloadUrl",
         "summary": "Get file download URL",
         "description": "Obtains a temporary download URL for a specific file in a dataset",
-        "tags": ["Open Data"],
+        "tags": [
+          "Open Data"
+        ],
         "parameters": [
-          {"name": "datasetName", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Dataset name"},
-          {"name": "versionId", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Dataset version ID"},
-          {"name": "filename", "in": "path", "required": true, "schema": {"type": "string"}, "description": "Name of the file to download"}
+          {
+            "name": "datasetName",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Dataset name"
+          },
+          {
+            "name": "versionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Dataset version ID"
+          },
+          {
+            "name": "filename",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Name of the file to download"
+          }
         ],
         "responses": {
-          "200": {"description": "Successful response", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/FileDownloadUrlResponse"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FileDownloadUrlResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -62,29 +204,55 @@
             "items": {
               "type": "object",
               "properties": {
-                "filename": {"type": "string"},
-                "lastModified": {"type": "string", "format": "date-time"},
-                "created": {"type": "string", "format": "date-time"},
-                "size": {"type": "integer"}
+                "filename": {
+                  "type": "string"
+                },
+                "lastModified": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "created": {
+                  "type": "string",
+                  "format": "date-time"
+                },
+                "size": {
+                  "type": "integer"
+                }
               }
             }
           },
-          "isTruncated": {"type": "boolean"},
-          "nextPageToken": {"type": "string"}
+          "isTruncated": {
+            "type": "boolean"
+          },
+          "nextPageToken": {
+            "type": "string"
+          }
         }
       },
       "FileDownloadUrlResponse": {
         "type": "object",
         "properties": {
-          "temporaryDownloadUrl": {"type": "string", "format": "uri"}
+          "temporaryDownloadUrl": {
+            "type": "string",
+            "format": "uri"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": {"type": "string", "enum": ["error"]},
-          "code": {"type": "string"},
-          "message": {"type": "string"}
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "code": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -98,6 +266,13 @@
     }
   },
   "security": [
-    {"apiKey": []}
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Open Data"
+    }
   ]
 }

--- a/apis/openapi/dayforce.com/dayforce/1.0.0/openapi.json
+++ b/apis/openapi/dayforce.com/dayforce/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dayforce API",
     "version": "1.0.0",
     "description": "Dayforce HCM platform API for human resources, payroll, workforce management, and talent management",
-    "x-jentic-source-url": "https://developers.dayforce.com/"
+    "x-jentic-source-url": "https://developers.dayforce.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -303,5 +304,19 @@
         ]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Employees"
+    },
+    {
+      "name": "Payroll"
+    },
+    {
+      "name": "Scheduling"
+    },
+    {
+      "name": "Time"
+    }
+  ]
 }

--- a/apis/openapi/db.com/db/1.0.0/openapi.json
+++ b/apis/openapi/db.com/db/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Deutsche Bank API",
     "version": "1.0.0",
     "description": "Deutsche Bank open banking platform",
-    "x-jentic-source-url": "https://developer.db.com/"
+    "x-jentic-source-url": "https://developer.db.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/db.com/db/1.0.0/openapi.json
+++ b/apis/openapi/db.com/db/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/dbfahrplanapi/db-fahrplan-api/1.0/openapi.json
+++ b/apis/openapi/dbfahrplanapi/db-fahrplan-api/1.0/openapi.json
@@ -78,7 +78,11 @@
           {
             "authKey": []
           }
-        ]
+        ],
+        "tags": [
+          "location.name"
+        ],
+        "operationId": "get-location-name"
       }
     },
     "/departureBoard": {
@@ -160,7 +164,11 @@
           {
             "authKey": []
           }
-        ]
+        ],
+        "tags": [
+          "departureBoard"
+        ],
+        "operationId": "get-departureboard"
       }
     },
     "/arrivalBoard": {
@@ -242,7 +250,11 @@
           {
             "authKey": []
           }
-        ]
+        ],
+        "tags": [
+          "arrivalBoard"
+        ],
+        "operationId": "get-arrivalboard"
       }
     },
     "/journeyDetail": {
@@ -301,7 +313,11 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "journeyDetail"
+        ],
+        "operationId": "get-journeydetail"
       }
     }
   },
@@ -722,5 +738,19 @@
       }
     }
   },
-  "x-original-swagger-version": "2.0"
+  "x-original-swagger-version": "2.0",
+  "tags": [
+    {
+      "name": "arrivalBoard"
+    },
+    {
+      "name": "departureBoard"
+    },
+    {
+      "name": "journeyDetail"
+    },
+    {
+      "name": "location.name"
+    }
+  ]
 }

--- a/apis/openapi/dealhub.io/dealhub-api/2.0.0/openapi.json
+++ b/apis/openapi/dealhub.io/dealhub-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "DealHub API",
     "version": "2.0.0",
     "description": "DealHub CPQ, CLM, and Billing API.",
-    "x-jentic-source-url": "https://developers.dealhub.io/"
+    "x-jentic-source-url": "https://developers.dealhub.io/",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Retrieve quote"
       }
     },
     "/quotes": {
@@ -87,7 +89,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List quotes"
       }
     },
     "/quotes/simulate": {
@@ -131,7 +134,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Simulate quote"
       }
     },
     "/quotes/generate": {
@@ -175,7 +179,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Generate quote"
       }
     },
     "/quotes/submit": {
@@ -219,7 +224,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Submit quote"
       }
     },
     "/quotes/publish": {
@@ -263,7 +269,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Publish quote"
       }
     },
     "/quotes/{id}/document": {
@@ -307,7 +314,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get quote document"
       }
     },
     "/users": {
@@ -341,7 +349,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List users"
       },
       "put": {
         "operationId": "updateUsers",
@@ -383,7 +392,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update users"
       }
     },
     "/users/{id}": {
@@ -427,7 +437,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get user by ID"
       }
     },
     "/users/login/{login}": {
@@ -471,7 +482,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get user by login"
       }
     },
     "/versions": {
@@ -505,7 +517,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List versions"
       }
     },
     "/versions/{id}": {
@@ -549,7 +562,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get version"
       }
     },
     "/versions/name/{name}": {
@@ -593,7 +607,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get version by name"
       }
     },
     "/versions/duplicate": {
@@ -637,7 +652,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Duplicate version"
       }
     },
     "/versions/activate": {
@@ -681,7 +697,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Activate version"
       }
     },
     "/versions/{id}/products": {
@@ -725,7 +742,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get version products"
       }
     },
     "/catalog": {
@@ -759,7 +777,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get catalog"
       },
       "post": {
         "operationId": "createCatalog",
@@ -801,7 +820,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update catalog"
       },
       "patch": {
         "operationId": "updateCatalogItems",
@@ -843,7 +863,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update catalog items"
       }
     },
     "/products/sku": {
@@ -887,7 +908,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get products by SKU"
       }
     },
     "/accounts": {
@@ -921,7 +943,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List accounts"
       },
       "post": {
         "operationId": "createAccount",
@@ -963,7 +986,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create account"
       }
     },
     "/accounts/{id}": {
@@ -1007,7 +1031,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get account"
       },
       "post": {
         "operationId": "updateAccount",
@@ -1059,7 +1084,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update account"
       }
     },
     "/plans": {
@@ -1093,7 +1119,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List plans"
       },
       "post": {
         "operationId": "createPlan",
@@ -1135,7 +1162,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create plan"
       }
     },
     "/plans/{id}": {
@@ -1179,7 +1207,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get plan"
       }
     },
     "/recurring-items": {
@@ -1213,7 +1242,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List recurring items"
       },
       "post": {
         "operationId": "createRecurringItem",
@@ -1255,7 +1285,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create recurring item"
       }
     },
     "/recurring-items/{id}": {
@@ -1299,7 +1330,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get recurring item"
       }
     },
     "/recurring-items/{id}/renew": {
@@ -1353,7 +1385,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Renew subscription"
       }
     },
     "/recurring-items/{id}/cancel": {
@@ -1407,7 +1440,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel subscription"
       }
     },
     "/one-time-items": {
@@ -1441,7 +1475,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List one-time items"
       },
       "post": {
         "operationId": "createOneTimeItem",
@@ -1483,7 +1518,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create one-time item"
       }
     },
     "/external-query/fulfill": {
@@ -1527,7 +1563,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Pull data into Playbooks"
       }
     },
     "/pricing": {
@@ -1571,7 +1608,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Sync pricing data"
       }
     },
     "/dealroom/signers": {
@@ -1605,7 +1643,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get DealRoom signers"
       }
     },
     "/opportunities": {
@@ -1649,7 +1688,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create opportunity"
       }
     },
     "/auth/user": {
@@ -1693,7 +1733,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Authenticate user"
       }
     },
     "/auth/partner": {
@@ -1737,7 +1778,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Authenticate partner"
       }
     }
   },
@@ -1768,6 +1810,41 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Billing"
+    },
+    {
+      "name": "Callouts"
+    },
+    {
+      "name": "DealRoom"
+    },
+    {
+      "name": "External Queries"
+    },
+    {
+      "name": "Headless Quoting"
+    },
+    {
+      "name": "Opportunities"
+    },
+    {
+      "name": "Products"
+    },
+    {
+      "name": "Quotes"
+    },
+    {
+      "name": "Users"
+    },
+    {
+      "name": "Versions"
     }
   ]
 }

--- a/apis/openapi/dealpath.com/dealpath-api/1.3/openapi.json
+++ b/apis/openapi/dealpath.com/dealpath-api/1.3/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dealpath API",
     "version": "1.3",
     "description": "The Dealpath Developer API provides endpoints for managing real estate deal operations, enabling integration with assets, deals, properties, funds, investments, loans, leases, and related entities.",
-    "x-jentic-source-url": "https://platform.dealpath.com/"
+    "x-jentic-source-url": "https://platform.dealpath.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -16,504 +17,1837 @@
       "post": {
         "operationId": "createAsset",
         "summary": "Create asset",
-        "tags": ["Assets"],
+        "tags": [
+          "Assets"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/AssetInput" }
+              "schema": {
+                "$ref": "#/components/schemas/AssetInput"
+              }
             }
           }
         },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssetResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create asset"
       }
     },
     "/assets": {
       "get": {
         "operationId": "listAssets",
         "summary": "List assets",
-        "tags": ["Assets"],
+        "tags": [
+          "Assets"
+        ],
         "parameters": [
-          { "name": "next_token", "in": "query", "description": "Pagination token for next page", "schema": { "type": "string" } },
-          { "name": "updated_before", "in": "query", "description": "Filter by updated before (Unix timestamp)", "schema": { "type": "integer" } },
-          { "name": "updated_after", "in": "query", "description": "Filter by updated after (Unix timestamp)", "schema": { "type": "integer" } }
+          {
+            "name": "next_token",
+            "in": "query",
+            "description": "Pagination token for next page",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updated_before",
+            "in": "query",
+            "description": "Filter by updated before (Unix timestamp)",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "updated_after",
+            "in": "query",
+            "description": "Filter by updated after (Unix timestamp)",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssetListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List assets"
       }
     },
     "/asset/{asset_id}": {
       "get": {
         "operationId": "getAsset",
         "summary": "Retrieve specific asset",
-        "tags": ["Assets"],
+        "tags": [
+          "Assets"
+        ],
         "parameters": [
-          { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssetResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve specific asset"
       },
       "put": {
         "operationId": "updateAsset",
         "summary": "Update asset",
-        "tags": ["Assets"],
+        "tags": [
+          "Assets"
+        ],
         "parameters": [
-          { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssetInput" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AssetInput"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/AssetResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AssetResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update asset"
       },
       "delete": {
         "operationId": "deleteAsset",
         "summary": "Delete asset",
-        "tags": ["Assets"],
+        "tags": [
+          "Assets"
+        ],
         "parameters": [
-          { "name": "asset_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "asset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete asset"
       }
     },
     "/deal": {
       "post": {
         "operationId": "createDeal",
         "summary": "Create deal",
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealInput" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DealInput"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DealResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create deal"
       }
     },
     "/deals": {
       "get": {
         "operationId": "listDeals",
         "summary": "List deals",
-        "tags": ["Deals"],
+        "tags": [
+          "Deals"
+        ],
         "parameters": [
-          { "name": "next_token", "in": "query", "schema": { "type": "string" } },
-          { "name": "updated_before", "in": "query", "schema": { "type": "integer" } },
-          { "name": "updated_after", "in": "query", "schema": { "type": "integer" } }
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updated_before",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "updated_after",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DealListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List deals"
       }
     },
     "/deal/{deal_id}": {
       "get": {
         "operationId": "getDeal",
         "summary": "Retrieve deal",
-        "tags": ["Deals"],
-        "parameters": [ { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Deals"
+        ],
+        "parameters": [
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DealResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve deal"
       },
       "put": {
         "operationId": "updateDeal",
         "summary": "Update deal",
-        "tags": ["Deals"],
-        "parameters": [ { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealInput" } } } },
+        "tags": [
+          "Deals"
+        ],
+        "parameters": [
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DealInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/DealResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DealResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update deal"
       },
       "delete": {
         "operationId": "deleteDeal",
         "summary": "Delete deal",
-        "tags": ["Deals"],
-        "parameters": [ { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Deals"
+        ],
+        "parameters": [
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete deal"
       }
     },
     "/fund": {
       "post": {
         "operationId": "createFund",
         "summary": "Create fund",
-        "tags": ["Funds"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FundInput" } } } },
+        "tags": [
+          "Funds"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FundInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FundResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create fund"
       }
     },
     "/funds": {
       "get": {
         "operationId": "listFunds",
         "summary": "List funds",
-        "tags": ["Funds"],
+        "tags": [
+          "Funds"
+        ],
         "parameters": [
-          { "name": "next_token", "in": "query", "schema": { "type": "string" } },
-          { "name": "updated_before", "in": "query", "schema": { "type": "integer" } },
-          { "name": "updated_after", "in": "query", "schema": { "type": "integer" } }
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "updated_before",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "updated_after",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FundListResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List funds"
       }
     },
     "/fund/{fund_id}": {
       "put": {
         "operationId": "updateFund",
         "summary": "Update fund",
-        "tags": ["Funds"],
-        "parameters": [ { "name": "fund_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FundInput" } } } },
+        "tags": [
+          "Funds"
+        ],
+        "parameters": [
+          {
+            "name": "fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FundInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FundResponse" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FundResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update fund"
       },
       "delete": {
         "operationId": "deleteFund",
         "summary": "Delete fund",
-        "tags": ["Funds"],
-        "parameters": [ { "name": "fund_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Funds"
+        ],
+        "parameters": [
+          {
+            "name": "fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete fund"
       }
     },
     "/attachment/fund/{fund_id}/deal/{deal_id}": {
       "post": {
         "operationId": "attachDealToFund",
         "summary": "Attach deal to fund",
-        "tags": ["Attachments"],
+        "tags": [
+          "Attachments"
+        ],
         "parameters": [
-          { "name": "fund_id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Attach deal to fund"
       }
     },
     "/attachment/fund/{fund_id}/investment/{investment_id}": {
       "post": {
         "operationId": "attachInvestmentToFund",
         "summary": "Attach investment to fund",
-        "tags": ["Attachments"],
+        "tags": [
+          "Attachments"
+        ],
         "parameters": [
-          { "name": "fund_id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "investment_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "fund_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "investment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Attach investment to fund"
       }
     },
     "/investment": {
       "post": {
         "operationId": "createInvestment",
         "summary": "Create investment",
-        "tags": ["Investments"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/InvestmentInput" } } } },
+        "tags": [
+          "Investments"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvestmentInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create investment"
       }
     },
     "/investments": {
       "get": {
         "operationId": "listInvestments",
         "summary": "List investments",
-        "tags": ["Investments"],
+        "tags": [
+          "Investments"
+        ],
         "parameters": [
-          { "name": "next_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List investments"
       }
     },
     "/investment/{investment_id}": {
       "put": {
         "operationId": "updateInvestment",
         "summary": "Update investment",
-        "tags": ["Investments"],
-        "parameters": [ { "name": "investment_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/InvestmentInput" } } } },
+        "tags": [
+          "Investments"
+        ],
+        "parameters": [
+          {
+            "name": "investment_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/InvestmentInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update investment"
       }
     },
     "/property": {
       "post": {
         "operationId": "createProperty",
         "summary": "Create property",
-        "tags": ["Properties"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PropertyInput" } } } },
+        "tags": [
+          "Properties"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PropertyInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create property"
       }
     },
     "/properties": {
       "get": {
         "operationId": "listProperties",
         "summary": "List properties",
-        "tags": ["Properties"],
+        "tags": [
+          "Properties"
+        ],
         "parameters": [
-          { "name": "next_token", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List properties"
       }
     },
     "/property/{property_id}": {
       "get": {
         "operationId": "getProperty",
         "summary": "Retrieve property",
-        "tags": ["Properties"],
-        "parameters": [ { "name": "property_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Properties"
+        ],
+        "parameters": [
+          {
+            "name": "property_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve property"
       },
       "put": {
         "operationId": "updateProperty",
         "summary": "Update property",
-        "tags": ["Properties"],
-        "parameters": [ { "name": "property_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PropertyInput" } } } },
+        "tags": [
+          "Properties"
+        ],
+        "parameters": [
+          {
+            "name": "property_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PropertyInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update property"
       },
       "delete": {
         "operationId": "deleteProperty",
         "summary": "Delete property",
-        "tags": ["Properties"],
-        "parameters": [ { "name": "property_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Properties"
+        ],
+        "parameters": [
+          {
+            "name": "property_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete property"
       }
     },
     "/loan": {
       "post": {
         "operationId": "createLoan",
         "summary": "Create loan",
-        "tags": ["Loans"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanInput" } } } },
+        "tags": [
+          "Loans"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoanInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create loan"
       }
     },
     "/loans": {
       "get": {
         "operationId": "listLoans",
         "summary": "List loans",
-        "tags": ["Loans"],
-        "parameters": [ { "name": "next_token", "in": "query", "schema": { "type": "string" } } ],
+        "tags": [
+          "Loans"
+        ],
+        "parameters": [
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List loans"
       }
     },
     "/loan/{loan_id}": {
       "put": {
         "operationId": "updateLoan",
         "summary": "Update loan",
-        "tags": ["Loans"],
-        "parameters": [ { "name": "loan_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LoanInput" } } } },
+        "tags": [
+          "Loans"
+        ],
+        "parameters": [
+          {
+            "name": "loan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoanInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update loan"
       },
       "delete": {
         "operationId": "deleteLoan",
         "summary": "Delete loan",
-        "tags": ["Loans"],
-        "parameters": [ { "name": "loan_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "Loans"
+        ],
+        "parameters": [
+          {
+            "name": "loan_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete loan"
       }
     },
     "/lease": {
       "post": {
         "operationId": "createLease",
         "summary": "Create lease",
-        "tags": ["Leases"],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LeaseInput" } } } },
+        "tags": [
+          "Leases"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeaseInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create lease"
       }
     },
     "/field_definitions": {
       "get": {
         "operationId": "listFieldDefinitions",
         "summary": "List field definitions",
-        "tags": ["Fields"],
-        "parameters": [ { "name": "next_token", "in": "query", "schema": { "type": "string" } } ],
+        "tags": [
+          "Fields"
+        ],
+        "parameters": [
+          {
+            "name": "next_token",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List field definitions"
       }
     },
     "/field/deal/{deal_id}/field_definition/{field_definition_id}": {
       "put": {
         "operationId": "updateDealField",
         "summary": "Update deal field value",
-        "tags": ["Fields"],
-        "parameters": [
-          { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "field_definition_id", "in": "path", "required": true, "schema": { "type": "string" } }
+        "tags": [
+          "Fields"
         ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/FieldValueInput" } } } },
+        "parameters": [
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "field_definition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FieldValueInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update deal field value"
       },
       "delete": {
         "operationId": "deleteDealField",
         "summary": "Delete deal field value",
-        "tags": ["Fields"],
+        "tags": [
+          "Fields"
+        ],
         "parameters": [
-          { "name": "deal_id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "field_definition_id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "deal_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "field_definition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete deal field value"
       }
     },
     "/list_options/field_definition/{field_definition_id}": {
       "get": {
         "operationId": "getListOptions",
         "summary": "Retrieve list options for field definition",
-        "tags": ["List Options"],
-        "parameters": [ { "name": "field_definition_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "List Options"
+        ],
+        "parameters": [
+          {
+            "name": "field_definition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Retrieve list options for field definition"
       }
     },
     "/list_option/field_definition/{field_definition_id}": {
       "post": {
         "operationId": "createListOption",
         "summary": "Create list option",
-        "tags": ["List Options"],
-        "parameters": [ { "name": "field_definition_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ListOptionInput" } } } },
+        "tags": [
+          "List Options"
+        ],
+        "parameters": [
+          {
+            "name": "field_definition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListOptionInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create list option"
       }
     },
     "/list_option/{list_option_id}": {
       "put": {
         "operationId": "updateListOption",
         "summary": "Update list option",
-        "tags": ["List Options"],
-        "parameters": [ { "name": "list_option_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
-        "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ListOptionInput" } } } },
+        "tags": [
+          "List Options"
+        ],
+        "parameters": [
+          {
+            "name": "list_option_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ListOptionInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update list option"
       },
       "delete": {
         "operationId": "deleteListOption",
         "summary": "Delete list option",
-        "tags": ["List Options"],
-        "parameters": [ { "name": "list_option_id", "in": "path", "required": true, "schema": { "type": "string" } } ],
+        "tags": [
+          "List Options"
+        ],
+        "parameters": [
+          {
+            "name": "list_option_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": { "description": "Successful response" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
-        }
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete list option"
       }
     }
   },
@@ -522,116 +1856,188 @@
       "AssetInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "description": "Asset name" }
+          "name": {
+            "type": "string",
+            "description": "Asset name"
+          }
         }
       },
       "AssetResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "object" },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "object"
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "AssetListResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "array", "items": { "type": "object" } },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "DealInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "description": "Deal name" }
+          "name": {
+            "type": "string",
+            "description": "Deal name"
+          }
         }
       },
       "DealResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "object" },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "object"
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "DealListResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "array", "items": { "type": "object" } },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "FundInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string", "description": "Fund name" }
+          "name": {
+            "type": "string",
+            "description": "Fund name"
+          }
         }
       },
       "FundResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "object" },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "object"
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "FundListResponse": {
         "type": "object",
         "properties": {
-          "data": { "type": "array", "items": { "type": "object" } },
-          "next_token": { "type": "string" }
+          "data": {
+            "type": "array",
+            "items": {
+              "type": "object"
+            }
+          },
+          "next_token": {
+            "type": "string"
+          }
         }
       },
       "InvestmentInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" }
+          "name": {
+            "type": "string"
+          }
         }
       },
       "PropertyInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" },
-          "address": { "$ref": "#/components/schemas/Address" }
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "$ref": "#/components/schemas/Address"
+          }
         }
       },
       "LoanInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" }
+          "name": {
+            "type": "string"
+          }
         }
       },
       "LeaseInput": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" }
+          "name": {
+            "type": "string"
+          }
         }
       },
       "FieldValueInput": {
         "type": "object",
         "properties": {
-          "value": { "type": "string" }
+          "value": {
+            "type": "string"
+          }
         }
       },
       "ListOptionInput": {
         "type": "object",
         "properties": {
-          "label": { "type": "string" },
-          "value": { "type": "string" }
+          "label": {
+            "type": "string"
+          },
+          "value": {
+            "type": "string"
+          }
         }
       },
       "Address": {
         "type": "object",
         "properties": {
-          "street": { "type": "string" },
-          "city": { "type": "string" },
-          "state": { "type": "string" },
-          "zip": { "type": "string" },
-          "country": { "type": "string" }
+          "street": {
+            "type": "string"
+          },
+          "city": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "zip": {
+            "type": "string"
+          },
+          "country": {
+            "type": "string"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "error": { "type": "string" },
-          "message": { "type": "string" }
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -645,6 +2051,38 @@
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Assets"
+    },
+    {
+      "name": "Attachments"
+    },
+    {
+      "name": "Deals"
+    },
+    {
+      "name": "Fields"
+    },
+    {
+      "name": "Funds"
+    },
+    {
+      "name": "Investments"
+    },
+    {
+      "name": "Leases"
+    },
+    {
+      "name": "List Options"
+    },
+    {
+      "name": "Loans"
+    },
+    {
+      "name": "Properties"
     }
   ]
 }

--- a/apis/openapi/debounce.io/debounce-api/1.0.0/openapi.json
+++ b/apis/openapi/debounce.io/debounce-api/1.0.0/openapi.json
@@ -4,104 +4,390 @@
     "title": "DeBounce API",
     "version": "1.0.0",
     "description": "DeBounce email verification and validation API. Check if emails are deliverable, risky, disposable, or part of a catch-all domain. Includes single validation, bulk upload, disposable detection, logo lookup, and account management.",
-    "x-jentic-source-url": "https://developers.debounce.com"
+    "x-jentic-source-url": "https://developers.debounce.com",
+    "contact": {}
   },
-  "servers": [{"url": "https://api.debounce.io/v1"}],
+  "servers": [
+    {
+      "url": "https://api.debounce.io/v1"
+    }
+  ],
   "paths": {
     "/": {
       "get": {
         "operationId": "validateEmail",
         "summary": "Validate a single email",
         "description": "Check if an email is deliverable, risky, disposable, or part of a catch-all domain",
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "parameters": [
-          {"name": "api_key", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Your DeBounce API key"},
-          {"name": "email", "in": "query", "required": true, "schema": {"type": "string"}, "description": "Email address to validate"}
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Your DeBounce API key"
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Email address to validate"
+          }
         ],
         "responses": {
-          "200": {"description": "Validation result", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ValidationResult"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Validation result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "/balance/": {
+    "/balance": {
       "get": {
         "operationId": "getAccountBalance",
         "summary": "Get account balance",
         "description": "Check remaining validation credits",
-        "tags": ["Account"],
+        "tags": [
+          "Account"
+        ],
         "parameters": [
-          {"name": "api_key", "in": "query", "required": true, "schema": {"type": "string"}}
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Account balance", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/BalanceResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Account balance",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BalanceResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "/disposable/": {
+    "/disposable": {
       "get": {
         "operationId": "checkDisposable",
         "summary": "Detect disposable email",
         "description": "Identify if an email domain is disposable/temporary",
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "parameters": [
-          {"name": "api_key", "in": "query", "required": true, "schema": {"type": "string"}},
-          {"name": "email", "in": "query", "required": true, "schema": {"type": "string"}}
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Disposable check result", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/DisposableResult"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Disposable check result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DisposableResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "/append/": {
+    "/append": {
       "get": {
         "operationId": "reverseEmailLookup",
         "summary": "Reverse email lookup (Data Append)",
         "description": "Retrieve contact information from an email address",
-        "tags": ["Data Append"],
+        "tags": [
+          "Data Append"
+        ],
         "parameters": [
-          {"name": "api_key", "in": "query", "required": true, "schema": {"type": "string"}},
-          {"name": "email", "in": "query", "required": true, "schema": {"type": "string"}}
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Append result", "content": {"application/json": {"schema": {"type": "object"}}}},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Append result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
-    "/logo/": {
+    "/logo": {
       "get": {
         "operationId": "getCompanyLogo",
         "summary": "Get company logo",
         "description": "Look up company logo by domain",
-        "tags": ["Data Append"],
+        "tags": [
+          "Data Append"
+        ],
         "parameters": [
-          {"name": "api_key", "in": "query", "required": true, "schema": {"type": "string"}},
-          {"name": "domain", "in": "query", "required": true, "schema": {"type": "string"}}
+          {
+            "name": "api_key",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "domain",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Logo result"},
-          "400": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-          "401": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
+          "200": {
+            "description": "Logo result"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "ValidationResult": {"type": "object", "properties": {"debounce": {"type": "object", "properties": {"email": {"type": "string"}, "code": {"type": "string"}, "role": {"type": "string"}, "free_email": {"type": "string"}, "result": {"type": "string"}, "reason": {"type": "string"}, "send_transactional": {"type": "string"}, "did_you_mean": {"type": "string"}}}}},
-      "BalanceResponse": {"type": "object", "properties": {"debounce": {"type": "object", "properties": {"balance": {"type": "string"}}}}},
-      "DisposableResult": {"type": "object", "properties": {"disposable": {"type": "string"}}},
-      "ErrorResponse": {"type": "object", "properties": {"debounce": {"type": "object", "properties": {"error": {"type": "string"}, "code": {"type": "string"}}}}}
+      "ValidationResult": {
+        "type": "object",
+        "properties": {
+          "debounce": {
+            "type": "object",
+            "properties": {
+              "email": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              },
+              "role": {
+                "type": "string"
+              },
+              "free_email": {
+                "type": "string"
+              },
+              "result": {
+                "type": "string"
+              },
+              "reason": {
+                "type": "string"
+              },
+              "send_transactional": {
+                "type": "string"
+              },
+              "did_you_mean": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "BalanceResponse": {
+        "type": "object",
+        "properties": {
+          "debounce": {
+            "type": "object",
+            "properties": {
+              "balance": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "DisposableResult": {
+        "type": "object",
+        "properties": {
+          "disposable": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "debounce": {
+            "type": "object",
+            "properties": {
+              "error": {
+                "type": "string"
+              },
+              "code": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
     },
     "securitySchemes": {
-      "apiKeyQuery": {"type": "apiKey", "in": "query", "name": "api_key", "description": "API key passed as query parameter"}
+      "apiKeyQuery": {
+        "type": "apiKey",
+        "in": "query",
+        "name": "api_key",
+        "description": "API key passed as query parameter"
+      }
     }
   },
-  "security": [{"apiKeyQuery": []}]
+  "security": [
+    {
+      "apiKeyQuery": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Account"
+    },
+    {
+      "name": "Data Append"
+    },
+    {
+      "name": "Validation"
+    }
+  ]
 }

--- a/apis/openapi/deep-image.ai/deep-image-api/1.0.0/openapi.json
+++ b/apis/openapi/deep-image.ai/deep-image-api/1.0.0/openapi.json
@@ -4,10 +4,13 @@
     "title": "DeepImage API",
     "version": "1.0.0",
     "description": "Deep-image.ai is a powerful AI-based image editing API providing image enhancement, upscaling, background removal, sharpening, denoising, and deblurring capabilities.",
-    "x-jentic-source-url": "https://documentation.deep-image.ai"
+    "x-jentic-source-url": "https://documentation.deep-image.ai",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://deep-image.ai" }
+    {
+      "url": "https://deep-image.ai"
+    }
   ],
   "paths": {
     "/rest_api/process_result": {
@@ -15,7 +18,9 @@
         "operationId": "processImage",
         "summary": "Process an image with AI enhancements",
         "description": "Submit an image for processing with specified enhancements such as denoising, deblurring, lighting enhancement, and upscaling.",
-        "tags": ["Image Processing"],
+        "tags": [
+          "Image Processing"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -23,9 +28,28 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "url": { "type": "string", "description": "Image URL or base64-encoded image data" },
-                  "enhancements": { "type": "array", "items": { "type": "string", "enum": ["denoise", "deblur", "light", "color", "upscale"] }, "description": "Enhancement types to apply" },
-                  "width": { "type": "integer", "description": "Target width in pixels for upscaling" }
+                  "url": {
+                    "type": "string",
+                    "description": "Image URL or base64-encoded image data"
+                  },
+                  "enhancements": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "denoise",
+                        "deblur",
+                        "light",
+                        "color",
+                        "upscale"
+                      ]
+                    },
+                    "description": "Enhancement types to apply"
+                  },
+                  "width": {
+                    "type": "integer",
+                    "description": "Target width in pixels for upscaling"
+                  }
                 }
               }
             },
@@ -33,9 +57,19 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "file": { "type": "string", "format": "binary", "description": "Image file to upload" },
-                  "enhancements": { "type": "string", "description": "JSON array of enhancement types" },
-                  "width": { "type": "integer", "description": "Target width in pixels" }
+                  "file": {
+                    "type": "string",
+                    "format": "binary",
+                    "description": "Image file to upload"
+                  },
+                  "enhancements": {
+                    "type": "string",
+                    "description": "JSON array of enhancement types"
+                  },
+                  "width": {
+                    "type": "integer",
+                    "description": "Target width in pixels"
+                  }
                 }
               }
             }
@@ -46,12 +80,32 @@
             "description": "Processing initiated",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProcessResult" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessResult"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -60,21 +114,51 @@
         "operationId": "getJobResult",
         "summary": "Check job status and get result",
         "description": "Retrieve the processing status and result URL of a submitted image job.",
-        "tags": ["Image Processing"],
+        "tags": [
+          "Image Processing"
+        ],
         "parameters": [
-          { "name": "job_id", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Unique job identifier" }
+          {
+            "name": "job_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Unique job identifier"
+          }
         ],
         "responses": {
           "200": {
             "description": "Job status and result",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ProcessResult" }
+                "schema": {
+                  "$ref": "#/components/schemas/ProcessResult"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -84,16 +168,32 @@
       "ProcessResult": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "description": "Processing status" },
-          "job": { "type": "string", "description": "Job identifier" },
-          "result_url": { "type": "string", "description": "URL of the processed image" }
+          "status": {
+            "type": "string",
+            "description": "Processing status"
+          },
+          "job": {
+            "type": "string",
+            "description": "Job identifier"
+          },
+          "result_url": {
+            "type": "string",
+            "description": "URL of the processed image"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "string", "enum": ["error"] },
-          "message": { "type": "string" }
+          "status": {
+            "type": "string",
+            "enum": [
+              "error"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     },
@@ -107,6 +207,13 @@
     }
   },
   "security": [
-    { "apiKey": [] }
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Image Processing"
+    }
   ]
 }

--- a/apis/openapi/deeparteffects.com/deep-art-effects/2017-02-10 16:24:46+00:00/openapi.json
+++ b/apis/openapi/deeparteffects.com/deep-art-effects/2017-02-10 16:24:46+00:00/openapi.json
@@ -25,7 +25,8 @@
       }
     ],
     "x-providerName": "deeparteffects.com",
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/deeparteffects.com/2017-02-10T162446Z/swagger.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/deeparteffects.com/2017-02-10T162446Z/swagger.yaml",
+    "description": "Deep Art Effects"
   },
   "securityDefinitions": {
     "api_key": {
@@ -104,7 +105,12 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/getsubmissionresultv3"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "GET /noauth/result",
+        "operationId": "get-noauth-result"
       }
     },
     "/noauth/styles": {
@@ -149,7 +155,12 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/liststyles?e=1"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "GET /noauth/styles",
+        "operationId": "get-noauth-styles"
       }
     },
     "/noauth/upload": {
@@ -219,15 +230,16 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/uploadv3"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "POST /noauth/upload",
+        "operationId": "post-noauth-upload"
       }
     }
   },
   "definitions": {
-    "Empty": {
-      "title": "Empty Schema",
-      "type": "object"
-    },
     "Error": {
       "properties": {
         "message": {
@@ -324,5 +336,10 @@
       "title": "Response Schema for upload request",
       "type": "object"
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "noauth"
+    }
+  ]
 }

--- a/apis/openapi/deeparteffects.com/deeparteffects-api/2017-02-10/openapi.json
+++ b/apis/openapi/deeparteffects.com/deeparteffects-api/2017-02-10/openapi.json
@@ -24,7 +24,8 @@
         "version": "2.0"
       }
     ],
-    "x-providerName": "deeparteffects.com"
+    "x-providerName": "deeparteffects.com",
+    "description": "Deep Art Effects"
   },
   "securityDefinitions": {
     "api_key": {
@@ -103,7 +104,12 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/getsubmissionresultv3"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "GET /noauth/result",
+        "operationId": "get-noauth-result"
       }
     },
     "/noauth/styles": {
@@ -148,7 +154,12 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/liststyles?e=1"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "GET /noauth/styles",
+        "operationId": "get-noauth-styles"
       }
     },
     "/noauth/upload": {
@@ -218,15 +229,16 @@
           },
           "type": "http",
           "uri": "https://www.deeparteffects.com/service/uploadv3"
-        }
+        },
+        "tags": [
+          "noauth"
+        ],
+        "description": "POST /noauth/upload",
+        "operationId": "post-noauth-upload"
       }
     }
   },
   "definitions": {
-    "Empty": {
-      "title": "Empty Schema",
-      "type": "object"
-    },
     "Error": {
       "properties": {
         "message": {
@@ -323,5 +335,10 @@
       "title": "Response Schema for upload request",
       "type": "object"
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "noauth"
+    }
+  ]
 }

--- a/apis/openapi/defastra.com/defastra-api/1.0.0/openapi.json
+++ b/apis/openapi/defastra.com/defastra-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Defastra API",
     "description": "Fraud detection and risk assessment API for email addresses and phone numbers",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://docs.defastra.com/reference/authentication"
+    "x-jentic-source-url": "https://docs.defastra.com/reference/authentication",
+    "contact": {}
   },
   "servers": [
     {
@@ -30,7 +31,9 @@
   "paths": {
     "/deep_email_check": {
       "post": {
-        "tags": ["Email Verification"],
+        "tags": [
+          "Email Verification"
+        ],
         "summary": "Perform deep email check",
         "description": "Performs fraud detection on email addresses",
         "operationId": "deepEmailCheck",
@@ -40,7 +43,9 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["email"],
+                "required": [
+                  "email"
+                ],
                 "properties": {
                   "email": {
                     "type": "string",
@@ -104,7 +109,9 @@
     },
     "/deep_phone_check": {
       "post": {
-        "tags": ["Phone Verification"],
+        "tags": [
+          "Phone Verification"
+        ],
         "summary": "Perform deep phone check",
         "description": "Analyzes phone numbers for fraud risk",
         "operationId": "deepPhoneCheck",
@@ -114,7 +121,9 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
-                "required": ["phone"],
+                "required": [
+                  "phone"
+                ],
                 "properties": {
                   "phone": {
                     "type": "string",

--- a/apis/openapi/delinea.com/delinea-privilege-manager-api/1.0.0/openapi.json
+++ b/apis/openapi/delinea.com/delinea-privilege-manager-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Delinea Privilege Manager API",
     "version": "1.0.0",
     "description": "Delinea Privilege Manager API for managing policies, agents, computers, users, and application control.",
-    "x-jentic-source-url": "https://docs.delinea.com/online-help/privilege-manager/api/index.htm"
+    "x-jentic-source-url": "https://docs.delinea.com/online-help/privilege-manager/api/index.htm",
+    "contact": {}
   },
   "servers": [
     {
@@ -572,6 +573,20 @@
   "security": [
     {
       "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Agents"
+    },
+    {
+      "name": "Auth"
+    },
+    {
+      "name": "Computers"
+    },
+    {
+      "name": "Policies"
     }
   ]
 }

--- a/apis/openapi/deliveryhero.com/pos-plugin-api/1.0.0/openapi.json
+++ b/apis/openapi/deliveryhero.com/pos-plugin-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Delivery Hero POS Plugin API",
     "version": "1.0.0",
     "description": "The Delivery Hero POS Plugin API enables POS systems to receive and process orders from the Delivery Hero POS Order Processing Service. It provides endpoints for order dispatch, status updates, and menu import triggering.",
-    "x-jentic-source-url": "https://developers.deliveryhero.com/documentation/pos.html"
+    "x-jentic-source-url": "https://developers.deliveryhero.com/documentation/pos.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -17,7 +18,9 @@
         "operationId": "dispatchOrder",
         "summary": "Dispatch order to POS plugin",
         "description": "Receives new orders from the POS Order Processing Service and dispatches them to the POS plugin.",
-        "tags": ["Orders"],
+        "tags": [
+          "Orders"
+        ],
         "parameters": [
           {
             "name": "remoteId",
@@ -88,7 +91,9 @@
         "operationId": "updateOrderStatus",
         "summary": "Update order status",
         "description": "Notifies POS plugins about order status changes including cancellations, pickups, and modifications.",
-        "tags": ["Orders"],
+        "tags": [
+          "Orders"
+        ],
         "parameters": [
           {
             "name": "remoteId",
@@ -158,7 +163,9 @@
         "operationId": "triggerMenuImport",
         "summary": "Trigger menu import",
         "description": "Requests menu submission from the POS plugin. The plugin should respond and then asynchronously submit the menu.",
-        "tags": ["Menu"],
+        "tags": [
+          "Menu"
+        ],
         "parameters": [
           {
             "name": "remoteId",
@@ -220,7 +227,9 @@
         "operationId": "catalogImportStatus",
         "summary": "Receive catalog import status",
         "description": "Receives catalog import status updates from the middleware.",
-        "tags": ["Menu"],
+        "tags": [
+          "Menu"
+        ],
         "parameters": [
           {
             "name": "catalogImportCallback",
@@ -370,7 +379,9 @@
             "$ref": "#/components/schemas/Order"
           }
         },
-        "required": ["status"]
+        "required": [
+          "status"
+        ]
       },
       "CatalogImportCallbackRequest": {
         "type": "object",
@@ -381,7 +392,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["in_progress", "done", "done_with_errors", "failed"],
+            "enum": [
+              "in_progress",
+              "done",
+              "done_with_errors",
+              "failed"
+            ],
             "description": "Import status"
           },
           "message": {
@@ -418,7 +434,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["success"]
+            "enum": [
+              "success"
+            ]
           },
           "message": {
             "type": "string"
@@ -430,7 +448,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["error"]
+            "enum": [
+              "error"
+            ]
           },
           "code": {
             "type": "string"
@@ -453,6 +473,14 @@
   "security": [
     {
       "BearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Menu"
+    },
+    {
+      "name": "Orders"
     }
   ]
 }

--- a/apis/openapi/dentally.co/dentally-api/1.0.0/openapi.json
+++ b/apis/openapi/dentally.co/dentally-api/1.0.0/openapi.json
@@ -1521,6 +1521,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "userAgent": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "userAgent"
+      }
     }
   },
   "security": [

--- a/apis/openapi/dentally.co/dentally-api/1.0.0/openapi.json
+++ b/apis/openapi/dentally.co/dentally-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Dentally API",
     "version": "1.0.0",
     "description": "Dentally is a cloud-based dental practice management software. The API allows integration with dental practices for managing patients, appointments, invoices, and more.",
-    "x-jentic-source-url": "https://developer.dentally.co/"
+    "x-jentic-source-url": "https://developer.dentally.co/",
+    "contact": {}
   },
   "servers": [
     {
@@ -72,7 +73,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List accounts"
       }
     },
     "/v1/accounts/{id}": {
@@ -116,7 +118,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get account"
       }
     },
     "/v1/acquisition_sources": {
@@ -150,7 +153,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List acquisition sources"
       }
     },
     "/v1/appointment_cancellation_reasons": {
@@ -202,7 +206,8 @@
               "format": "date-time"
             }
           }
-        ]
+        ],
+        "description": "List cancellation reasons"
       }
     },
     "/v1/appointments": {
@@ -246,7 +251,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create appointment"
       },
       "get": {
         "operationId": "listAppointments",
@@ -325,7 +331,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List appointments"
       }
     },
     "/v1/appointments/{id}": {
@@ -369,7 +376,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get appointment"
       },
       "put": {
         "operationId": "updateAppointment",
@@ -421,7 +429,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update appointment"
       },
       "delete": {
         "operationId": "deleteAppointment",
@@ -463,7 +472,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Delete appointment"
       }
     },
     "/v1/appointments/availability": {
@@ -525,7 +535,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Check availability"
       }
     },
     "/v1/appointment_reasons": {
@@ -559,7 +570,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List appointment reasons"
       }
     },
     "/v1/contracts/{id}": {
@@ -603,7 +615,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get contract"
       }
     },
     "/v1/contracts": {
@@ -653,7 +666,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List contracts"
       }
     },
     "/v1/custom_fields": {
@@ -687,7 +701,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List custom fields"
       }
     },
     "/v1/custom_fields/{id}": {
@@ -731,7 +746,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get custom field"
       }
     },
     "/v1/fees/{id}": {
@@ -775,7 +791,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get fee"
       },
       "put": {
         "operationId": "updateFee",
@@ -827,7 +844,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update fee"
       }
     },
     "/v1/fees": {
@@ -877,7 +895,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List fees"
       }
     },
     "/v1/invoices/{id}": {
@@ -921,7 +940,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get invoice"
       }
     },
     "/v1/invoices": {
@@ -987,7 +1007,8 @@
               "format": "date-time"
             }
           }
-        ]
+        ],
+        "description": "List invoices"
       }
     },
     "/v1/invoice_items": {
@@ -1030,7 +1051,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List invoice items"
       }
     },
     "/v1/nhs_claims/{id}": {
@@ -1074,7 +1096,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get NHS claim"
       }
     },
     "/v1/nhs_claims": {
@@ -1117,7 +1140,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List NHS claims"
       }
     },
     "/v1/patients": {
@@ -1161,7 +1185,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create patient"
       },
       "get": {
         "operationId": "listPatients",
@@ -1217,7 +1242,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "List patients"
       }
     },
     "/v1/patients/{id}": {
@@ -1261,7 +1287,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get patient"
       },
       "put": {
         "operationId": "updatePatient",
@@ -1313,7 +1340,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update patient"
       },
       "delete": {
         "operationId": "deletePatient",
@@ -1355,7 +1383,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Delete patient"
       }
     },
     "/v1/patients/{id}/stats": {
@@ -1399,7 +1428,8 @@
               "type": "string"
             }
           }
-        ]
+        ],
+        "description": "Get patient stats"
       }
     },
     "/v1/patient_stats": {
@@ -1433,7 +1463,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List patient stats"
       }
     },
     "/v1/payment_plans": {
@@ -1467,94 +1498,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List payment plans"
       }
     }
   },
   "components": {
     "schemas": {
-      "Patient": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "title": {
-            "type": "string"
-          },
-          "first_name": {
-            "type": "string"
-          },
-          "last_name": {
-            "type": "string"
-          },
-          "date_of_birth": {
-            "type": "string",
-            "format": "date"
-          },
-          "gender": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phone": {
-            "type": "string"
-          }
-        }
-      },
-      "Appointment": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "start_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "finish_time": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "practitioner_id": {
-            "type": "string"
-          },
-          "patient_id": {
-            "type": "string"
-          },
-          "state": {
-            "type": "string"
-          },
-          "reason": {
-            "type": "string"
-          },
-          "notes": {
-            "type": "string"
-          }
-        }
-      },
-      "Invoice": {
-        "type": "object",
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "patient_id": {
-            "type": "string"
-          },
-          "site_id": {
-            "type": "string"
-          },
-          "total": {
-            "type": "number"
-          },
-          "dated_on": {
-            "type": "string",
-            "format": "date"
-          }
-        }
-      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -1571,18 +1521,43 @@
           }
         }
       }
-    },
-    "securitySchemes": {
-      "userAgent": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "User-Agent"
-      }
     }
   },
   "security": [
     {
       "userAgent": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Accounts"
+    },
+    {
+      "name": "Acquisition Sources"
+    },
+    {
+      "name": "Appointments"
+    },
+    {
+      "name": "Contracts"
+    },
+    {
+      "name": "Custom Fields"
+    },
+    {
+      "name": "Fees"
+    },
+    {
+      "name": "Invoices"
+    },
+    {
+      "name": "NHS Claims"
+    },
+    {
+      "name": "Patients"
+    },
+    {
+      "name": "Payment Plans"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Spectral-lint clean **50** OpenAPI specs. All specs now pass `spectral lint` with the default `spectral:oas` ruleset with zero warnings and zero errors.

### Fixes Applied

| Rule | Specs Fixed |
|------|-------------|
| info-contact | 39 |
| operation-tag-defined | 33 |
| operation-description | 20 |
| operation-tags | 9 |
| unused-components | 9 |
| operation-operationId | 6 |
| path-keys-no-trailing-slash | 4 |
| info-description | 3 |
| no-$ref-siblings | 1 |

### APIs Fixed

- crisp.chat/crisp-rest-api
- crossbrowsertesting.com/crossbrowsertesting.com-screenshot-comparisons-api
- crossmint.com/crossmint-api
- crove.app/crove-api
- crowd.dev/crowd-dev-api
- crucible.local/crucible
- cruisen.com/cruisen-api
- crustdata.com/crustdata-api
- cryptolens.io/cryptolens
- cs-cart.com/rest-api
- cube.dev/cube-rest-api
- cupixworks.com/cupixworks
- currencyapi.com/currency-api
- currencyfreaks.com/currencyfreaks-api
- currencylayer.com/currencylayer-api
- currencyscoop.com/currencybeacon-api
- customerbase.com/customerbase-api
- customjs.space/customjs-api
- cutt.ly/cuttly-team-api
- cvr.dev/cvr-api
- cyberark.com/cyberark
- cyberimpact.com/cyberimpact-api
- cybertaxonomy.eu/eu-bon-utis
- cyfe.com/cyfe-push-api
- dacast.com/dacast-api
- dagpi.xyz/dagpi
- daktela.com/daktela-api
- dana.id/dashboarddana
- dandelion.events/dandelion-events-api
- dante-ai.com/dante-ai-api
- dat.com/dat-freight-api
- data.crunchbase.com/crunchbase-api
- data.gov/regulations.gov
- dataatwork.org/open-skills-api
- datacite.org/datacite-rest-api
- datahubproject.io/datahub-metadata-service-api
- dataplatform.knmi.nl/knmi-data-platform-api
- dayforce.com/dayforce
- db.com/db
- dbfahrplanapi/db-fahrplan-api
- dealhub.io/dealhub-api
- dealpath.com/dealpath-api
- debounce.io/debounce-api
- deep-image.ai/deep-image-api
- deeparteffects.com/deep-art-effects
- deeparteffects.com/deeparteffects-api
- defastra.com/defastra-api
- delinea.com/delinea-privilege-manager-api
- deliveryhero.com/pos-plugin-api
- dentally.co/dentally-api

## Test plan
- [x] All 50 specs pass `spectral lint` after fixes
