### PR TITLE
Spectral-lint clean 50 OpenAPI specs (batch 012)

### DIFF
--- a/apis/openapi/esendex.com/esendex/1.0.0/openapi.json
+++ b/apis/openapi/esendex.com/esendex/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Esendex API",
     "version": "1.0.0",
     "description": "SMS, Voice, and Rich Content messaging APIs",
-    "x-jentic-source-url": "https://developers.esendex.com/api-reference"
+    "x-jentic-source-url": "https://developers.esendex.com/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -85,7 +86,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messagedispatcher"
+        ]
       }
     },
     "/messages/information": {
@@ -119,7 +123,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messages"
+        ]
       }
     },
     "/messageheaders": {
@@ -154,7 +161,12 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["Sent", "Delivered", "Failed", "Pending"]
+              "enum": [
+                "Sent",
+                "Delivered",
+                "Failed",
+                "Pending"
+              ]
             },
             "description": "Filter by message status"
           },
@@ -191,7 +203,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messageheaders"
+        ]
       }
     },
     "/messageheaders/{id}": {
@@ -235,7 +250,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messageheaders"
+        ]
       }
     },
     "/inbox/messages": {
@@ -280,7 +298,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "inbox"
+        ]
       }
     },
     "/conversation/{phonenumber}/messages": {
@@ -334,7 +355,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "conversation"
+        ]
       }
     },
     "/messagebatches": {
@@ -361,7 +385,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messagebatches"
+        ]
       }
     },
     "/messagebatches/{id}": {
@@ -395,7 +422,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "messagebatches"
+        ]
       },
       "put": {
         "summary": "Name Message Batch",
@@ -435,7 +465,10 @@
           "200": {
             "description": "OK"
           }
-        }
+        },
+        "tags": [
+          "messagebatches"
+        ]
       }
     },
     "/messagebatches/{id}/schedule": {
@@ -462,7 +495,10 @@
           "204": {
             "description": "No Content"
           }
-        }
+        },
+        "tags": [
+          "messagebatches"
+        ]
       }
     },
     "/send": {
@@ -511,7 +547,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "send"
+        ]
       }
     },
     "/accounts/{AccountReference}/messages/{GatewayId}": {
@@ -558,7 +597,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/surveys/{id}/send": {
@@ -595,7 +637,10 @@
           "200": {
             "description": "OK"
           }
-        }
+        },
+        "tags": [
+          "surveys"
+        ]
       }
     },
     "/surveys/{id}/report/standard": {
@@ -661,7 +706,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "surveys"
+        ]
       }
     },
     "/accounts/{accountReference}/subscriptions": {
@@ -698,7 +746,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "accounts"
+        ]
       },
       "post": {
         "summary": "Create Webhook Subscription",
@@ -740,7 +791,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "accounts"
+        ]
       }
     },
     "/accounts/{accountReference}/subscriptions/{productId}/{eventId}": {
@@ -783,7 +837,10 @@
           "204": {
             "description": "No Content"
           }
-        }
+        },
+        "tags": [
+          "accounts"
+        ]
       }
     }
   },
@@ -818,7 +875,10 @@
       },
       "MessageDispatchRequest": {
         "type": "object",
-        "required": ["accountreference", "messages"],
+        "required": [
+          "accountreference",
+          "messages"
+        ],
         "properties": {
           "accountreference": {
             "type": "string"
@@ -840,7 +900,10 @@
                 },
                 "type": {
                   "type": "string",
-                  "enum": ["SMS", "Voice"]
+                  "enum": [
+                    "SMS",
+                    "Voice"
+                  ]
                 },
                 "sendAt": {
                   "type": "string",
@@ -944,7 +1007,10 @@
           },
           "direction": {
             "type": "string",
-            "enum": ["Inbound", "Outbound"]
+            "enum": [
+              "Inbound",
+              "Outbound"
+            ]
           },
           "body": {
             "type": "string"
@@ -975,7 +1041,12 @@
       },
       "RichContentRequest": {
         "type": "object",
-        "required": ["accountReference", "channels", "recipient", "content"],
+        "required": [
+          "accountReference",
+          "channels",
+          "recipient",
+          "content"
+        ],
         "properties": {
           "accountReference": {
             "type": "string"
@@ -984,7 +1055,11 @@
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["SMS", "RCS", "WhatsApp"]
+              "enum": [
+                "SMS",
+                "RCS",
+                "WhatsApp"
+              ]
             }
           },
           "recipient": {
@@ -1070,7 +1145,14 @@
           },
           "eventId": {
             "type": "string",
-            "enum": ["delivered", "failed", "read", "clicked", "inbound", "stop"]
+            "enum": [
+              "delivered",
+              "failed",
+              "read",
+              "clicked",
+              "inbound",
+              "stop"
+            ]
           },
           "url": {
             "type": "string",
@@ -1080,14 +1162,25 @@
       },
       "WebhookSubscriptionRequest": {
         "type": "object",
-        "required": ["productId", "eventId", "url"],
+        "required": [
+          "productId",
+          "eventId",
+          "url"
+        ],
         "properties": {
           "productId": {
             "type": "string"
           },
           "eventId": {
             "type": "string",
-            "enum": ["delivered", "failed", "read", "clicked", "inbound", "stop"]
+            "enum": [
+              "delivered",
+              "failed",
+              "read",
+              "clicked",
+              "inbound",
+              "stop"
+            ]
           },
           "url": {
             "type": "string",
@@ -1096,5 +1189,34 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "accounts"
+    },
+    {
+      "name": "conversation"
+    },
+    {
+      "name": "inbox"
+    },
+    {
+      "name": "messagebatches"
+    },
+    {
+      "name": "messagedispatcher"
+    },
+    {
+      "name": "messageheaders"
+    },
+    {
+      "name": "messages"
+    },
+    {
+      "name": "send"
+    },
+    {
+      "name": "surveys"
+    }
+  ]
 }

--- a/apis/openapi/esendex.com/messaging-api/1.0.0/openapi.json
+++ b/apis/openapi/esendex.com/messaging-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Esendex Messaging API",
     "version": "1.0.0",
     "description": "Esendex provides SMS, voice, and messaging services. The REST API allows sending messages, checking delivery status, managing accounts, and retrieving inbox messages.",
-    "x-jentic-source-url": "https://developers.esendex.com/api-reference"
+    "x-jentic-source-url": "https://developers.esendex.com/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,10 +19,22 @@
     }
   ],
   "tags": [
-    { "name": "Messages", "description": "Send and manage messages" },
-    { "name": "MessageHeaders", "description": "Retrieve message headers and statuses" },
-    { "name": "Inbox", "description": "Manage inbox messages" },
-    { "name": "Accounts", "description": "Account management" }
+    {
+      "name": "Messages",
+      "description": "Send and manage messages"
+    },
+    {
+      "name": "MessageHeaders",
+      "description": "Retrieve message headers and statuses"
+    },
+    {
+      "name": "Inbox",
+      "description": "Manage inbox messages"
+    },
+    {
+      "name": "Accounts",
+      "description": "Account management"
+    }
   ],
   "paths": {
     "/messagedispatcher": {
@@ -29,12 +42,16 @@
         "operationId": "sendMessage",
         "summary": "Send a message",
         "description": "Dispatches one or more SMS, voice, or other messages to the specified recipients.",
-        "tags": ["Messages"],
+        "tags": [
+          "Messages"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/MessageDispatchRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/MessageDispatchRequest"
+              }
             }
           }
         },
@@ -43,7 +60,9 @@
             "description": "Messages dispatched successfully",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MessageDispatchResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/MessageDispatchResponse"
+                }
               }
             }
           },
@@ -51,7 +70,9 @@
             "description": "Bad request",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           },
@@ -59,7 +80,9 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -71,24 +94,32 @@
         "operationId": "getMessageHeaders",
         "summary": "Get message headers",
         "description": "Retrieves a list of sent message headers for the authenticated account.",
-        "tags": ["MessageHeaders"],
+        "tags": [
+          "MessageHeaders"
+        ],
         "parameters": [
           {
             "name": "startindex",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Start index for pagination"
           },
           {
             "name": "count",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Number of results to return"
           },
           {
             "name": "accountreference",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by account reference"
           }
         ],
@@ -97,12 +128,32 @@
             "description": "Message headers retrieved",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MessageHeadersResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/MessageHeadersResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -111,13 +162,18 @@
         "operationId": "getMessageHeaderById",
         "summary": "Get a message header by ID",
         "description": "Retrieves the header for a specific sent message.",
-        "tags": ["MessageHeaders"],
+        "tags": [
+          "MessageHeaders"
+        ],
         "parameters": [
           {
             "name": "messageId",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "format": "uuid" },
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
             "description": "The unique message identifier"
           }
         ],
@@ -126,13 +182,42 @@
             "description": "Message header retrieved",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/MessageHeader" }
+                "schema": {
+                  "$ref": "#/components/schemas/MessageHeader"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -141,24 +226,32 @@
         "operationId": "getInboxMessages",
         "summary": "Get inbox messages",
         "description": "Retrieves a list of inbox messages for the authenticated account.",
-        "tags": ["Inbox"],
+        "tags": [
+          "Inbox"
+        ],
         "parameters": [
           {
             "name": "startindex",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Start index for pagination"
           },
           {
             "name": "count",
             "in": "query",
-            "schema": { "type": "integer" },
+            "schema": {
+              "type": "integer"
+            },
             "description": "Number of results to return"
           },
           {
             "name": "accountreference",
             "in": "query",
-            "schema": { "type": "string" },
+            "schema": {
+              "type": "string"
+            },
             "description": "Filter by account reference"
           }
         ],
@@ -167,12 +260,32 @@
             "description": "Inbox messages retrieved",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/InboxMessagesResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/InboxMessagesResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -181,19 +294,44 @@
         "operationId": "deleteInboxMessage",
         "summary": "Delete an inbox message",
         "description": "Deletes a specific inbox message by ID.",
-        "tags": ["Inbox"],
+        "tags": [
+          "Inbox"
+        ],
         "parameters": [
           {
             "name": "messageId",
             "in": "path",
             "required": true,
-            "schema": { "type": "string", "format": "uuid" }
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
           }
         ],
         "responses": {
-          "200": { "description": "Message deleted" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Message deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -202,17 +340,30 @@
         "operationId": "getAccounts",
         "summary": "Get accounts",
         "description": "Retrieves the list of accounts associated with the authenticated user.",
-        "tags": ["Accounts"],
+        "tags": [
+          "Accounts"
+        ],
         "responses": {
           "200": {
             "description": "Accounts retrieved",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/AccountsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/AccountsResponse"
+                }
               }
             }
           },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -228,94 +379,194 @@
     "schemas": {
       "MessageDispatchRequest": {
         "type": "object",
-        "required": ["accountreference", "messages"],
+        "required": [
+          "accountreference",
+          "messages"
+        ],
         "properties": {
-          "accountreference": { "type": "string", "description": "The Esendex account reference (e.g. EX00xxxxx)" },
-          "from": { "type": "string", "description": "The sender/originator of the message" },
-          "type": { "type": "string", "enum": ["SMS", "Voice"], "description": "Message type" },
+          "accountreference": {
+            "type": "string",
+            "description": "The Esendex account reference (e.g. EX00xxxxx)"
+          },
+          "from": {
+            "type": "string",
+            "description": "The sender/originator of the message"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "SMS",
+              "Voice"
+            ],
+            "description": "Message type"
+          },
           "messages": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/MessageRequest" }
+            "items": {
+              "$ref": "#/components/schemas/MessageRequest"
+            }
           }
         }
       },
       "MessageRequest": {
         "type": "object",
-        "required": ["to", "body"],
+        "required": [
+          "to",
+          "body"
+        ],
         "properties": {
-          "to": { "type": "string", "description": "Recipient phone number" },
-          "body": { "type": "string", "description": "Message content" }
+          "to": {
+            "type": "string",
+            "description": "Recipient phone number"
+          },
+          "body": {
+            "type": "string",
+            "description": "Message content"
+          }
         }
       },
       "MessageDispatchResponse": {
         "type": "object",
         "properties": {
-          "batchid": { "type": "string", "format": "uuid" },
+          "batchid": {
+            "type": "string",
+            "format": "uuid"
+          },
           "messageheaders": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/MessageHeaderRef" }
+            "items": {
+              "$ref": "#/components/schemas/MessageHeaderRef"
+            }
           }
         }
       },
       "MessageHeaderRef": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "uri": { "type": "string" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "uri": {
+            "type": "string"
+          }
         }
       },
       "MessageHeadersResponse": {
         "type": "object",
         "properties": {
-          "startindex": { "type": "integer" },
-          "count": { "type": "integer" },
-          "totalcount": { "type": "integer" },
+          "startindex": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "totalcount": {
+            "type": "integer"
+          },
           "messageheaders": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/MessageHeader" }
+            "items": {
+              "$ref": "#/components/schemas/MessageHeader"
+            }
           }
         }
       },
       "MessageHeader": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "reference": { "type": "string" },
-          "status": { "type": "string", "description": "Message status (e.g. Delivered, Failed, Submitted)" },
-          "laststatusat": { "type": "string", "format": "date-time" },
-          "submittedat": { "type": "string", "format": "date-time" },
-          "type": { "type": "string" },
-          "to": { "type": "string" },
-          "from": { "type": "string" },
-          "summary": { "type": "string" },
-          "body": { "type": "string" },
-          "direction": { "type": "string" },
-          "parts": { "type": "integer" },
-          "username": { "type": "string" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reference": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "description": "Message status (e.g. Delivered, Failed, Submitted)"
+          },
+          "laststatusat": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "submittedat": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "type": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "summary": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "direction": {
+            "type": "string"
+          },
+          "parts": {
+            "type": "integer"
+          },
+          "username": {
+            "type": "string"
+          }
         }
       },
       "InboxMessagesResponse": {
         "type": "object",
         "properties": {
-          "startindex": { "type": "integer" },
-          "count": { "type": "integer" },
-          "totalcount": { "type": "integer" },
+          "startindex": {
+            "type": "integer"
+          },
+          "count": {
+            "type": "integer"
+          },
+          "totalcount": {
+            "type": "integer"
+          },
           "messages": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/InboxMessage" }
+            "items": {
+              "$ref": "#/components/schemas/InboxMessage"
+            }
           }
         }
       },
       "InboxMessage": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "from": { "type": "string" },
-          "to": { "type": "string" },
-          "body": { "type": "string" },
-          "receivedat": { "type": "string", "format": "date-time" },
-          "readat": { "type": "string", "format": "date-time" },
-          "readby": { "type": "string" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "from": {
+            "type": "string"
+          },
+          "to": {
+            "type": "string"
+          },
+          "body": {
+            "type": "string"
+          },
+          "receivedat": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "readat": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "readby": {
+            "type": "string"
+          }
         }
       },
       "AccountsResponse": {
@@ -323,21 +574,41 @@
         "properties": {
           "accounts": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Account" }
+            "items": {
+              "$ref": "#/components/schemas/Account"
+            }
           }
         }
       },
       "Account": {
         "type": "object",
         "properties": {
-          "id": { "type": "string", "format": "uuid" },
-          "reference": { "type": "string" },
-          "label": { "type": "string" },
-          "address": { "type": "string" },
-          "type": { "type": "string" },
-          "messagesremaining": { "type": "integer" },
-          "expireson": { "type": "string", "format": "date-time" },
-          "role": { "type": "string" }
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "reference": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "messagesremaining": {
+            "type": "integer"
+          },
+          "expireson": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "role": {
+            "type": "string"
+          }
         }
       },
       "ErrorResponse": {
@@ -348,8 +619,12 @@
             "items": {
               "type": "object",
               "properties": {
-                "code": { "type": "string" },
-                "description": { "type": "string" }
+                "code": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                }
               }
             }
           }

--- a/apis/openapi/esewa.com.np/esewa-epay-api/2.0.0/openapi.json
+++ b/apis/openapi/esewa.com.np/esewa-epay-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "eSewa ePay API",
     "version": "2.0.0",
     "description": "eSewa payment gateway API for Nepal. Enables merchants to accept payments through eSewa digital wallet.",
-    "x-jentic-source-url": "https://developer.esewa.com.np/pages/Epay"
+    "x-jentic-source-url": "https://developer.esewa.com.np/pages/Epay",
+    "contact": {}
   },
   "servers": [
     {
@@ -62,7 +63,7 @@
         }
       }
     },
-    "/api/epay/transaction/status/": {
+    "/api/epay/transaction/status": {
       "get": {
         "operationId": "getTransactionStatus",
         "summary": "Check transaction status",
@@ -254,6 +255,11 @@
   "security": [
     {
       "HmacSignature": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Payments"
     }
   ]
 }

--- a/apis/openapi/esgenterprise.com/esg-rating-data/1.0.0/openapi.json
+++ b/apis/openapi/esgenterprise.com/esg-rating-data/1.0.0/openapi.json
@@ -25,7 +25,9 @@
     "x-logo": {
       "url": "https://api.apis.guru/v2/cache/logo/https_apis.guru_assets_images_no-logo.svg"
     },
-    "x-jentic-source-url": "https://api.apis.guru/v2/specs/esgenterprise.com/1.0.0/openapi.yaml"
+    "x-jentic-source-url": "https://api.apis.guru/v2/specs/esgenterprise.com/1.0.0/openapi.yaml",
+    "contact": {},
+    "description": "ESG Rating Data"
   },
   "paths": {
     "/search": {
@@ -93,7 +95,9 @@
         "summary": "List all company ESG Ratings",
         "tags": [
           "rating"
-        ]
+        ],
+        "description": "List all company ESG Ratings",
+        "operationId": "get-search"
       }
     }
   },
@@ -105,5 +109,10 @@
         "type": "apiKey"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "rating"
+    }
+  ]
 }

--- a/apis/openapi/espocrm.com/crm-api/1.0.0/openapi.json
+++ b/apis/openapi/espocrm.com/crm-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "EspoCRM REST API",
     "version": "1.0.0",
     "description": "EspoCRM is an open-source CRM. The REST API provides CRUD operations for all entity types (Contacts, Accounts, Leads, Opportunities, etc.), including listing, creating, reading, updating, and deleting records. The API uses a generic CRUD pattern where {entityType} is the CRM entity name.",
-    "x-jentic-source-url": "https://docs.espocrm.com/development/api/"
+    "x-jentic-source-url": "https://docs.espocrm.com/development/api/",
+    "contact": {}
   },
   "servers": [
     {
@@ -27,8 +28,14 @@
     }
   ],
   "tags": [
-    { "name": "CRUD", "description": "Generic CRUD operations on entities" },
-    { "name": "Relationships", "description": "Manage entity relationships" }
+    {
+      "name": "CRUD",
+      "description": "Generic CRUD operations on entities"
+    },
+    {
+      "name": "Relationships",
+      "description": "Manage entity relationships"
+    }
   ],
   "paths": {
     "/{entityType}": {
@@ -36,42 +43,130 @@
         "operationId": "listEntities",
         "summary": "List entities",
         "description": "Returns a list of records of a given entity type. Supports filtering, sorting, and pagination via query parameters.",
-        "tags": ["CRUD"],
+        "tags": [
+          "CRUD"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity type name (e.g. Contact, Account, Lead, Opportunity)" },
-          { "name": "offset", "in": "query", "schema": { "type": "integer" }, "description": "Offset for pagination" },
-          { "name": "maxSize", "in": "query", "schema": { "type": "integer" }, "description": "Max number of records to return" },
-          { "name": "where", "in": "query", "schema": { "type": "string" }, "description": "JSON-encoded where clause for filtering" },
-          { "name": "orderBy", "in": "query", "schema": { "type": "string" }, "description": "Field name to order by" },
-          { "name": "order", "in": "query", "schema": { "type": "string", "enum": ["asc", "desc"] }, "description": "Sort direction" },
-          { "name": "select", "in": "query", "schema": { "type": "string" }, "description": "Comma-separated list of fields to return" }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Entity type name (e.g. Contact, Account, Lead, Opportunity)"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Offset for pagination"
+          },
+          {
+            "name": "maxSize",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Max number of records to return"
+          },
+          {
+            "name": "where",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "JSON-encoded where clause for filtering"
+          },
+          {
+            "name": "orderBy",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Field name to order by"
+          },
+          {
+            "name": "order",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ]
+            },
+            "description": "Sort direction"
+          },
+          {
+            "name": "select",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Comma-separated list of fields to return"
+          }
         ],
         "responses": {
           "200": {
             "description": "List of entity records",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EntityListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/EntityListResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "createEntity",
         "summary": "Create an entity record",
         "description": "Creates a new record of the specified entity type.",
-        "tags": ["CRUD"],
+        "tags": [
+          "CRUD"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Entity type name" }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Entity type name"
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/EntityRecord" }
+              "schema": {
+                "$ref": "#/components/schemas/EntityRecord"
+              }
             }
           }
         },
@@ -80,12 +175,32 @@
             "description": "Created entity record",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EntityRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/EntityRecord"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -94,39 +209,102 @@
         "operationId": "getEntity",
         "summary": "Get an entity record",
         "description": "Retrieves a single record of the specified entity type by ID.",
-        "tags": ["CRUD"],
+        "tags": [
+          "CRUD"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
             "description": "Entity record",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EntityRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/EntityRecord"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "put": {
         "operationId": "updateEntity",
         "summary": "Update an entity record",
         "description": "Updates an existing record of the specified entity type.",
-        "tags": ["CRUD"],
+        "tags": [
+          "CRUD"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/EntityRecord" }
+              "schema": {
+                "$ref": "#/components/schemas/EntityRecord"
+              }
             }
           }
         },
@@ -135,29 +313,103 @@
             "description": "Updated entity record",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EntityRecord" }
+                "schema": {
+                  "$ref": "#/components/schemas/EntityRecord"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "operationId": "deleteEntity",
         "summary": "Delete an entity record",
         "description": "Deletes a record of the specified entity type by ID.",
-        "tags": ["CRUD"],
+        "tags": [
+          "CRUD"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "Record deleted successfully" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Record deleted successfully"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -166,36 +418,115 @@
         "operationId": "listRelatedEntities",
         "summary": "List related entities",
         "description": "Returns a list of records related to a given entity via a specified relationship link.",
-        "tags": ["Relationships"],
+        "tags": [
+          "Relationships"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "link", "in": "path", "required": true, "schema": { "type": "string" }, "description": "Relationship link name" },
-          { "name": "offset", "in": "query", "schema": { "type": "integer" } },
-          { "name": "maxSize", "in": "query", "schema": { "type": "integer" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "link",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Relationship link name"
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "maxSize",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
         ],
         "responses": {
           "200": {
             "description": "Related entity records",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EntityListResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/EntityListResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "linkRelatedEntity",
         "summary": "Link a related entity",
         "description": "Creates a relationship between the entity and another entity via the specified link.",
-        "tags": ["Relationships"],
+        "tags": [
+          "Relationships"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "link", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "link",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "required": true,
@@ -204,28 +535,76 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string", "description": "ID of the entity to link" }
+                  "id": {
+                    "type": "string",
+                    "description": "ID of the entity to link"
+                  }
                 },
-                "required": ["id"]
+                "required": [
+                  "id"
+                ]
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Relationship created" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Relationship created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "delete": {
         "operationId": "unlinkRelatedEntity",
         "summary": "Unlink a related entity",
         "description": "Removes a relationship between the entity and another entity.",
-        "tags": ["Relationships"],
+        "tags": [
+          "Relationships"
+        ],
         "parameters": [
-          { "name": "entityType", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "id", "in": "path", "required": true, "schema": { "type": "string" } },
-          { "name": "link", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "entityType",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "link",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "requestBody": {
           "content": {
@@ -233,16 +612,38 @@
               "schema": {
                 "type": "object",
                 "properties": {
-                  "id": { "type": "string" }
+                  "id": {
+                    "type": "string"
+                  }
                 }
               }
             }
           }
         },
         "responses": {
-          "200": { "description": "Relationship removed" },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Relationship removed"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -265,10 +666,15 @@
       "EntityListResponse": {
         "type": "object",
         "properties": {
-          "total": { "type": "integer", "description": "Total number of records" },
+          "total": {
+            "type": "integer",
+            "description": "Total number of records"
+          },
           "list": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/EntityRecord" }
+            "items": {
+              "$ref": "#/components/schemas/EntityRecord"
+            }
           }
         }
       },
@@ -276,19 +682,38 @@
         "type": "object",
         "description": "A generic entity record. Properties vary by entity type.",
         "properties": {
-          "id": { "type": "string", "description": "Record ID" },
-          "name": { "type": "string", "description": "Record name" },
-          "deleted": { "type": "boolean", "description": "Whether the record is deleted" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "modifiedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string",
+            "description": "Record ID"
+          },
+          "name": {
+            "type": "string",
+            "description": "Record name"
+          },
+          "deleted": {
+            "type": "boolean",
+            "description": "Whether the record is deleted"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "modifiedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         },
         "additionalProperties": true
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "status": { "type": "integer" },
-          "message": { "type": "string" }
+          "status": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }

--- a/apis/openapi/ethereum.org/json-rpc-api/1.0.0/openapi.json
+++ b/apis/openapi/ethereum.org/json-rpc-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Ethereum JSON-RPC API",
     "version": "1.0.0",
     "description": "The Ethereum JSON-RPC API provides access to Ethereum node functionality. All methods are invoked via JSON-RPC 2.0 POST requests to the node endpoint. Common methods include querying blocks, transactions, balances, and sending transactions.",
-    "x-jentic-source-url": "https://ethereum.org/en/developers/docs/apis/json-rpc/"
+    "x-jentic-source-url": "https://ethereum.org/en/developers/docs/apis/json-rpc/",
+    "contact": {}
   },
   "servers": [
     {
@@ -19,7 +20,10 @@
     }
   ],
   "tags": [
-    { "name": "JSON-RPC", "description": "Ethereum JSON-RPC methods" }
+    {
+      "name": "JSON-RPC",
+      "description": "Ethereum JSON-RPC methods"
+    }
   ],
   "paths": {
     "/": {
@@ -27,64 +31,160 @@
         "operationId": "jsonRpcCall",
         "summary": "Make a JSON-RPC call",
         "description": "Sends a JSON-RPC 2.0 request to the Ethereum node. The method field determines which Ethereum API is invoked. Common methods include eth_blockNumber, eth_getBalance, eth_getTransactionByHash, eth_sendRawTransaction, eth_call, eth_estimateGas, eth_getBlockByNumber, eth_getTransactionReceipt, net_version, web3_clientVersion, etc.",
-        "tags": ["JSON-RPC"],
+        "tags": [
+          "JSON-RPC"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/JsonRpcRequest" },
+              "schema": {
+                "$ref": "#/components/schemas/JsonRpcRequest"
+              },
               "examples": {
                 "eth_blockNumber": {
                   "summary": "Get current block number",
-                  "value": { "jsonrpc": "2.0", "method": "eth_blockNumber", "params": [], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_blockNumber",
+                    "params": [],
+                    "id": 1
+                  }
                 },
                 "eth_getBalance": {
                   "summary": "Get ETH balance",
-                  "value": { "jsonrpc": "2.0", "method": "eth_getBalance", "params": ["0xAddress", "latest"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_getBalance",
+                    "params": [
+                      "0xAddress",
+                      "latest"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_getBlockByNumber": {
                   "summary": "Get block by number",
-                  "value": { "jsonrpc": "2.0", "method": "eth_getBlockByNumber", "params": ["0x1b4", true], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_getBlockByNumber",
+                    "params": [
+                      "0x1b4",
+                      true
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_getTransactionByHash": {
                   "summary": "Get transaction by hash",
-                  "value": { "jsonrpc": "2.0", "method": "eth_getTransactionByHash", "params": ["0xTransactionHash"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionByHash",
+                    "params": [
+                      "0xTransactionHash"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_sendRawTransaction": {
                   "summary": "Send raw transaction",
-                  "value": { "jsonrpc": "2.0", "method": "eth_sendRawTransaction", "params": ["0xSignedTxData"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_sendRawTransaction",
+                    "params": [
+                      "0xSignedTxData"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_call": {
                   "summary": "Execute a call (read-only)",
-                  "value": { "jsonrpc": "2.0", "method": "eth_call", "params": [{"to": "0xContractAddress", "data": "0xCallData"}, "latest"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_call",
+                    "params": [
+                      {
+                        "to": "0xContractAddress",
+                        "data": "0xCallData"
+                      },
+                      "latest"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_estimateGas": {
                   "summary": "Estimate gas for a transaction",
-                  "value": { "jsonrpc": "2.0", "method": "eth_estimateGas", "params": [{"from": "0xFromAddress", "to": "0xToAddress", "value": "0x0"}], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_estimateGas",
+                    "params": [
+                      {
+                        "from": "0xFromAddress",
+                        "to": "0xToAddress",
+                        "value": "0x0"
+                      }
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_gasPrice": {
                   "summary": "Get current gas price",
-                  "value": { "jsonrpc": "2.0", "method": "eth_gasPrice", "params": [], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_gasPrice",
+                    "params": [],
+                    "id": 1
+                  }
                 },
                 "eth_getTransactionReceipt": {
                   "summary": "Get transaction receipt",
-                  "value": { "jsonrpc": "2.0", "method": "eth_getTransactionReceipt", "params": ["0xTransactionHash"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionReceipt",
+                    "params": [
+                      "0xTransactionHash"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_getTransactionCount": {
                   "summary": "Get transaction count (nonce)",
-                  "value": { "jsonrpc": "2.0", "method": "eth_getTransactionCount", "params": ["0xAddress", "latest"], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_getTransactionCount",
+                    "params": [
+                      "0xAddress",
+                      "latest"
+                    ],
+                    "id": 1
+                  }
                 },
                 "eth_chainId": {
                   "summary": "Get chain ID",
-                  "value": { "jsonrpc": "2.0", "method": "eth_chainId", "params": [], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "eth_chainId",
+                    "params": [],
+                    "id": 1
+                  }
                 },
                 "net_version": {
                   "summary": "Get network version",
-                  "value": { "jsonrpc": "2.0", "method": "net_version", "params": [], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "net_version",
+                    "params": [],
+                    "id": 1
+                  }
                 },
                 "web3_clientVersion": {
                   "summary": "Get client version",
-                  "value": { "jsonrpc": "2.0", "method": "web3_clientVersion", "params": [], "id": 1 }
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "method": "web3_clientVersion",
+                    "params": [],
+                    "id": 1
+                  }
                 }
               }
             }
@@ -95,7 +195,9 @@
             "description": "JSON-RPC response",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JsonRpcResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcResponse"
+                }
               }
             }
           },
@@ -103,7 +205,9 @@
             "description": "Bad request / invalid JSON-RPC",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/JsonRpcErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/JsonRpcErrorResponse"
+                }
               }
             }
           },
@@ -111,7 +215,9 @@
             "description": "Unauthorized",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ErrorResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
               }
             }
           }
@@ -123,9 +229,19 @@
     "schemas": {
       "JsonRpcRequest": {
         "type": "object",
-        "required": ["jsonrpc", "method", "id"],
+        "required": [
+          "jsonrpc",
+          "method",
+          "id"
+        ],
         "properties": {
-          "jsonrpc": { "type": "string", "enum": ["2.0"], "description": "JSON-RPC version" },
+          "jsonrpc": {
+            "type": "string",
+            "enum": [
+              "2.0"
+            ],
+            "description": "JSON-RPC version"
+          },
           "method": {
             "type": "string",
             "description": "The Ethereum JSON-RPC method to call (e.g. eth_blockNumber, eth_getBalance, eth_call, eth_sendRawTransaction)"
@@ -135,14 +251,24 @@
             "items": {},
             "description": "Parameters for the method call"
           },
-          "id": { "type": "integer", "description": "Request identifier" }
+          "id": {
+            "type": "integer",
+            "description": "Request identifier"
+          }
         }
       },
       "JsonRpcResponse": {
         "type": "object",
         "properties": {
-          "jsonrpc": { "type": "string", "enum": ["2.0"] },
-          "id": { "type": "integer" },
+          "jsonrpc": {
+            "type": "string",
+            "enum": [
+              "2.0"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
           "result": {
             "description": "The result of the RPC call. Type varies by method."
           }
@@ -151,14 +277,29 @@
       "JsonRpcErrorResponse": {
         "type": "object",
         "properties": {
-          "jsonrpc": { "type": "string", "enum": ["2.0"] },
-          "id": { "type": "integer" },
+          "jsonrpc": {
+            "type": "string",
+            "enum": [
+              "2.0"
+            ]
+          },
+          "id": {
+            "type": "integer"
+          },
           "error": {
             "type": "object",
             "properties": {
-              "code": { "type": "integer", "description": "JSON-RPC error code" },
-              "message": { "type": "string", "description": "Error message" },
-              "data": { "description": "Additional error data" }
+              "code": {
+                "type": "integer",
+                "description": "JSON-RPC error code"
+              },
+              "message": {
+                "type": "string",
+                "description": "Error message"
+              },
+              "data": {
+                "description": "Additional error data"
+              }
             }
           }
         }
@@ -166,8 +307,12 @@
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "error": { "type": "string" },
-          "message": { "type": "string" }
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
       }
     }

--- a/apis/openapi/etherpad.org/etherpad-http-api/1.9.0/openapi.json
+++ b/apis/openapi/etherpad.org/etherpad-http-api/1.9.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Etherpad HTTP API",
     "version": "1.9.0",
     "description": "Etherpad is a highly customizable open source online editor providing collaborative editing in real-time. The HTTP API allows programmatic access to manage pads, groups, authors, sessions, and chat.",
-    "x-jentic-source-url": "https://etherpad.org/doc/v2.2.7/api/http_api.html"
+    "x-jentic-source-url": "https://etherpad.org/doc/v2.2.7/api/http_api.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -3318,6 +3319,29 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authors"
+    },
+    {
+      "name": "Chat"
+    },
+    {
+      "name": "Groups"
+    },
+    {
+      "name": "Pad Content"
+    },
+    {
+      "name": "Pad Management"
+    },
+    {
+      "name": "Sessions"
+    },
+    {
+      "name": "System"
     }
   ]
 }

--- a/apis/openapi/etmdb.com/etmdb-rest-api-v1/1.0.0/openapi.json
+++ b/apis/openapi/etmdb.com/etmdb-rest-api-v1/1.0.0/openapi.json
@@ -752,5 +752,61 @@
         "type": "oauth2"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "cinema"
+    },
+    {
+      "name": "cinema-detail"
+    },
+    {
+      "name": "cinema-schedule"
+    },
+    {
+      "name": "cinema-shedule-showtime"
+    },
+    {
+      "name": "company"
+    },
+    {
+      "name": "company-credits"
+    },
+    {
+      "name": "filmography"
+    },
+    {
+      "name": "filmography-type"
+    },
+    {
+      "name": "genre"
+    },
+    {
+      "name": "genre-type"
+    },
+    {
+      "name": "job"
+    },
+    {
+      "name": "media"
+    },
+    {
+      "name": "movie"
+    },
+    {
+      "name": "movie-cast"
+    },
+    {
+      "name": "news"
+    },
+    {
+      "name": "people"
+    },
+    {
+      "name": "showtime"
+    },
+    {
+      "name": "watchlist"
+    }
+  ]
 }

--- a/apis/openapi/etrigue.com/etrigue/1.0.0/openapi.json
+++ b/apis/openapi/etrigue.com/etrigue/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Etrigue API",
     "description": "Demand generation and marketing automation platform API for managing leads, campaigns, and marketing activities.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://int1.etrigue.com/integration/swagger-ui/index.html"
+    "x-jentic-source-url": "https://int1.etrigue.com/integration/swagger-ui/index.html",
+    "contact": {}
   },
   "servers": [
     {
@@ -34,7 +35,9 @@
   "paths": {
     "/leads": {
       "get": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "List leads",
         "operationId": "listLeads",
         "parameters": [
@@ -43,7 +46,12 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["new", "contacted", "qualified", "converted"]
+              "enum": [
+                "new",
+                "contacted",
+                "qualified",
+                "converted"
+              ]
             }
           },
           {
@@ -85,10 +93,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List leads"
       },
       "post": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Create lead",
         "operationId": "createLead",
         "requestBody": {
@@ -112,12 +123,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create lead"
       }
     },
     "/leads/{leadId}": {
       "get": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Get lead",
         "operationId": "getLead",
         "parameters": [
@@ -141,10 +155,13 @@
               }
             }
           }
-        }
+        },
+        "description": "Get lead"
       },
       "put": {
-        "tags": ["Leads"],
+        "tags": [
+          "Leads"
+        ],
         "summary": "Update lead",
         "operationId": "updateLead",
         "parameters": [
@@ -178,12 +195,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Update lead"
       }
     },
     "/campaigns": {
       "get": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "List campaigns",
         "operationId": "listCampaigns",
         "responses": {
@@ -200,10 +220,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List campaigns"
       },
       "post": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "Create campaign",
         "operationId": "createCampaign",
         "requestBody": {
@@ -227,12 +250,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create campaign"
       }
     },
     "/campaigns/{campaignId}": {
       "get": {
-        "tags": ["Campaigns"],
+        "tags": [
+          "Campaigns"
+        ],
         "summary": "Get campaign",
         "operationId": "getCampaign",
         "parameters": [
@@ -256,12 +282,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Get campaign"
       }
     },
     "/activities": {
       "get": {
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "summary": "List activities",
         "operationId": "listActivities",
         "parameters": [
@@ -277,7 +306,12 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["email", "call", "meeting", "note"]
+              "enum": [
+                "email",
+                "call",
+                "meeting",
+                "note"
+              ]
             }
           }
         ],
@@ -295,10 +329,13 @@
               }
             }
           }
-        }
+        },
+        "description": "List activities"
       },
       "post": {
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "summary": "Create activity",
         "operationId": "createActivity",
         "requestBody": {
@@ -322,12 +359,15 @@
               }
             }
           }
-        }
+        },
+        "description": "Create activity"
       }
     },
     "/activities/{activityId}": {
       "get": {
-        "tags": ["Activities"],
+        "tags": [
+          "Activities"
+        ],
         "summary": "Get activity",
         "operationId": "getActivity",
         "parameters": [
@@ -351,18 +391,12 @@
               }
             }
           }
-        }
+        },
+        "description": "Get activity"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-API-Key"
-      }
-    },
     "schemas": {
       "Lead": {
         "type": "object",
@@ -391,7 +425,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["new", "contacted", "qualified", "converted"]
+            "enum": [
+              "new",
+              "contacted",
+              "qualified",
+              "converted"
+            ]
           },
           "score": {
             "type": "integer"
@@ -407,7 +446,9 @@
       },
       "LeadInput": {
         "type": "object",
-        "required": ["email"],
+        "required": [
+          "email"
+        ],
         "properties": {
           "firstName": {
             "type": "string"
@@ -430,7 +471,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["new", "contacted", "qualified", "converted"]
+            "enum": [
+              "new",
+              "contacted",
+              "qualified",
+              "converted"
+            ]
           },
           "source": {
             "type": "string"
@@ -448,11 +494,21 @@
           },
           "type": {
             "type": "string",
-            "enum": ["email", "nurture", "webinar", "event"]
+            "enum": [
+              "email",
+              "nurture",
+              "webinar",
+              "event"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "active", "paused", "completed"]
+            "enum": [
+              "draft",
+              "active",
+              "paused",
+              "completed"
+            ]
           },
           "startDate": {
             "type": "string",
@@ -487,18 +543,31 @@
       },
       "CampaignInput": {
         "type": "object",
-        "required": ["name", "type"],
+        "required": [
+          "name",
+          "type"
+        ],
         "properties": {
           "name": {
             "type": "string"
           },
           "type": {
             "type": "string",
-            "enum": ["email", "nurture", "webinar", "event"]
+            "enum": [
+              "email",
+              "nurture",
+              "webinar",
+              "event"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "active", "paused", "completed"]
+            "enum": [
+              "draft",
+              "active",
+              "paused",
+              "completed"
+            ]
           },
           "startDate": {
             "type": "string",
@@ -521,7 +590,12 @@
           },
           "type": {
             "type": "string",
-            "enum": ["email", "call", "meeting", "note"]
+            "enum": [
+              "email",
+              "call",
+              "meeting",
+              "note"
+            ]
           },
           "subject": {
             "type": "string"
@@ -540,14 +614,22 @@
       },
       "ActivityInput": {
         "type": "object",
-        "required": ["leadId", "type"],
+        "required": [
+          "leadId",
+          "type"
+        ],
         "properties": {
           "leadId": {
             "type": "string"
           },
           "type": {
             "type": "string",
-            "enum": ["email", "call", "meeting", "note"]
+            "enum": [
+              "email",
+              "call",
+              "meeting",
+              "note"
+            ]
           },
           "subject": {
             "type": "string"
@@ -583,38 +665,6 @@
               "message": {
                 "type": "string"
               }
-            }
-          }
-        }
-      }
-    },
-    "responses": {
-      "UnauthorizedError": {
-        "description": "Unauthorized",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            }
-          }
-        }
-      },
-      "NotFoundError": {
-        "description": "Not found",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
-            }
-          }
-        }
-      },
-      "BadRequestError": {
-        "description": "Bad request",
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
             }
           }
         }

--- a/apis/openapi/etrigue.com/etrigue/1.0.0/openapi.json
+++ b/apis/openapi/etrigue.com/etrigue/1.0.0/openapi.json
@@ -652,22 +652,13 @@
             "type": "integer"
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              }
-            }
-          }
-        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   }

--- a/apis/openapi/etrusted.com/reviews-api/1.0.0/openapi.json
+++ b/apis/openapi/etrusted.com/reviews-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "eTrusted (Trusted Shops) API",
     "version": "1.0.0",
     "description": "The eTrusted API by Trusted Shops allows managing channels, event types, reviews, and invites for collecting customer feedback and reviews.",
-    "x-jentic-source-url": "https://developers.etrusted.com/reference/api-introduction"
+    "x-jentic-source-url": "https://developers.etrusted.com/reference/api-introduction",
+    "contact": {}
   },
   "servers": [
     {
@@ -18,10 +19,22 @@
     }
   ],
   "tags": [
-    { "name": "Channels", "description": "Manage channels" },
-    { "name": "EventTypes", "description": "Manage event types" },
-    { "name": "Reviews", "description": "Retrieve and manage reviews" },
-    { "name": "Invites", "description": "Send review invites" }
+    {
+      "name": "Channels",
+      "description": "Manage channels"
+    },
+    {
+      "name": "EventTypes",
+      "description": "Manage event types"
+    },
+    {
+      "name": "Reviews",
+      "description": "Retrieve and manage reviews"
+    },
+    {
+      "name": "Invites",
+      "description": "Send review invites"
+    }
   ],
   "paths": {
     "/channels": {
@@ -29,7 +42,9 @@
         "operationId": "getAllChannels",
         "summary": "Get all channels",
         "description": "Returns a list of all channels for the authenticated account.",
-        "tags": ["Channels"],
+        "tags": [
+          "Channels"
+        ],
         "responses": {
           "200": {
             "description": "List of channels",
@@ -40,15 +55,35 @@
                   "properties": {
                     "items": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/Channel" }
+                      "items": {
+                        "$ref": "#/components/schemas/Channel"
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -57,22 +92,60 @@
         "operationId": "getChannel",
         "summary": "Get a channel by ID",
         "description": "Retrieves a specific channel by its unique identifier.",
-        "tags": ["Channels"],
+        "tags": [
+          "Channels"
+        ],
         "parameters": [
-          { "name": "channelId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "channelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
             "description": "Channel details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Channel" }
+                "schema": {
+                  "$ref": "#/components/schemas/Channel"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -81,9 +154,18 @@
         "operationId": "getAllEventTypes",
         "summary": "Get all event types",
         "description": "Returns a list of all configured event types.",
-        "tags": ["EventTypes"],
+        "tags": [
+          "EventTypes"
+        ],
         "parameters": [
-          { "name": "channelId", "in": "query", "schema": { "type": "string" }, "description": "Filter by channel ID" }
+          {
+            "name": "channelId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by channel ID"
+          }
         ],
         "responses": {
           "200": {
@@ -95,27 +177,51 @@
                   "properties": {
                     "items": {
                       "type": "array",
-                      "items": { "$ref": "#/components/schemas/EventType" }
+                      "items": {
+                        "$ref": "#/components/schemas/EventType"
+                      }
                     }
                   }
                 }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       },
       "post": {
         "operationId": "createEventType",
         "summary": "Create an event type",
         "description": "Creates a new event type for a channel.",
-        "tags": ["EventTypes"],
+        "tags": [
+          "EventTypes"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/CreateEventTypeRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/CreateEventTypeRequest"
+              }
             }
           }
         },
@@ -124,12 +230,32 @@
             "description": "Event type created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EventType" }
+                "schema": {
+                  "$ref": "#/components/schemas/EventType"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -138,22 +264,60 @@
         "operationId": "getEventType",
         "summary": "Get an event type by ID",
         "description": "Retrieves a specific event type.",
-        "tags": ["EventTypes"],
+        "tags": [
+          "EventTypes"
+        ],
         "parameters": [
-          { "name": "eventTypeId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "eventTypeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
             "description": "Event type details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/EventType" }
+                "schema": {
+                  "$ref": "#/components/schemas/EventType"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -162,23 +326,66 @@
         "operationId": "getAllReviews",
         "summary": "Get all reviews",
         "description": "Returns a paginated list of reviews, optionally filtered by channel.",
-        "tags": ["Reviews"],
+        "tags": [
+          "Reviews"
+        ],
         "parameters": [
-          { "name": "channelId", "in": "query", "schema": { "type": "string" }, "description": "Filter by channel ID" },
-          { "name": "count", "in": "query", "schema": { "type": "integer" }, "description": "Number of results per page" },
-          { "name": "cursor", "in": "query", "schema": { "type": "string" }, "description": "Pagination cursor" }
+          {
+            "name": "channelId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Filter by channel ID"
+          },
+          {
+            "name": "count",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Number of results per page"
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            },
+            "description": "Pagination cursor"
+          }
         ],
         "responses": {
           "200": {
             "description": "List of reviews",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/ReviewsResponse" }
+                "schema": {
+                  "$ref": "#/components/schemas/ReviewsResponse"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -187,22 +394,60 @@
         "operationId": "getReview",
         "summary": "Get a review by ID",
         "description": "Retrieves a specific review.",
-        "tags": ["Reviews"],
+        "tags": [
+          "Reviews"
+        ],
         "parameters": [
-          { "name": "reviewId", "in": "path", "required": true, "schema": { "type": "string" } }
+          {
+            "name": "reviewId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
           "200": {
             "description": "Review details",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Review" }
+                "schema": {
+                  "$ref": "#/components/schemas/Review"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "404": { "description": "Not found", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -211,12 +456,16 @@
         "operationId": "createInvite",
         "summary": "Send a review invite",
         "description": "Creates and sends a review invite to a customer.",
-        "tags": ["Invites"],
+        "tags": [
+          "Invites"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
-              "schema": { "$ref": "#/components/schemas/InviteRequest" }
+              "schema": {
+                "$ref": "#/components/schemas/InviteRequest"
+              }
             }
           }
         },
@@ -225,12 +474,32 @@
             "description": "Invite created",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Invite" }
+                "schema": {
+                  "$ref": "#/components/schemas/Invite"
+                }
               }
             }
           },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
@@ -251,33 +520,73 @@
       "Channel": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "address": { "type": "string" },
-          "url": { "type": "string" },
-          "locale": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "address": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          },
+          "locale": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "EventType": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "name": { "type": "string" },
-          "active": { "type": "boolean" },
-          "channelRef": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean"
+          },
+          "channelRef": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "CreateEventTypeRequest": {
         "type": "object",
-        "required": ["name", "channelRef"],
+        "required": [
+          "name",
+          "channelRef"
+        ],
         "properties": {
-          "name": { "type": "string" },
-          "channelRef": { "type": "string" },
-          "active": { "type": "boolean", "default": true }
+          "name": {
+            "type": "string"
+          },
+          "channelRef": {
+            "type": "string"
+          },
+          "active": {
+            "type": "boolean",
+            "default": true
+          }
         }
       },
       "ReviewsResponse": {
@@ -285,83 +594,167 @@
         "properties": {
           "items": {
             "type": "array",
-            "items": { "$ref": "#/components/schemas/Review" }
+            "items": {
+              "$ref": "#/components/schemas/Review"
+            }
           },
-          "paging": { "$ref": "#/components/schemas/Paging" }
+          "paging": {
+            "$ref": "#/components/schemas/Paging"
+          }
         }
       },
       "Review": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "channelRef": { "type": "string" },
-          "eventTypeRef": { "type": "string" },
-          "title": { "type": "string" },
-          "comment": { "type": "string" },
-          "rating": { "type": "integer", "minimum": 1, "maximum": 5 },
-          "status": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" },
-          "updatedAt": { "type": "string", "format": "date-time" },
-          "customer": { "$ref": "#/components/schemas/Customer" },
-          "reply": { "$ref": "#/components/schemas/ReviewReply" }
+          "id": {
+            "type": "string"
+          },
+          "channelRef": {
+            "type": "string"
+          },
+          "eventTypeRef": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "comment": {
+            "type": "string"
+          },
+          "rating": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 5
+          },
+          "status": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
+          "reply": {
+            "$ref": "#/components/schemas/ReviewReply"
+          }
         }
       },
       "ReviewReply": {
         "type": "object",
         "properties": {
-          "comment": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" }
+          "comment": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Customer": {
         "type": "object",
         "properties": {
-          "firstName": { "type": "string" },
-          "lastName": { "type": "string" },
-          "email": { "type": "string" },
-          "reference": { "type": "string" }
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "reference": {
+            "type": "string"
+          }
         }
       },
       "InviteRequest": {
         "type": "object",
-        "required": ["channelRef", "eventTypeRef", "customer"],
+        "required": [
+          "channelRef",
+          "eventTypeRef",
+          "customer"
+        ],
         "properties": {
-          "channelRef": { "type": "string" },
-          "eventTypeRef": { "type": "string" },
-          "customer": { "$ref": "#/components/schemas/Customer" },
+          "channelRef": {
+            "type": "string"
+          },
+          "eventTypeRef": {
+            "type": "string"
+          },
+          "customer": {
+            "$ref": "#/components/schemas/Customer"
+          },
           "transaction": {
             "type": "object",
             "properties": {
-              "reference": { "type": "string" },
-              "date": { "type": "string", "format": "date-time" }
+              "reference": {
+                "type": "string"
+              },
+              "date": {
+                "type": "string",
+                "format": "date-time"
+              }
             }
           },
-          "metadata": { "type": "object", "additionalProperties": { "type": "string" } }
+          "metadata": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
         }
       },
       "Invite": {
         "type": "object",
         "properties": {
-          "id": { "type": "string" },
-          "channelRef": { "type": "string" },
-          "eventTypeRef": { "type": "string" },
-          "status": { "type": "string" },
-          "createdAt": { "type": "string", "format": "date-time" }
+          "id": {
+            "type": "string"
+          },
+          "channelRef": {
+            "type": "string"
+          },
+          "eventTypeRef": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "Paging": {
         "type": "object",
         "properties": {
-          "cursor": { "type": "string" },
-          "count": { "type": "integer" }
+          "cursor": {
+            "type": "string"
+          },
+          "count": {
+            "type": "integer"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "statusCode": { "type": "integer" },
-          "message": { "type": "string" },
-          "error": { "type": "string" }
+          "statusCode": {
+            "type": "integer"
+          },
+          "message": {
+            "type": "string"
+          },
+          "error": {
+            "type": "string"
+          }
         }
       }
     }

--- a/apis/openapi/evalumo.com/evalumo-api/1.0.0/openapi.json
+++ b/apis/openapi/evalumo.com/evalumo-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Evalumo API",
     "version": "1.0.0",
     "description": "Evalumo is a construction project estimation API for managing projects, user information, and exported project data with OAuth2 authentication.",
-    "x-jentic-source-url": "https://evalumo.apidocumentation.com"
+    "x-jentic-source-url": "https://evalumo.apidocumentation.com",
+    "contact": {}
   },
   "servers": [
     {
@@ -44,7 +45,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "Generate authorization token"
       }
     },
     "/token": {
@@ -94,7 +96,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "Exchange authorization code for tokens"
       }
     },
     "/refreshToken": {
@@ -141,7 +144,8 @@
           "400": {
             "description": "Bad request"
           }
-        }
+        },
+        "description": "Refresh access token"
       }
     },
     "/user": {
@@ -173,7 +177,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get user information"
       }
     },
     "/project": {
@@ -220,7 +225,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a new project"
       }
     },
     "/project/{project_id}": {
@@ -265,7 +271,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update project status"
       }
     },
     "/exportedProject": {
@@ -305,31 +312,25 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer"
+        },
+        "description": "List exported projects"
       }
     }
   },
   "security": [
     {
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Projects"
+    },
+    {
+      "name": "Users"
     }
   ]
 }

--- a/apis/openapi/evalumo.com/evalumo-api/1.0.0/openapi.json
+++ b/apis/openapi/evalumo.com/evalumo-api/1.0.0/openapi.json
@@ -332,5 +332,13 @@
     {
       "name": "Users"
     }
-  ]
+  ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
 }

--- a/apis/openapi/evemarketer.com/evemarketer-api/1.0.1/openapi.json
+++ b/apis/openapi/evemarketer.com/evemarketer-api/1.0.1/openapi.json
@@ -97,7 +97,9 @@
         "summary": "XML Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "XML Marketstat",
+        "operationId": "get-marketstat"
       },
       "post": {
         "consumes": [
@@ -164,7 +166,9 @@
         "summary": "XML Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "XML Marketstat",
+        "operationId": "post-marketstat"
       }
     },
     "/marketstat/json": {
@@ -236,7 +240,9 @@
         "summary": "JSON Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "JSON Marketstat",
+        "operationId": "get-marketstat-json"
       },
       "post": {
         "parameters": [
@@ -303,7 +309,9 @@
         "summary": "JSON Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "JSON Marketstat",
+        "operationId": "post-marketstat-json"
       }
     }
   },

--- a/apis/openapi/evemarketer.com/evemarketer-marketstat-api/1.0.1/openapi.json
+++ b/apis/openapi/evemarketer.com/evemarketer-marketstat-api/1.0.1/openapi.json
@@ -98,7 +98,9 @@
         "summary": "XML Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "XML Marketstat",
+        "operationId": "get-marketstat"
       },
       "post": {
         "consumes": [
@@ -165,7 +167,9 @@
         "summary": "XML Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "XML Marketstat",
+        "operationId": "post-marketstat"
       }
     },
     "/marketstat/json": {
@@ -237,7 +241,9 @@
         "summary": "JSON Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "JSON Marketstat",
+        "operationId": "get-marketstat-json"
       },
       "post": {
         "parameters": [
@@ -304,7 +310,9 @@
         "summary": "JSON Marketstat",
         "tags": [
           "marketstat"
-        ]
+        ],
+        "description": "JSON Marketstat",
+        "operationId": "post-marketstat-json"
       }
     }
   },

--- a/apis/openapi/eventcinch.com/e-cinch-api/1.0.0/openapi.json
+++ b/apis/openapi/eventcinch.com/e-cinch-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "E-cinch API",
     "description": "Event management API for E-cinch platform providing cart and user validation functionality for Zapier integrations",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://eventcinch.com/zap/apidocs"
+    "x-jentic-source-url": "https://eventcinch.com/zap/apidocs",
+    "contact": {}
   },
   "servers": [
     {
@@ -98,7 +99,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       }
     },
     "/zap/newcart": {
@@ -161,7 +165,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       },
       "delete": {
         "summary": "Unsubscribe from New Cart Trigger",
@@ -209,7 +216,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       }
     },
     "/zap/updatecart": {
@@ -249,7 +259,10 @@
           "200": {
             "description": "Subscription successful"
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       },
       "delete": {
         "summary": "Unsubscribe from Update Cart Trigger",
@@ -287,7 +300,10 @@
           "200": {
             "description": "Unsubscription successful"
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       }
     },
     "/zap/carts/new": {
@@ -328,7 +344,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       }
     },
     "/zap/carts/fresh": {
@@ -369,7 +388,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zap"
+        ]
       }
     }
   },
@@ -432,5 +454,10 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "zap"
+    }
+  ]
 }

--- a/apis/openapi/eventleaf.com/eventleaf-api/v1/openapi.json
+++ b/apis/openapi/eventleaf.com/eventleaf-api/v1/openapi.json
@@ -3,7 +3,9 @@
   "info": {
     "version": "v1",
     "title": "Eventleaf API",
-    "x-jentic-source-url": "https://api.eventleaf.com/swagger/docs/v1"
+    "x-jentic-source-url": "https://api.eventleaf.com/swagger/docs/v1",
+    "contact": {},
+    "description": "Eventleaf API"
   },
   "host": "api.eventleaf.com",
   "schemes": [
@@ -78,7 +80,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get the attendance logs for an event (session attendance not included)."
       }
     },
     "/api/v1/events/{eventId}/attendance/{sessionId}": {
@@ -157,7 +160,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get the attendance logs for a session"
       }
     },
     "/api/v1/contactlists": {
@@ -220,7 +224,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get all contact lists."
       },
       "post": {
         "tags": [
@@ -269,7 +274,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Add new contact list."
       }
     },
     "/api/v1/contactlists/{contactListId}": {
@@ -313,7 +319,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get contact list."
       },
       "delete": {
         "tags": [
@@ -355,7 +362,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Delete contact list."
       },
       "patch": {
         "tags": [
@@ -412,7 +420,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Rename contact list."
       }
     },
     "/api/v1/contactlists/{contactListId}/contacts": {
@@ -483,7 +492,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get contacts on contact list."
       },
       "post": {
         "tags": [
@@ -543,7 +553,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Add one or more contacts."
       }
     },
     "/api/v1/contactlists/{contactListId}/contacts/search": {
@@ -621,7 +632,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for contacts."
       }
     },
     "/api/v1/contactlists/{contactListId}/contacts/{contactId}": {
@@ -673,7 +685,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get contact."
       },
       "delete": {
         "tags": [
@@ -723,7 +736,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Delete contact."
       },
       "patch": {
         "tags": [
@@ -788,7 +802,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Update contact."
       }
     },
     "/api/v1/contactlists/{contactListId}/contacts/contactform": {
@@ -833,7 +848,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get contact form caption / internal name pairs."
       }
     },
     "/api/v1/events": {
@@ -896,7 +912,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get all published events."
       }
     },
     "/api/v1/events/{eventId}": {
@@ -940,7 +957,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get event."
       }
     },
     "/api/v1/orders/search": {
@@ -1019,7 +1037,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for orders."
       }
     },
     "/api/v1/orders/{orderId}": {
@@ -1071,7 +1090,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get order."
       }
     },
     "/api/v1/orders/{orderId}/items": {
@@ -1142,7 +1162,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get order items."
       }
     },
     "/api/v1/orders/items/search": {
@@ -1221,7 +1242,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for order items."
       }
     },
     "/api/v1/events/{eventId}/registrationoptiongroups": {
@@ -1284,7 +1306,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get registration option groups for an event."
       }
     },
     "/api/v1/events/{eventId}/registrationoptiongroups/{groupId}": {
@@ -1355,7 +1378,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get registration options for an option group."
       }
     },
     "/api/v1/events/{eventId}/registrations/registrationform": {
@@ -1402,7 +1426,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Get registration form caption / internal name pairs"
       }
     },
     "/api/v1/events/{eventId}/registrations": {
@@ -1473,7 +1498,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Get registrations for an event"
       },
       "post": {
         "tags": [
@@ -1530,7 +1556,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Add new registration"
       }
     },
     "/api/v1/events/{eventId}/registrations/{registrationId}": {
@@ -1582,7 +1609,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Get registration"
       },
       "patch": {
         "tags": [
@@ -1647,7 +1675,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Update registration"
       }
     },
     "/api/v1/events/{eventId}/registrations/search": {
@@ -1725,7 +1754,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for registrations"
       }
     },
     "/api/v1/events/{eventId}/registrations/{registrationId}/options": {
@@ -1796,7 +1826,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get registration options for a registration"
       },
       "put": {
         "tags": [
@@ -1861,7 +1892,8 @@
           "400": {
             "description": "Request not valid"
           }
-        }
+        },
+        "description": "Adds or replaces registration options for a registration"
       }
     },
     "/api/v1/events/{eventId}/registrationtypes": {
@@ -1924,7 +1956,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get registration option groups for an event."
       }
     },
     "/api/v1/events/{eventId}/registrationtypes/{registrationTypeId}": {
@@ -1979,7 +2012,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get registration option groups for an event."
       }
     },
     "/api/v1/events/{eventId}/sessions": {
@@ -2042,7 +2076,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get sessions for an event."
       }
     },
     "/api/v1/events/{eventId}/sessions/search": {
@@ -2120,7 +2155,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for sessions"
       }
     },
     "/api/v1/events/{eventId}/sessions/{sessionId}": {
@@ -2172,7 +2208,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get a session."
       }
     },
     "/api/v1/transactions": {
@@ -2235,7 +2272,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get all transactions."
       }
     },
     "/api/v1/transactions/search": {
@@ -2314,7 +2352,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Search for transactions."
       }
     },
     "/api/v1/transactions/{transactionId}": {
@@ -2361,7 +2400,8 @@
           "400": {
             "description": "Request not valid."
           }
-        }
+        },
+        "description": "Get a transaction."
       }
     }
   },
@@ -3023,5 +3063,37 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Attendence"
+    },
+    {
+      "name": "ContactLists"
+    },
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Events"
+    },
+    {
+      "name": "Orders"
+    },
+    {
+      "name": "RegistrationOptions"
+    },
+    {
+      "name": "RegistrationTypes"
+    },
+    {
+      "name": "Registrations"
+    },
+    {
+      "name": "Sessions"
+    },
+    {
+      "name": "Transactions"
+    }
+  ]
 }

--- a/apis/openapi/eventmaker.io/eventmaker/1.0.0/openapi.json
+++ b/apis/openapi/eventmaker.io/eventmaker/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Eventmaker API",
     "version": "1.0.0",
     "description": "Event management and registration API (Documentation URL not found)",
-    "x-jentic-source-url": "http://developers.eventmaker.io/api/v1/"
+    "x-jentic-source-url": "http://developers.eventmaker.io/api/v1/",
+    "contact": {}
   },
   "servers": [
     {
@@ -47,7 +48,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "events"
+        ]
       },
       "post": {
         "summary": "Create Event",
@@ -74,7 +78,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "events"
+        ]
       }
     },
     "/events/{id}": {
@@ -103,7 +110,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "events"
+        ]
       },
       "put": {
         "summary": "Update Event",
@@ -133,7 +143,10 @@
           "200": {
             "description": "OK"
           }
-        }
+        },
+        "tags": [
+          "events"
+        ]
       }
     },
     "/registrations": {
@@ -164,7 +177,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "registrations"
+        ]
       },
       "post": {
         "summary": "Create Registration",
@@ -191,7 +207,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "registrations"
+        ]
       }
     },
     "/registrations/{id}": {
@@ -220,7 +239,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "registrations"
+        ]
       },
       "delete": {
         "summary": "Cancel Registration",
@@ -240,7 +262,10 @@
           "204": {
             "description": "No Content"
           }
-        }
+        },
+        "tags": [
+          "registrations"
+        ]
       }
     },
     "/attendees": {
@@ -272,7 +297,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "attendees"
+        ]
       }
     }
   },
@@ -333,7 +361,11 @@
       },
       "EventRequest": {
         "type": "object",
-        "required": ["name", "start_date", "end_date"],
+        "required": [
+          "name",
+          "start_date",
+          "end_date"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -383,7 +415,11 @@
       },
       "RegistrationRequest": {
         "type": "object",
-        "required": ["event_id", "attendee_email", "attendee_name"],
+        "required": [
+          "event_id",
+          "attendee_email",
+          "attendee_name"
+        ],
         "properties": {
           "event_id": {
             "type": "string"
@@ -426,5 +462,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "attendees"
+    },
+    {
+      "name": "events"
+    },
+    {
+      "name": "registrations"
+    }
+  ]
 }

--- a/apis/openapi/eventscase.com/eventscase/2.0.0/openapi.json
+++ b/apis/openapi/eventscase.com/eventscase/2.0.0/openapi.json
@@ -4,280 +4,804 @@
     "title": "Eventscase API",
     "description": "Event management platform API for managing events, attendees, schedules, and registrations.",
     "version": "2.0.0",
-    "x-jentic-source-url": "https://zappierdemo.eventscase.com/api/v2/doc"
+    "x-jentic-source-url": "https://zappierdemo.eventscase.com/api/v2/doc",
+    "contact": {}
   },
-  "servers": [{"url": "https://api.eventscase.com/v2"}],
-  "security": [{"ApiKeyAuth": []}],
+  "servers": [
+    {
+      "url": "https://api.eventscase.com/v2"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
   "tags": [
-    {"name": "Events", "description": "Event management"},
-    {"name": "Attendees", "description": "Attendee management"},
-    {"name": "Sessions", "description": "Session management"},
-    {"name": "Registrations", "description": "Registration management"}
+    {
+      "name": "Events",
+      "description": "Event management"
+    },
+    {
+      "name": "Attendees",
+      "description": "Attendee management"
+    },
+    {
+      "name": "Sessions",
+      "description": "Session management"
+    },
+    {
+      "name": "Registrations",
+      "description": "Registration management"
+    }
   ],
   "paths": {
     "/events": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "List events",
         "operationId": "listEvents",
         "parameters": [
-          {"name": "status", "in": "query", "schema": {"type": "string", "enum": ["upcoming", "ongoing", "past"]}},
-          {"name": "page", "in": "query", "schema": {"type": "integer", "default": 1}}
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "upcoming",
+                "ongoing",
+                "past"
+              ]
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"type": "object", "properties": {"data": {"type": "array", "items": {"$ref": "#/components/schemas/Event"}}, "pagination": {"$ref": "#/components/schemas/Pagination"}}}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/Event"
+                      }
+                    },
+                    "pagination": {
+                      "$ref": "#/components/schemas/Pagination"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "List events"
       },
       "post": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Create event",
         "operationId": "createEvent",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/EventInput"}}}},
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Event created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Event"}}}}
-        }
+          "201": {
+            "description": "Event created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create event"
       }
     },
     "/events/{eventId}": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Get event",
         "operationId": "getEvent",
-        "parameters": [{"name": "eventId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Event"}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get event"
       },
       "put": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Update event",
         "operationId": "updateEvent",
-        "parameters": [{"name": "eventId", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/EventInput"}}}},
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Event updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Event"}}}}
-        }
+          "200": {
+            "description": "Event updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update event"
       }
     },
     "/attendees": {
       "get": {
-        "tags": ["Attendees"],
+        "tags": [
+          "Attendees"
+        ],
         "summary": "List attendees",
         "operationId": "listAttendees",
         "parameters": [
-          {"name": "eventId", "in": "query", "schema": {"type": "string"}},
-          {"name": "status", "in": "query", "schema": {"type": "string", "enum": ["registered", "confirmed", "cancelled"]}}
+          {
+            "name": "eventId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "registered",
+                "confirmed",
+                "cancelled"
+              ]
+            }
+          }
         ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Attendee"}}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Attendee"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "List attendees"
       },
       "post": {
-        "tags": ["Attendees"],
+        "tags": [
+          "Attendees"
+        ],
         "summary": "Create attendee",
         "operationId": "createAttendee",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AttendeeInput"}}}},
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendeeInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Attendee created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Attendee"}}}}
-        }
+          "201": {
+            "description": "Attendee created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendee"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create attendee"
       }
     },
     "/attendees/{attendeeId}": {
       "get": {
-        "tags": ["Attendees"],
+        "tags": [
+          "Attendees"
+        ],
         "summary": "Get attendee",
         "operationId": "getAttendee",
-        "parameters": [{"name": "attendeeId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "parameters": [
+          {
+            "name": "attendeeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Attendee"}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendee"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get attendee"
       },
       "put": {
-        "tags": ["Attendees"],
+        "tags": [
+          "Attendees"
+        ],
         "summary": "Update attendee",
         "operationId": "updateAttendee",
-        "parameters": [{"name": "attendeeId", "in": "path", "required": true, "schema": {"type": "string"}}],
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/AttendeeInput"}}}},
+        "parameters": [
+          {
+            "name": "attendeeId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendeeInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "200": {"description": "Attendee updated", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Attendee"}}}}
-        }
+          "200": {
+            "description": "Attendee updated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Attendee"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update attendee"
       }
     },
     "/sessions": {
       "get": {
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "List sessions",
         "operationId": "listSessions",
-        "parameters": [{"name": "eventId", "in": "query", "schema": {"type": "string"}}],
+        "parameters": [
+          {
+            "name": "eventId",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"type": "array", "items": {"$ref": "#/components/schemas/Session"}}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Session"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "description": "List sessions"
       },
       "post": {
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Create session",
         "operationId": "createSession",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/SessionInput"}}}},
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SessionInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Session created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Session"}}}}
-        }
+          "201": {
+            "description": "Session created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create session"
       }
     },
     "/sessions/{sessionId}": {
       "get": {
-        "tags": ["Sessions"],
+        "tags": [
+          "Sessions"
+        ],
         "summary": "Get session",
         "operationId": "getSession",
-        "parameters": [{"name": "sessionId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "parameters": [
+          {
+            "name": "sessionId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Session"}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Session"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get session"
       }
     },
     "/registrations": {
       "post": {
-        "tags": ["Registrations"],
+        "tags": [
+          "Registrations"
+        ],
         "summary": "Create registration",
         "operationId": "createRegistration",
-        "requestBody": {"required": true, "content": {"application/json": {"schema": {"$ref": "#/components/schemas/RegistrationInput"}}}},
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RegistrationInput"
+              }
+            }
+          }
+        },
         "responses": {
-          "201": {"description": "Registration created", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Registration"}}}}
-        }
+          "201": {
+            "description": "Registration created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Registration"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create registration"
       }
     },
     "/registrations/{registrationId}": {
       "get": {
-        "tags": ["Registrations"],
+        "tags": [
+          "Registrations"
+        ],
         "summary": "Get registration",
         "operationId": "getRegistration",
-        "parameters": [{"name": "registrationId", "in": "path", "required": true, "schema": {"type": "string"}}],
+        "parameters": [
+          {
+            "name": "registrationId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
         "responses": {
-          "200": {"description": "Success", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/Registration"}}}}
-        }
+          "200": {
+            "description": "Success",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Registration"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get registration"
       }
     }
   },
   "components": {
-    "securitySchemes": {"ApiKeyAuth": {"type": "apiKey", "in": "header", "name": "X-API-Key"}},
     "schemas": {
       "Event": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "startDate": {"type": "string", "format": "date-time"},
-          "endDate": {"type": "string", "format": "date-time"},
-          "location": {"type": "string"},
-          "capacity": {"type": "integer"},
-          "status": {"type": "string", "enum": ["upcoming", "ongoing", "past"]},
-          "attendeeCount": {"type": "integer"},
-          "createdAt": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": "string"
+          },
+          "capacity": {
+            "type": "integer"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "upcoming",
+              "ongoing",
+              "past"
+            ]
+          },
+          "attendeeCount": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "EventInput": {
         "type": "object",
-        "required": ["name", "startDate", "endDate"],
+        "required": [
+          "name",
+          "startDate",
+          "endDate"
+        ],
         "properties": {
-          "name": {"type": "string"},
-          "description": {"type": "string"},
-          "startDate": {"type": "string", "format": "date-time"},
-          "endDate": {"type": "string", "format": "date-time"},
-          "location": {"type": "string"},
-          "capacity": {"type": "integer"}
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": "string"
+          },
+          "capacity": {
+            "type": "integer"
+          }
         }
       },
       "Attendee": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "eventId": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "status": {"type": "string", "enum": ["registered", "confirmed", "cancelled"]},
-          "checkInTime": {"type": "string", "format": "date-time"},
-          "createdAt": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "registered",
+              "confirmed",
+              "cancelled"
+            ]
+          },
+          "checkInTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "AttendeeInput": {
         "type": "object",
-        "required": ["eventId", "firstName", "lastName", "email"],
+        "required": [
+          "eventId",
+          "firstName",
+          "lastName",
+          "email"
+        ],
         "properties": {
-          "eventId": {"type": "string"},
-          "firstName": {"type": "string"},
-          "lastName": {"type": "string"},
-          "email": {"type": "string", "format": "email"},
-          "company": {"type": "string"},
-          "status": {"type": "string", "enum": ["registered", "confirmed", "cancelled"]}
+          "eventId": {
+            "type": "string"
+          },
+          "firstName": {
+            "type": "string"
+          },
+          "lastName": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "company": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "registered",
+              "confirmed",
+              "cancelled"
+            ]
+          }
         }
       },
       "Session": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "eventId": {"type": "string"},
-          "title": {"type": "string"},
-          "description": {"type": "string"},
-          "speaker": {"type": "string"},
-          "startTime": {"type": "string", "format": "date-time"},
-          "endTime": {"type": "string", "format": "date-time"},
-          "location": {"type": "string"},
-          "capacity": {"type": "integer"},
-          "createdAt": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "speaker": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": "string"
+          },
+          "capacity": {
+            "type": "integer"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "SessionInput": {
         "type": "object",
-        "required": ["eventId", "title", "startTime", "endTime"],
+        "required": [
+          "eventId",
+          "title",
+          "startTime",
+          "endTime"
+        ],
         "properties": {
-          "eventId": {"type": "string"},
-          "title": {"type": "string"},
-          "description": {"type": "string"},
-          "speaker": {"type": "string"},
-          "startTime": {"type": "string", "format": "date-time"},
-          "endTime": {"type": "string", "format": "date-time"},
-          "location": {"type": "string"},
-          "capacity": {"type": "integer"}
+          "eventId": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "speaker": {
+            "type": "string"
+          },
+          "startTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "location": {
+            "type": "string"
+          },
+          "capacity": {
+            "type": "integer"
+          }
         }
       },
       "Registration": {
         "type": "object",
         "properties": {
-          "id": {"type": "string"},
-          "eventId": {"type": "string"},
-          "attendeeId": {"type": "string"},
-          "status": {"type": "string", "enum": ["pending", "confirmed", "cancelled"]},
-          "registrationDate": {"type": "string", "format": "date-time"},
-          "createdAt": {"type": "string", "format": "date-time"}
+          "id": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "attendeeId": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "pending",
+              "confirmed",
+              "cancelled"
+            ]
+          },
+          "registrationDate": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          }
         }
       },
       "RegistrationInput": {
         "type": "object",
-        "required": ["eventId", "attendeeId"],
+        "required": [
+          "eventId",
+          "attendeeId"
+        ],
         "properties": {
-          "eventId": {"type": "string"},
-          "attendeeId": {"type": "string"}
+          "eventId": {
+            "type": "string"
+          },
+          "attendeeId": {
+            "type": "string"
+          }
         }
       },
       "Pagination": {
         "type": "object",
         "properties": {
-          "page": {"type": "integer"},
-          "limit": {"type": "integer"},
-          "total": {"type": "integer"}
+          "page": {
+            "type": "integer"
+          },
+          "limit": {
+            "type": "integer"
+          },
+          "total": {
+            "type": "integer"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
-        "properties": {"error": {"type": "object", "properties": {"code": {"type": "string"}, "message": {"type": "string"}}}}
+        "properties": {
+          "error": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "string"
+              },
+              "message": {
+                "type": "string"
+              }
+            }
+          }
+        }
       }
-    },
-    "responses": {
-      "UnauthorizedError": {"description": "Unauthorized", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-      "NotFoundError": {"description": "Not found", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}},
-      "BadRequestError": {"description": "Bad request", "content": {"application/json": {"schema": {"$ref": "#/components/schemas/ErrorResponse"}}}}
     }
   }
 }

--- a/apis/openapi/eventscase.com/eventscase/2.0.0/openapi.json
+++ b/apis/openapi/eventscase.com/eventscase/2.0.0/openapi.json
@@ -785,22 +785,13 @@
             "type": "integer"
           }
         }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "object",
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "message": {
-                "type": "string"
-              }
-            }
-          }
-        }
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   }

--- a/apis/openapi/everflow.io/everflow-affiliate-api/1.0.0/openapi.json
+++ b/apis/openapi/everflow.io/everflow-affiliate-api/1.0.0/openapi.json
@@ -426,6 +426,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   },
   "security": [

--- a/apis/openapi/everflow.io/everflow-affiliate-api/1.0.0/openapi.json
+++ b/apis/openapi/everflow.io/everflow-affiliate-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Everflow Affiliate API",
     "version": "1.0.0",
     "description": "Everflow affiliate/partner marketing API for managing offers, clicks, conversions, and reporting.",
-    "x-jentic-source-url": "https://developers.everflow.io/docs/affiliate/"
+    "x-jentic-source-url": "https://developers.everflow.io/docs/affiliate/",
+    "contact": {}
   },
   "servers": [
     {
@@ -424,79 +425,26 @@
             "type": "string"
           }
         }
-      },
-      "Click": {
-        "type": "object",
-        "properties": {
-          "click_id": {
-            "type": "string"
-          },
-          "offer_id": {
-            "type": "integer"
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "ip_address": {
-            "type": "string"
-          }
-        }
-      },
-      "Conversion": {
-        "type": "object",
-        "properties": {
-          "conversion_id": {
-            "type": "string"
-          },
-          "offer_id": {
-            "type": "integer"
-          },
-          "revenue": {
-            "type": "number"
-          },
-          "payout": {
-            "type": "number"
-          },
-          "timestamp": {
-            "type": "string",
-            "format": "date-time"
-          }
-        }
-      },
-      "ReportRow": {
-        "type": "object",
-        "properties": {
-          "date": {
-            "type": "string",
-            "format": "date"
-          },
-          "clicks": {
-            "type": "integer"
-          },
-          "conversions": {
-            "type": "integer"
-          },
-          "revenue": {
-            "type": "number"
-          },
-          "payout": {
-            "type": "number"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Eflow-API-Key"
       }
     }
   },
   "security": [
     {
       "ApiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Creatives"
+    },
+    {
+      "name": "Offers"
+    },
+    {
+      "name": "Postbacks"
+    },
+    {
+      "name": "Reporting"
     }
   ]
 }

--- a/apis/openapi/everhour.com/time-tracking-api/1.2.0/openapi.json
+++ b/apis/openapi/everhour.com/time-tracking-api/1.2.0/openapi.json
@@ -1580,6 +1580,13 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "apiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
     }
   }
 }

--- a/apis/openapi/everhour.com/time-tracking-api/1.2.0/openapi.json
+++ b/apis/openapi/everhour.com/time-tracking-api/1.2.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Everhour Time Tracking API",
     "version": "1.2.0",
     "description": "Everhour is a time tracking tool. The API provides access to clients, invoices, expenses, projects, tasks, time records, timers, timecards, timesheets, users, and resource planning.",
-    "x-jentic-source-url": "https://everhour.docs.apiary.io/"
+    "x-jentic-source-url": "https://everhour.docs.apiary.io/",
+    "contact": {}
   },
   "servers": [
     {
@@ -87,7 +88,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get all clients"
       },
       "post": {
         "operationId": "createClient",
@@ -122,7 +124,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a client"
       }
     },
     "/clients/{client_id}": {
@@ -159,7 +162,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a client"
       },
       "put": {
         "operationId": "updateClient",
@@ -204,7 +208,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a client"
       }
     },
     "/clients/{client_id}/budget": {
@@ -244,7 +249,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update client budget"
       },
       "delete": {
         "operationId": "deleteClientBudget",
@@ -269,7 +275,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete client budget"
       }
     },
     "/invoices": {
@@ -296,7 +303,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get all invoices"
       }
     },
     "/invoices/{invoice_id}": {
@@ -330,7 +338,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get an invoice"
       },
       "put": {
         "operationId": "updateInvoice",
@@ -365,7 +374,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an invoice"
       },
       "delete": {
         "operationId": "deleteInvoice",
@@ -390,7 +400,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an invoice"
       }
     },
     "/clients/{client_id}/invoices": {
@@ -427,7 +438,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an invoice for a client"
       }
     },
     "/invoices/{invoice_id}/{status}": {
@@ -467,7 +479,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Mark invoice as draft/sent/paid"
       }
     },
     "/expenses": {
@@ -484,7 +497,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get all expenses"
       },
       "post": {
         "operationId": "createExpense",
@@ -509,7 +523,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create an expense"
       }
     },
     "/expenses/{expense_id}": {
@@ -546,7 +561,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update an expense"
       },
       "delete": {
         "operationId": "deleteExpense",
@@ -571,7 +587,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete an expense"
       }
     },
     "/projects": {
@@ -621,7 +638,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get all projects"
       },
       "post": {
         "operationId": "createProject",
@@ -646,7 +664,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a project"
       }
     },
     "/projects/{project_id}": {
@@ -680,7 +699,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a project"
       },
       "put": {
         "operationId": "updateProject",
@@ -715,7 +735,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a project"
       },
       "delete": {
         "operationId": "deleteProject",
@@ -740,7 +761,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a project"
       }
     },
     "/projects/{project_id}/tasks": {
@@ -789,7 +811,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get project tasks"
       },
       "post": {
         "operationId": "createTask",
@@ -824,7 +847,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a task"
       }
     },
     "/tasks/{task_id}": {
@@ -851,7 +875,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get a task"
       },
       "put": {
         "operationId": "updateTask",
@@ -886,7 +911,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a task"
       },
       "delete": {
         "operationId": "deleteTask",
@@ -911,7 +937,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a task"
       }
     },
     "/tasks/search": {
@@ -951,7 +978,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Search tasks"
       }
     },
     "/time": {
@@ -978,7 +1006,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Add a time record"
       }
     },
     "/time/{time_id}": {
@@ -1015,7 +1044,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a time record"
       },
       "delete": {
         "operationId": "deleteTimeRecord",
@@ -1040,7 +1070,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a time record"
       }
     },
     "/timers": {
@@ -1067,7 +1098,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Start a timer"
       }
     },
     "/timers/current": {
@@ -1084,7 +1116,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get running timer"
       },
       "delete": {
         "operationId": "stopTimer",
@@ -1099,7 +1132,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Stop running timer"
       }
     },
     "/team/timers": {
@@ -1116,7 +1150,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get all team timers"
       }
     },
     "/users/{user_id}/timecards/clock-in": {
@@ -1143,7 +1178,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Clock in"
       }
     },
     "/users/{user_id}/timecards/clock-out": {
@@ -1170,7 +1206,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Clock out"
       }
     },
     "/resource-planner/assignments": {
@@ -1216,7 +1253,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get schedule assignments"
       },
       "post": {
         "operationId": "createAssignment",
@@ -1231,7 +1269,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create assignment"
       }
     },
     "/projects/{project_id}/billing": {
@@ -1268,7 +1307,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update project billing/budget"
       }
     },
     "/projects/{project_id}/sync": {
@@ -1296,19 +1336,12 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Sync integration project to Everhour"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "apiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "X-Api-Key",
-        "description": "API key from your Everhour profile"
-      }
-    },
     "schemas": {
       "Client": {
         "type": "object",
@@ -1543,17 +1576,6 @@
             "type": "string"
           },
           "comment": {
-            "type": "string"
-          }
-        }
-      },
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "integer"
-          },
-          "message": {
             "type": "string"
           }
         }

--- a/apis/openapi/everlytic.com/everlytic-api/1.0.0/openapi.json
+++ b/apis/openapi/everlytic.com/everlytic-api/1.0.0/openapi.json
@@ -496,5 +496,13 @@
     {
       "name": "Transactional"
     }
-  ]
+  ],
+  "components": {
+    "securitySchemes": {
+      "basicAuth": {
+        "type": "http",
+        "scheme": "basic"
+      }
+    }
+  }
 }

--- a/apis/openapi/everlytic.com/everlytic-api/1.0.0/openapi.json
+++ b/apis/openapi/everlytic.com/everlytic-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Everlytic API",
     "version": "1.0.0",
     "description": "Everlytic API for email marketing, SMS, and push notification automation. Manage contacts, lists, campaigns, and transactional messages.",
-    "x-jentic-source-url": "https://help.everlytic.com/knowledgebase-category/api-documentation/"
+    "x-jentic-source-url": "https://help.everlytic.com/knowledgebase-category/api-documentation/",
+    "contact": {}
   },
   "servers": [
     {
@@ -51,7 +52,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List contacts"
       },
       "post": {
         "operationId": "createContact",
@@ -87,7 +89,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create contact"
       }
     },
     "/contacts/{id}": {
@@ -117,7 +120,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get contact"
       },
       "put": {
         "operationId": "updateContact",
@@ -155,7 +159,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update contact"
       },
       "delete": {
         "operationId": "deleteContact",
@@ -183,7 +188,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete contact"
       }
     },
     "/lists": {
@@ -203,7 +209,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List mailing lists"
       },
       "post": {
         "operationId": "createList",
@@ -236,7 +243,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create mailing list"
       }
     },
     "/lists/{id}": {
@@ -266,7 +274,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get mailing list"
       },
       "put": {
         "operationId": "updateList",
@@ -304,7 +313,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update mailing list"
       },
       "delete": {
         "operationId": "deleteList",
@@ -332,7 +342,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete mailing list"
       }
     },
     "/messages": {
@@ -352,7 +363,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List messages/campaigns"
       },
       "post": {
         "operationId": "createMessage",
@@ -380,7 +392,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create message/campaign"
       }
     },
     "/transactional/email": {
@@ -421,7 +434,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Send transactional email"
       }
     },
     "/transactional/sms": {
@@ -459,34 +473,28 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "status": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "securitySchemes": {
-      "basicAuth": {
-        "type": "http",
-        "scheme": "basic"
+        },
+        "description": "Send transactional SMS"
       }
     }
   },
   "security": [
     {
       "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Contacts"
+    },
+    {
+      "name": "Lists"
+    },
+    {
+      "name": "Messages"
+    },
+    {
+      "name": "Transactional"
     }
   ]
 }

--- a/apis/openapi/eversign.com/xodo-sign/1.0.0/openapi.json
+++ b/apis/openapi/eversign.com/xodo-sign/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Xodo Sign (eversign) API",
     "version": "1.0.0",
     "description": "The Xodo Sign API (formerly eversign) is a lightweight RESTful JSON API for e-signature workflows. Create documents, send for signature, manage templates, and more.",
-    "x-jentic-source-url": "https://eversign.com/api/documentation"
+    "x-jentic-source-url": "https://eversign.com/api/documentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -151,7 +152,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Documents"
       },
       "post": {
         "operationId": "createDocument",
@@ -286,7 +288,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get Document"
       },
       "delete": {
         "operationId": "deleteDocument",
@@ -351,7 +354,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete Document"
       }
     },
     "/document/{document_hash}/cancel": {
@@ -418,7 +422,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Cancel Document"
       }
     },
     "/document/{document_hash}/download_final_pdf": {
@@ -486,7 +491,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Download Final PDF"
       }
     },
     "/document/{document_hash}/send_reminder": {
@@ -616,7 +622,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Templates"
       }
     }
   },
@@ -831,5 +838,16 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Business"
+    },
+    {
+      "name": "Documents"
+    },
+    {
+      "name": "Templates"
+    }
+  ]
 }

--- a/apis/openapi/evervault.com/encryption-api/1.0.0/openapi.json
+++ b/apis/openapi/evervault.com/encryption-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Evervault Encryption API",
     "version": "1.0.0",
     "description": "Evervault provides encryption-as-a-service. The API allows encrypting data, decrypting data, running Evervault Functions (serverless encryption), creating tokens for client-side decryption, and managing cages/functions.",
-    "x-jentic-source-url": "https://docs.evervault.com/"
+    "x-jentic-source-url": "https://docs.evervault.com/",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/evervault.com/evervault-api/1.0.0/openapi.json
+++ b/apis/openapi/evervault.com/evervault-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Evervault API",
     "version": "1.0.0",
     "description": "Evervault provides encryption, decryption, relay proxying, payment card processing, network tokenization, and webhook management.",
-    "x-jentic-source-url": "https://docs.evervault.com/api"
+    "x-jentic-source-url": "https://docs.evervault.com/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -354,7 +355,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a Relay"
       },
       "get": {
         "operationId": "listRelays",
@@ -401,7 +403,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all Relays"
       }
     },
     "/relays/{id}": {
@@ -452,7 +455,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a Relay"
       },
       "patch": {
         "operationId": "updateRelay",
@@ -511,7 +515,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a Relay"
       },
       "delete": {
         "operationId": "deleteRelay",
@@ -553,7 +558,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a Relay"
       }
     },
     "/relays/{relay_id}/custom-domains": {
@@ -619,7 +625,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create custom domain for Relay"
       },
       "get": {
         "operationId": "listRelayCustomDomains",
@@ -676,7 +683,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List custom domains for Relay"
       }
     },
     "/relays/{relay_id}/custom-domains/{id}": {
@@ -735,7 +743,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve custom domain"
       },
       "delete": {
         "operationId": "deleteRelayCustomDomain",
@@ -785,7 +794,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete custom domain"
       }
     },
     "/insights/cards": {
@@ -945,7 +955,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a Merchant"
       },
       "get": {
         "operationId": "listMerchants",
@@ -992,7 +1003,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Merchants"
       }
     },
     "/merchants/{id}": {
@@ -1043,7 +1055,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a Merchant"
       },
       "patch": {
         "operationId": "updateMerchant",
@@ -1102,7 +1115,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a Merchant"
       },
       "delete": {
         "operationId": "deleteMerchant",
@@ -1144,7 +1158,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a Merchant"
       }
     },
     "/acquirers": {
@@ -1195,7 +1210,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an Acquirer"
       },
       "get": {
         "operationId": "listAcquirers",
@@ -1242,7 +1258,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Acquirers"
       }
     },
     "/acquirers/{id}": {
@@ -1293,7 +1310,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve an Acquirer"
       },
       "patch": {
         "operationId": "updateAcquirer",
@@ -1352,7 +1370,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an Acquirer"
       },
       "delete": {
         "operationId": "deleteAcquirer",
@@ -1394,7 +1413,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete an Acquirer"
       }
     },
     "/network-tokens": {
@@ -1445,7 +1465,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a Network Token"
       }
     },
     "/network-tokens/{id}": {
@@ -1496,7 +1517,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a Network Token"
       },
       "delete": {
         "operationId": "deleteNetworkToken",
@@ -1538,7 +1560,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a Network Token"
       }
     },
     "/network-tokens/{id}/cryptogram": {
@@ -1599,7 +1622,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a Cryptogram"
       }
     },
     "/network-tokens/{id}/simulate-update": {
@@ -1650,7 +1674,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Simulate a Network Token Update"
       }
     },
     "/network-tokens/{id}/card-art": {
@@ -1701,7 +1726,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve Card Art"
       }
     },
     "/3ds-sessions": {
@@ -1752,7 +1778,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a 3DS Session"
       }
     },
     "/3ds-sessions/{id}": {
@@ -1803,7 +1830,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a 3DS Session"
       }
     },
     "/cards": {
@@ -1854,7 +1882,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Register a Card"
       }
     },
     "/cards/{id}": {
@@ -1905,7 +1934,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a Card"
       },
       "delete": {
         "operationId": "deleteCard",
@@ -1947,7 +1977,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a Card"
       }
     },
     "/cards/{id}/simulate-update": {
@@ -1998,7 +2029,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Simulate a Card Update"
       }
     },
     "/webhooks/endpoints": {
@@ -2049,7 +2081,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a Webhook Endpoint"
       },
       "get": {
         "operationId": "listWebhookEndpoints",
@@ -2096,7 +2129,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List Webhook Endpoints"
       }
     },
     "/webhooks/endpoints/{id}": {
@@ -2147,7 +2181,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Retrieve a Webhook Endpoint"
       },
       "patch": {
         "operationId": "updateWebhookEndpoint",
@@ -2206,7 +2241,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a Webhook Endpoint"
       },
       "delete": {
         "operationId": "deleteWebhookEndpoint",
@@ -2248,7 +2284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a Webhook Endpoint"
       }
     }
   },
@@ -2406,6 +2443,41 @@
   "security": [
     {
       "basicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "3D Secure"
+    },
+    {
+      "name": "Acquirers"
+    },
+    {
+      "name": "Cards"
+    },
+    {
+      "name": "Encryption"
+    },
+    {
+      "name": "Functions"
+    },
+    {
+      "name": "Merchants"
+    },
+    {
+      "name": "Network Tokens"
+    },
+    {
+      "name": "Payments"
+    },
+    {
+      "name": "Relays"
+    },
+    {
+      "name": "Tokens"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/exa.ai/search-api/1.0.0/openapi.json
+++ b/apis/openapi/exa.ai/search-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Exa Search API",
     "version": "1.0.0",
     "description": "Exa is an AI-powered search engine designed for use by AI agents and applications. The API provides neural and keyword search, content retrieval, and similar-link discovery. Exa understands natural language queries and returns clean, structured results.",
-    "x-jentic-source-url": "https://exa.ai/docs/reference/search"
+    "x-jentic-source-url": "https://exa.ai/docs/reference/search",
+    "contact": {}
   },
   "servers": [
     {
@@ -277,8 +278,7 @@
             "description": "Filter by category (e.g. company, research_paper, news, pdf, github, tweet, etc.)"
           },
           "contents": {
-            "$ref": "#/components/schemas/ContentsOptions",
-            "description": "Inline content retrieval options"
+            "$ref": "#/components/schemas/ContentsOptions"
           }
         }
       },

--- a/apis/openapi/exchangeratesapi.io/exchangeratesapi-io/1.0.0/openapi.json
+++ b/apis/openapi/exchangeratesapi.io/exchangeratesapi-io/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Exchangeratesapi.io API",
     "description": "REST API interface delivering currency exchange rate data for over 168 world currencies and precious metals. Provides real-time rates updated as often as every 60 seconds, historical data, and conversion capabilities.",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://exchangeratesapi.io"
+    "x-jentic-source-url": "https://exchangeratesapi.io",
+    "contact": {}
   },
   "servers": [
     {
@@ -41,7 +42,9 @@
         "operationId": "getLatestRates",
         "summary": "Get latest exchange rates",
         "description": "Retrieve current exchange rates for all available currencies. Base currency is EUR by default.",
-        "tags": ["rates"],
+        "tags": [
+          "rates"
+        ],
         "parameters": [
           {
             "name": "base",
@@ -100,7 +103,9 @@
         "operationId": "getSymbols",
         "summary": "Get supported currencies",
         "description": "Get a list of all supported currency codes and precious metals",
-        "tags": ["symbols"],
+        "tags": [
+          "symbols"
+        ],
         "responses": {
           "200": {
             "description": "Successful response",
@@ -130,7 +135,9 @@
         "operationId": "convertCurrency",
         "summary": "Convert between currencies",
         "description": "Convert an amount from one currency to another",
-        "tags": ["conversion"],
+        "tags": [
+          "conversion"
+        ],
         "parameters": [
           {
             "name": "from",
@@ -198,7 +205,9 @@
         "operationId": "getHistoricalRates",
         "summary": "Get historical rates",
         "description": "Retrieve exchange rates for a specific date in the past",
-        "tags": ["historical"],
+        "tags": [
+          "historical"
+        ],
         "parameters": [
           {
             "name": "date",
@@ -257,7 +266,9 @@
         "operationId": "getTimeseries",
         "summary": "Get time series data",
         "description": "Get daily exchange rates over a custom date range (up to 365 days)",
-        "tags": ["historical"],
+        "tags": [
+          "historical"
+        ],
         "parameters": [
           {
             "name": "start_date",
@@ -326,7 +337,9 @@
         "operationId": "getFluctuation",
         "summary": "Get rate fluctuation data",
         "description": "Get absolute and percentage change in exchange rates between two dates",
-        "tags": ["historical"],
+        "tags": [
+          "historical"
+        ],
         "parameters": [
           {
             "name": "start_date",
@@ -566,7 +579,9 @@
         "properties": {
           "success": {
             "type": "boolean",
-            "enum": [false]
+            "enum": [
+              false
+            ]
           },
           "error": {
             "type": "object",

--- a/apis/openapi/exist.io/exist-api/2.0.0/openapi.json
+++ b/apis/openapi/exist.io/exist-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Exist.io API",
     "version": "2.0.0",
     "description": "Exist.io is a personal analytics platform that aggregates data from various services. The API allows you to read user profiles, attributes, attribute values, insights, correlations, averages, and write data to attributes you own.",
-    "x-jentic-source-url": "https://developer.exist.io/"
+    "x-jentic-source-url": "https://developer.exist.io/",
+    "contact": {}
   },
   "servers": [
     {
@@ -48,7 +49,7 @@
     }
   ],
   "paths": {
-    "/api/2/accounts/profile/": {
+    "/api/2/accounts/profile": {
       "get": {
         "operationId": "getUserProfile",
         "summary": "Get profile for user",
@@ -80,7 +81,7 @@
         }
       }
     },
-    "/api/2/attributes/templates/": {
+    "/api/2/attributes/templates": {
       "get": {
         "operationId": "getAttributeTemplates",
         "summary": "Get attribute templates",
@@ -140,7 +141,7 @@
         }
       }
     },
-    "/api/2/attributes/": {
+    "/api/2/attributes": {
       "get": {
         "operationId": "getUserAttributes",
         "summary": "Get a user's attributes",
@@ -237,7 +238,7 @@
         }
       }
     },
-    "/api/2/attributes/with-values/": {
+    "/api/2/attributes/with-values": {
       "get": {
         "operationId": "getAttributesWithValues",
         "summary": "Get attributes with values",
@@ -327,7 +328,7 @@
         }
       }
     },
-    "/api/2/attributes/values/": {
+    "/api/2/attributes/values": {
       "get": {
         "operationId": "getAttributeValues",
         "summary": "Get a specific attribute's values",
@@ -387,7 +388,7 @@
         }
       }
     },
-    "/api/2/attributes/owned/": {
+    "/api/2/attributes/owned": {
       "get": {
         "operationId": "getOwnedAttributes",
         "summary": "List owned attributes",
@@ -471,7 +472,7 @@
         }
       }
     },
-    "/api/2/attributes/acquire/": {
+    "/api/2/attributes/acquire": {
       "post": {
         "operationId": "acquireAttributes",
         "summary": "Acquire attributes",
@@ -530,7 +531,7 @@
         }
       }
     },
-    "/api/2/attributes/release/": {
+    "/api/2/attributes/release": {
       "post": {
         "operationId": "releaseAttributes",
         "summary": "Release attributes",
@@ -581,7 +582,7 @@
         }
       }
     },
-    "/api/2/attributes/update/": {
+    "/api/2/attributes/update": {
       "post": {
         "operationId": "updateAttributeValues",
         "summary": "Update attribute values",
@@ -622,7 +623,7 @@
         }
       }
     },
-    "/api/2/attributes/increment/": {
+    "/api/2/attributes/increment": {
       "post": {
         "operationId": "incrementAttributeValues",
         "summary": "Increment attribute values",
@@ -656,7 +657,7 @@
         }
       }
     },
-    "/api/2/insights/": {
+    "/api/2/insights": {
       "get": {
         "operationId": "getInsights",
         "summary": "Get all insights",
@@ -731,7 +732,7 @@
         }
       }
     },
-    "/api/2/averages/": {
+    "/api/2/averages": {
       "get": {
         "operationId": "getAverages",
         "summary": "Get averages",
@@ -811,7 +812,7 @@
         }
       }
     },
-    "/api/2/correlations/": {
+    "/api/2/correlations": {
       "get": {
         "operationId": "getCorrelations",
         "summary": "Get all correlations",
@@ -878,7 +879,7 @@
         }
       }
     },
-    "/api/2/correlations/combo/": {
+    "/api/2/correlations/combo": {
       "get": {
         "operationId": "getCorrelationCombo",
         "summary": "Find a specific correlation combination",

--- a/apis/openapi/exotel.com/exotel-api/1.0.0/openapi.json
+++ b/apis/openapi/exotel.com/exotel-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Exotel API",
     "version": "1.0.0",
     "description": "Exotel cloud communication platform API for voice calls, SMS, and campaign management.",
-    "x-jentic-source-url": "https://developer.exotel.com/api"
+    "x-jentic-source-url": "https://developer.exotel.com/api",
+    "contact": {}
   },
   "servers": [
     {
@@ -438,6 +439,14 @@
   "security": [
     {
       "BasicAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Calls"
+    },
+    {
+      "name": "SMS"
     }
   ]
 }

--- a/apis/openapi/experian.com/experian-data-quality-api/1.0.0/openapi.json
+++ b/apis/openapi/experian.com/experian-data-quality-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Experian Data Quality API",
     "version": "1.0.0",
     "description": "Experian data quality and verification APIs for address validation, identity verification, and credit data.",
-    "x-jentic-source-url": "https://developer.experian.com/"
+    "x-jentic-source-url": "https://developer.experian.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -85,7 +86,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get OAuth token"
       }
     },
     "/address/validate/v1": {
@@ -136,7 +138,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Validate an address"
       }
     },
     "/address/search/v1": {
@@ -187,7 +190,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search for addresses"
       }
     },
     "/consumerservices/credit-profile/v2": {
@@ -238,7 +242,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get consumer credit profile"
       }
     }
   },
@@ -310,6 +315,17 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Address"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Credit"
     }
   ]
 }

--- a/apis/openapi/extensis.com/extensis-portfolio-api/1.0.0/openapi.json
+++ b/apis/openapi/extensis.com/extensis-portfolio-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Extensis Portfolio API",
     "version": "1.0.0",
     "description": "Extensis Portfolio REST API for digital asset management, including catalog management, asset metadata, and file operations.",
-    "x-jentic-source-url": "https://www.extensis.com/support/developers"
+    "x-jentic-source-url": "https://www.extensis.com/support/developers",
+    "contact": {}
   },
   "servers": [
     {
@@ -50,7 +51,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List catalogs"
       }
     },
     "/catalogs/{catalog_id}/assets": {
@@ -101,7 +103,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List assets in catalog"
       }
     },
     "/catalogs/{catalog_id}/assets/{asset_id}": {
@@ -160,7 +163,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get asset"
       }
     },
     "/catalogs/{catalog_id}/search": {
@@ -221,7 +225,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search assets"
       }
     }
   },
@@ -295,6 +300,17 @@
   "security": [
     {
       "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Assets"
+    },
+    {
+      "name": "Catalogs"
+    },
+    {
+      "name": "Search"
     }
   ]
 }

--- a/apis/openapi/extensiv.com/extensiv-integration-manager-api/1.0.0/openapi.json
+++ b/apis/openapi/extensiv.com/extensiv-integration-manager-api/1.0.0/openapi.json
@@ -773,6 +773,17 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/oauth/authorize",
+            "scopes": {}
+          }
+        }
+      }
     }
   }
 }

--- a/apis/openapi/extensiv.com/extensiv-integration-manager-api/1.0.0/openapi.json
+++ b/apis/openapi/extensiv.com/extensiv-integration-manager-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Extensiv Integration Manager API",
     "version": "1.0.0",
     "description": "Extensiv (formerly 3PL Central) Integration Manager connects ecommerce, warehouse, and order management systems. The API provides access to orders, products, inventory, warehouses, and integrations. Auth uses OAuth2.",
-    "x-jentic-source-url": "https://developers.extensiv.com/"
+    "x-jentic-source-url": "https://developers.extensiv.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -111,7 +112,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List orders"
       },
       "post": {
         "operationId": "createOrder",
@@ -146,7 +148,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create order"
       }
     },
     "/orders/{id}": {
@@ -183,7 +186,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get order by ID"
       },
       "put": {
         "operationId": "updateOrder",
@@ -218,7 +222,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update order"
       },
       "delete": {
         "operationId": "deleteOrder",
@@ -243,7 +248,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete order"
       }
     },
     "/products": {
@@ -298,7 +304,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List products"
       },
       "post": {
         "operationId": "createProduct",
@@ -323,7 +330,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create product"
       }
     },
     "/products/{id}": {
@@ -357,7 +365,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get product by ID"
       }
     },
     "/inventory": {
@@ -412,7 +421,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List inventory"
       }
     },
     "/warehouses": {
@@ -453,7 +463,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List warehouses"
       }
     },
     "/warehouses/{id}": {
@@ -487,7 +498,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get warehouse by ID"
       }
     },
     "/integrations": {
@@ -513,34 +525,13 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List integrations"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "oauth2": {
-        "type": "oauth2",
-        "flows": {
-          "clientCredentials": {
-            "tokenUrl": "https://auth.extensiv.com/oauth/token",
-            "scopes": {}
-          }
-        }
-      }
-    },
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
       "Pagination": {
         "type": "object",
         "properties": {

--- a/apis/openapi/eyefinity.com/eyefinity-ehr-fhir-api/R4/openapi.json
+++ b/apis/openapi/eyefinity.com/eyefinity-ehr-fhir-api/R4/openapi.json
@@ -4,7 +4,8 @@
     "title": "Eyefinity EHR FHIR API",
     "version": "R4",
     "description": "Eyefinity Electronic Health Records FHIR API providing patient demographics, clinical data access through the FHIR R4 standard. Connects to Encompass EHR.",
-    "x-jentic-source-url": "https://help.eyefinity.com/eehr/infoblocking/api/eehr.htm"
+    "x-jentic-source-url": "https://help.eyefinity.com/eehr/infoblocking/api/eehr.htm",
+    "contact": {}
   },
   "servers": [
     {
@@ -66,7 +67,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search patients"
       }
     },
     "/Patient/{id}": {
@@ -117,7 +119,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get patient by ID"
       }
     },
     "/Condition": {
@@ -167,7 +170,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Search conditions"
       }
     },
     "/metadata": {
@@ -208,7 +212,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get capability statement"
       }
     }
   },
@@ -296,6 +301,11 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "FHIR"
     }
   ]
 }

--- a/apis/openapi/eyefinity.com/eyefinity-fhir-api/R4/openapi.json
+++ b/apis/openapi/eyefinity.com/eyefinity-fhir-api/R4/openapi.json
@@ -4,7 +4,8 @@
     "title": "Eyefinity Optometry EHR FHIR API",
     "version": "R4",
     "description": "FHIR R4 API for Eyefinity Optometry Electronic Health Records, providing access to patient demographics, conditions, procedures, observations, medications, and more.",
-    "x-jentic-source-url": "https://fhirapi.eyefinity.com/eyefinity/base/r4/Home/ApiDocumentation"
+    "x-jentic-source-url": "https://fhirapi.eyefinity.com/eyefinity/base/r4/Home/ApiDocumentation",
+    "contact": {}
   },
   "servers": [
     {
@@ -2095,6 +2096,11 @@
   "security": [
     {
       "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "FHIR"
     }
   ]
 }

--- a/apis/openapi/ezeep.com/ezeep-blue-api/1.0.0/openapi.json
+++ b/apis/openapi/ezeep.com/ezeep-blue-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "ezeep Blue Printing API",
     "version": "1.0.0",
     "description": "ezeep Blue is a cloud printing platform. The API allows printing documents, managing printers, users, and print configurations.",
-    "x-jentic-source-url": "https://docs.ezeep.com/"
+    "x-jentic-source-url": "https://docs.ezeep.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -232,30 +233,7 @@
     }
   },
   "components": {
-    "securitySchemes": {
-      "oauth2": {
-        "type": "oauth2",
-        "flows": {
-          "authorizationCode": {
-            "authorizationUrl": "https://account.ezeep.com/oauth/authorize",
-            "tokenUrl": "https://account.ezeep.com/oauth/access_token",
-            "scopes": {}
-          }
-        }
-      }
-    },
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
       "PrinterConfiguration": {
         "type": "object",
         "properties": {

--- a/apis/openapi/ezeep.com/ezeep-blue-api/1.0.0/openapi.json
+++ b/apis/openapi/ezeep.com/ezeep-blue-api/1.0.0/openapi.json
@@ -376,6 +376,17 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "oauth2": {
+        "type": "oauth2",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://example.com/oauth/authorize",
+            "scopes": {}
+          }
+        }
+      }
     }
   }
 }

--- a/apis/openapi/ezfiledrop.com/ez-file-drop-api/1.0.0/openapi.json
+++ b/apis/openapi/ezfiledrop.com/ez-file-drop-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "EZ File Drop API",
     "version": "1.0.0",
     "description": "EZ File Drop form submission and webhook API for retrieving file submissions and managing webhook subscriptions.",
-    "x-jentic-source-url": "https://www.ezfiledrop.com/documentation/zapier-api-documentation-for-ez-file-drop"
+    "x-jentic-source-url": "https://www.ezfiledrop.com/documentation/zapier-api-documentation-for-ez-file-drop",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get form submissions"
       }
     },
     "/third-party/zapier/subscribe": {
@@ -105,7 +107,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Subscribe to webhook"
       },
       "delete": {
         "operationId": "unsubscribe",
@@ -155,7 +158,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Unsubscribe webhook"
       }
     },
     "/third-party/zapier/auth-test": {
@@ -189,7 +193,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Test authentication"
       }
     }
   },
@@ -221,6 +226,17 @@
   "security": [
     {
       "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Submissions"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/ezidox.com/ezidox-api/2.0/openapi.json
+++ b/apis/openapi/ezidox.com/ezidox-api/2.0/openapi.json
@@ -4,10 +4,13 @@
     "title": "EziDox API",
     "version": "2.0",
     "description": "EziDox API V2 for document management and e-signature workflows. Supports application testing and e-signature attachment operations.",
-    "x-jentic-source-url": "https://api.ezidox.com/swagger/ui/index"
+    "x-jentic-source-url": "https://api.ezidox.com/swagger/ui/index",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://api.ezidox.com" }
+    {
+      "url": "https://api.ezidox.com"
+    }
   ],
   "paths": {
     "/api/v2.0/Applications/Test": {
@@ -15,66 +18,102 @@
         "operationId": "testApplication",
         "summary": "Test application connectivity",
         "description": "Returns OK response indicating successful operation",
-        "tags": ["Applications"],
+        "tags": [
+          "Applications"
+        ],
         "responses": {
-          "200": { "description": "Successful response", "content": { "application/json": { "schema": { "type": "string" } } } },
-          "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } },
-          "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
         }
       }
     }
   },
   "components": {
     "schemas": {
-      "ESignSignAttachmentDto": {
-        "type": "object",
-        "properties": {
-          "EntityName": { "type": "string" },
-          "OutdocumentId": { "type": "integer" },
-          "OutdocumentRequestId": { "type": "string" },
-          "IsInteractiveForm": { "type": "boolean" },
-          "OutDocumentComment": { "type": "string" },
-          "IsMandatory": { "type": "boolean" },
-          "RequestId": { "type": "string" },
-          "Signers": { "type": "array", "items": { "$ref": "#/components/schemas/RecipientsList" } },
-          "Message": { "type": "string" },
-          "Status": { "type": "string" },
-          "OrderingEnabled": { "type": "boolean" },
-          "IsContentReviewed": { "type": "boolean" }
-        }
-      },
       "RecipientsList": {
         "type": "object",
         "properties": {
-          "name": { "type": "string" },
-          "email": { "type": "string" },
-          "phoneNumber": { "type": "string" },
-          "role": { "type": "string" },
-          "canEdit": { "type": "boolean" },
-          "fieldEdit": { "type": "boolean" },
-          "fillForm": { "type": "boolean" },
-          "signForm": { "type": "boolean" },
-          "isRequired": { "type": "boolean" },
-          "signingOrder": { "type": "integer" }
+          "name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "phoneNumber": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "canEdit": {
+            "type": "boolean"
+          },
+          "fieldEdit": {
+            "type": "boolean"
+          },
+          "fillForm": {
+            "type": "boolean"
+          },
+          "signForm": {
+            "type": "boolean"
+          },
+          "isRequired": {
+            "type": "boolean"
+          },
+          "signingOrder": {
+            "type": "integer"
+          }
         }
       },
       "ErrorResponse": {
         "type": "object",
         "properties": {
-          "error": { "type": "string" },
-          "message": { "type": "string" }
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
         }
-      }
-    },
-    "securitySchemes": {
-      "apiKey": {
-        "type": "apiKey",
-        "in": "query",
-        "name": "api_key"
       }
     }
   },
   "security": [
-    { "apiKey": [] }
+    {
+      "apiKey": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Applications"
+    }
   ]
 }

--- a/apis/openapi/ezidox.com/ezidox-api/2.0/openapi.json
+++ b/apis/openapi/ezidox.com/ezidox-api/2.0/openapi.json
@@ -58,41 +58,6 @@
   },
   "components": {
     "schemas": {
-      "RecipientsList": {
-        "type": "object",
-        "properties": {
-          "name": {
-            "type": "string"
-          },
-          "email": {
-            "type": "string"
-          },
-          "phoneNumber": {
-            "type": "string"
-          },
-          "role": {
-            "type": "string"
-          },
-          "canEdit": {
-            "type": "boolean"
-          },
-          "fieldEdit": {
-            "type": "boolean"
-          },
-          "fillForm": {
-            "type": "boolean"
-          },
-          "signForm": {
-            "type": "boolean"
-          },
-          "isRequired": {
-            "type": "boolean"
-          },
-          "signingOrder": {
-            "type": "integer"
-          }
-        }
-      },
       "ErrorResponse": {
         "type": "object",
         "properties": {
@@ -103,6 +68,13 @@
             "type": "string"
           }
         }
+      }
+    },
+    "securitySchemes": {
+      "apiKey": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   },

--- a/apis/openapi/eztexting.com/eztexting-api/2.0.0/openapi.json
+++ b/apis/openapi/eztexting.com/eztexting-api/2.0.0/openapi.json
@@ -887,6 +887,12 @@
           }
         }
       }
+    },
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
     }
   }
 }

--- a/apis/openapi/eztexting.com/eztexting-api/2.0.0/openapi.json
+++ b/apis/openapi/eztexting.com/eztexting-api/2.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "EZ Texting API",
     "version": "2.0.0",
     "description": "EZ Texting is an SMS marketing and messaging platform. The API allows sending messages, managing contacts, groups, keywords, and toll-free numbers.",
-    "x-jentic-source-url": "https://developers.eztexting.com/docs/getting-started"
+    "x-jentic-source-url": "https://developers.eztexting.com/docs/getting-started",
+    "contact": {}
   },
   "servers": [
     {
@@ -81,7 +82,8 @@
           "429": {
             "description": "Rate limited"
           }
-        }
+        },
+        "description": "Send a message"
       },
       "get": {
         "operationId": "listMessages",
@@ -134,7 +136,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List messages"
       }
     },
     "/messages/{id}": {
@@ -171,7 +174,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get message by ID"
       }
     },
     "/contacts": {
@@ -233,7 +237,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List contacts"
       },
       "post": {
         "operationId": "createContact",
@@ -268,7 +273,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a contact"
       }
     },
     "/contacts/{id}": {
@@ -305,7 +311,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get contact by ID"
       },
       "patch": {
         "operationId": "updateContact",
@@ -343,7 +350,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a contact"
       },
       "delete": {
         "operationId": "deleteContact",
@@ -368,7 +376,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a contact"
       }
     },
     "/groups": {
@@ -416,7 +425,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List groups"
       },
       "post": {
         "operationId": "createGroup",
@@ -448,7 +458,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create a group"
       }
     },
     "/groups/{id}": {
@@ -482,7 +493,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get group by ID"
       },
       "patch": {
         "operationId": "updateGroup",
@@ -517,7 +529,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update a group"
       },
       "delete": {
         "operationId": "deleteGroup",
@@ -542,7 +555,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete a group"
       }
     },
     "/keywords": {
@@ -590,7 +604,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List keywords"
       }
     },
     "/keywords/{id}": {
@@ -624,7 +639,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get keyword by ID"
       }
     },
     "/media": {
@@ -650,7 +666,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List media files"
       },
       "post": {
         "operationId": "uploadMedia",
@@ -684,30 +701,13 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Upload media file"
       }
     }
   },
   "components": {
-    "securitySchemes": {
-      "bearerAuth": {
-        "type": "http",
-        "scheme": "bearer",
-        "description": "Bearer token authentication. Obtain via OAuth2 or API key."
-      }
-    },
     "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
-      },
       "SendMessageRequest": {
         "type": "object",
         "required": [

--- a/apis/openapi/ezus.io/ezus-api/1.0.0/openapi.json
+++ b/apis/openapi/ezus.io/ezus-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Ezus API",
     "version": "1.0.0",
     "description": "Travel agency management API for projects, clients, suppliers, products, packages, destinations, invoices and webhooks.",
-    "x-jentic-source-url": "https://api.ezus.io/#introduction"
+    "x-jentic-source-url": "https://api.ezus.io/#introduction",
+    "contact": {}
   },
   "servers": [
     {
@@ -70,7 +71,8 @@
           {
             "apiKey": []
           }
-        ]
+        ],
+        "description": "Obtain bearer token"
       }
     },
     "/projects": {
@@ -129,7 +131,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List projects"
       }
     },
     "/project": {
@@ -173,7 +176,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get project"
       }
     },
     "/projects-upsert": {
@@ -207,7 +211,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create or update project"
       }
     },
     "/project-documents": {
@@ -251,7 +256,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project documents"
       }
     },
     "/project-documents-create": {
@@ -285,7 +291,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Generate PDF document"
       }
     },
     "/project-steps": {
@@ -329,7 +336,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project steps"
       }
     },
     "/project-steps-upsert": {
@@ -363,7 +371,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update project step"
       }
     },
     "/project-travellers": {
@@ -407,7 +416,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List project travellers"
       }
     },
     "/clients": {
@@ -450,7 +460,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List clients"
       }
     },
     "/client": {
@@ -494,7 +505,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get client"
       }
     },
     "/clients-upsert": {
@@ -528,7 +540,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update client"
       }
     },
     "/suppliers": {
@@ -571,7 +584,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List suppliers"
       }
     },
     "/supplier": {
@@ -615,7 +629,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get supplier"
       }
     },
     "/suppliers-upsert": {
@@ -649,7 +664,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update supplier"
       }
     },
     "/products": {
@@ -692,7 +708,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List products"
       }
     },
     "/product": {
@@ -736,7 +753,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get product"
       }
     },
     "/products-upsert": {
@@ -770,7 +788,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update product"
       }
     },
     "/product-seasons-upsert": {
@@ -804,7 +823,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update seasonal tariff"
       }
     },
     "/package": {
@@ -848,7 +868,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get package"
       }
     },
     "/packages-upsert": {
@@ -882,7 +903,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update package"
       }
     },
     "/categories": {
@@ -916,7 +938,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List categories"
       }
     },
     "/destinations": {
@@ -950,7 +973,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List destinations"
       }
     },
     "/destinations-upsert": {
@@ -984,7 +1008,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update destination"
       }
     },
     "/subdestination": {
@@ -1028,7 +1053,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get subdestination"
       }
     },
     "/subdestinations-upsert": {
@@ -1062,7 +1088,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update subdestination"
       }
     },
     "/invoices": {
@@ -1096,7 +1123,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List client invoices"
       }
     },
     "/invoice": {
@@ -1140,7 +1168,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get invoice"
       }
     },
     "/invoices-update": {
@@ -1174,7 +1203,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update invoice"
       }
     },
     "/invoices-supplier": {
@@ -1208,7 +1238,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List supplier invoices"
       }
     },
     "/invoice-supplier": {
@@ -1252,7 +1283,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get supplier invoice"
       }
     },
     "/deposits-create": {
@@ -1286,7 +1318,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create deposit"
       }
     },
     "/tags": {
@@ -1320,7 +1353,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List tags"
       }
     },
     "/webhooks": {
@@ -1354,7 +1388,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List webhooks"
       }
     },
     "/webhooks-last": {
@@ -1388,7 +1423,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get last webhook"
       }
     },
     "/webhooks-upsert": {
@@ -1422,7 +1458,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create/update webhook"
       }
     },
     "/webhooks-delete": {
@@ -1456,7 +1493,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete webhook"
       }
     }
   },
@@ -1496,6 +1534,44 @@
     {
       "apiKey": [],
       "bearerAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Categories"
+    },
+    {
+      "name": "Clients"
+    },
+    {
+      "name": "Deposits"
+    },
+    {
+      "name": "Destinations"
+    },
+    {
+      "name": "Invoices"
+    },
+    {
+      "name": "Packages"
+    },
+    {
+      "name": "Products"
+    },
+    {
+      "name": "Projects"
+    },
+    {
+      "name": "Suppliers"
+    },
+    {
+      "name": "Tags"
+    },
+    {
+      "name": "Webhooks"
     }
   ]
 }

--- a/apis/openapi/factorialhr.com/factorial-api/2026-01-01/openapi.json
+++ b/apis/openapi/factorialhr.com/factorial-api/2026-01-01/openapi.json
@@ -4,76 +4,1183 @@
     "title": "Factorial API",
     "version": "2026-01-01",
     "description": "Factorial HR's API for managing employees, attendance, time off, ATS (applicant tracking), tasks, finance, and webhook subscriptions. Provides comprehensive HR management capabilities.",
-    "x-jentic-source-url": "https://apidoc.factorialhr.com/"
+    "x-jentic-source-url": "https://apidoc.factorialhr.com/",
+    "contact": {}
   },
   "servers": [
-    { "url": "https://api.factorialhr.com/api/2026-01-01/resources" }
+    {
+      "url": "https://api.factorialhr.com/api/2026-01-01/resources"
+    }
   ],
   "paths": {
     "/employees/employees": {
-      "get": { "operationId": "listEmployees", "summary": "List employees", "tags": ["Employees"], "responses": { "200": { "description": "Successful response", "content": { "application/json": { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Employee" } } } } }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createEmployee", "summary": "Create employee", "tags": ["Employees"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmployeeRequest" } } } }, "responses": { "201": { "description": "Created", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Employee" } } } }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listEmployees",
+        "summary": "List employees",
+        "tags": [
+          "Employees"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Employee"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List employees"
+      },
+      "post": {
+        "operationId": "createEmployee",
+        "summary": "Create employee",
+        "tags": [
+          "Employees"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmployeeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Employee"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create employee"
+      }
     },
     "/employees/employees/{id}": {
-      "get": { "operationId": "getEmployee", "summary": "Get employee", "tags": ["Employees"], "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "Successful response", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Employee" } } } }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "put": { "operationId": "updateEmployee", "summary": "Update employee", "tags": ["Employees"], "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }], "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EmployeeRequest" } } } }, "responses": { "200": { "description": "Updated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "delete": { "operationId": "deleteEmployee", "summary": "Delete employee", "tags": ["Employees"], "parameters": [{ "name": "id", "in": "path", "required": true, "schema": { "type": "string" } }], "responses": { "200": { "description": "Deleted" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "getEmployee",
+        "summary": "Get employee",
+        "tags": [
+          "Employees"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Employee"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Get employee"
+      },
+      "put": {
+        "operationId": "updateEmployee",
+        "summary": "Update employee",
+        "tags": [
+          "Employees"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EmployeeRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Update employee"
+      },
+      "delete": {
+        "operationId": "deleteEmployee",
+        "summary": "Delete employee",
+        "tags": [
+          "Employees"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Delete employee"
+      }
     },
     "/attendance/shifts": {
-      "get": { "operationId": "listShifts", "summary": "List shifts", "tags": ["Attendance"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createShift", "summary": "Create shift", "tags": ["Attendance"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ShiftRequest" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listShifts",
+        "summary": "List shifts",
+        "tags": [
+          "Attendance"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List shifts"
+      },
+      "post": {
+        "operationId": "createShift",
+        "summary": "Create shift",
+        "tags": [
+          "Attendance"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ShiftRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create shift"
+      }
     },
     "/attendance/shifts/clock-in": {
-      "post": { "operationId": "clockIn", "summary": "Clock in", "tags": ["Attendance"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "employee_id": { "type": "string" }, "now": { "type": "string", "format": "date-time" } } } } } }, "responses": { "200": { "description": "Clocked in" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "post": {
+        "operationId": "clockIn",
+        "summary": "Clock in",
+        "tags": [
+          "Attendance"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "employee_id": {
+                    "type": "string"
+                  },
+                  "now": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Clocked in"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Clock in"
+      }
     },
     "/attendance/shifts/clock-out": {
-      "post": { "operationId": "clockOut", "summary": "Clock out", "tags": ["Attendance"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "employee_id": { "type": "string" }, "now": { "type": "string", "format": "date-time" } } } } } }, "responses": { "200": { "description": "Clocked out" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "post": {
+        "operationId": "clockOut",
+        "summary": "Clock out",
+        "tags": [
+          "Attendance"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "employee_id": {
+                    "type": "string"
+                  },
+                  "now": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Clocked out"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Clock out"
+      }
     },
     "/timeoff/leaves": {
-      "get": { "operationId": "listLeaves", "summary": "List leaves", "tags": ["Time Off"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createLeave", "summary": "Create leave request", "tags": ["Time Off"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/LeaveRequest" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listLeaves",
+        "summary": "List leaves",
+        "tags": [
+          "Time Off"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List leaves"
+      },
+      "post": {
+        "operationId": "createLeave",
+        "summary": "Create leave request",
+        "tags": [
+          "Time Off"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LeaveRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create leave request"
+      }
     },
     "/ats/applications": {
-      "get": { "operationId": "listApplications", "summary": "List applications", "tags": ["ATS"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createApplication", "summary": "Create application", "tags": ["ATS"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listApplications",
+        "summary": "List applications",
+        "tags": [
+          "ATS"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List applications"
+      },
+      "post": {
+        "operationId": "createApplication",
+        "summary": "Create application",
+        "tags": [
+          "ATS"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create application"
+      }
     },
     "/ats/applications/apply": {
-      "post": { "operationId": "applyApplication", "summary": "Apply for a position", "tags": ["ATS"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } }, "responses": { "200": { "description": "Applied" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "post": {
+        "operationId": "applyApplication",
+        "summary": "Apply for a position",
+        "tags": [
+          "ATS"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Applied"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Apply for a position"
+      }
     },
     "/ats/candidates": {
-      "get": { "operationId": "listCandidates", "summary": "List candidates", "tags": ["ATS"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listCandidates",
+        "summary": "List candidates",
+        "tags": [
+          "ATS"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List candidates"
+      }
     },
     "/ats/job-postings": {
-      "get": { "operationId": "listJobPostings", "summary": "List job postings", "tags": ["ATS"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createJobPosting", "summary": "Create job posting", "tags": ["ATS"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listJobPostings",
+        "summary": "List job postings",
+        "tags": [
+          "ATS"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List job postings"
+      },
+      "post": {
+        "operationId": "createJobPosting",
+        "summary": "Create job posting",
+        "tags": [
+          "ATS"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create job posting"
+      }
     },
     "/ats/job-postings/duplicate": {
-      "post": { "operationId": "duplicateJobPosting", "summary": "Duplicate job posting", "tags": ["ATS"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object", "properties": { "job_posting_id": { "type": "string" } } } } } }, "responses": { "200": { "description": "Duplicated" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "post": {
+        "operationId": "duplicateJobPosting",
+        "summary": "Duplicate job posting",
+        "tags": [
+          "ATS"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "job_posting_id": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Duplicated"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Duplicate job posting"
+      }
     },
     "/tasks/tasks": {
-      "get": { "operationId": "listTasks", "summary": "List tasks", "tags": ["Tasks"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createTask", "summary": "Create task", "tags": ["Tasks"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listTasks",
+        "summary": "List tasks",
+        "tags": [
+          "Tasks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List tasks"
+      },
+      "post": {
+        "operationId": "createTask",
+        "summary": "Create task",
+        "tags": [
+          "Tasks"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create task"
+      }
     },
     "/finance/accounts": {
-      "get": { "operationId": "listAccounts", "summary": "List finance accounts", "tags": ["Finance"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createAccount", "summary": "Create finance account", "tags": ["Finance"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "type": "object" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listAccounts",
+        "summary": "List finance accounts",
+        "tags": [
+          "Finance"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List finance accounts"
+      },
+      "post": {
+        "operationId": "createAccount",
+        "summary": "Create finance account",
+        "tags": [
+          "Finance"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create finance account"
+      }
     },
     "/api_public/credentials": {
-      "get": { "operationId": "listCredentials", "summary": "List API credentials", "tags": ["System"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listCredentials",
+        "summary": "List API credentials",
+        "tags": [
+          "System"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List API credentials"
+      }
     },
     "/api_public/webhook-subscriptions": {
-      "get": { "operationId": "listWebhookSubscriptions", "summary": "List webhook subscriptions", "tags": ["Webhooks"], "responses": { "200": { "description": "Successful response" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } },
-      "post": { "operationId": "createWebhookSubscription", "summary": "Create webhook subscription", "tags": ["Webhooks"], "requestBody": { "required": true, "content": { "application/json": { "schema": { "$ref": "#/components/schemas/WebhookSubscriptionRequest" } } } }, "responses": { "201": { "description": "Created" }, "400": { "description": "Bad request", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } }, "401": { "description": "Unauthorized", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/ErrorResponse" } } } } } }
+      "get": {
+        "operationId": "listWebhookSubscriptions",
+        "summary": "List webhook subscriptions",
+        "tags": [
+          "Webhooks"
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "List webhook subscriptions"
+      },
+      "post": {
+        "operationId": "createWebhookSubscription",
+        "summary": "Create webhook subscription",
+        "tags": [
+          "Webhooks"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WebhookSubscriptionRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "description": "Create webhook subscription"
+      }
     }
   },
   "components": {
     "schemas": {
-      "Employee": { "type": "object", "properties": { "id": { "type": "string" }, "first_name": { "type": "string" }, "last_name": { "type": "string" }, "email": { "type": "string", "format": "email" }, "hire_date": { "type": "string", "format": "date" }, "status": { "type": "string" } } },
-      "EmployeeRequest": { "type": "object", "properties": { "first_name": { "type": "string" }, "last_name": { "type": "string" }, "email": { "type": "string" }, "hire_date": { "type": "string", "format": "date" } } },
-      "ShiftRequest": { "type": "object", "properties": { "employee_id": { "type": "string" }, "start_time": { "type": "string", "format": "date-time" }, "end_time": { "type": "string", "format": "date-time" } } },
-      "LeaveRequest": { "type": "object", "properties": { "employee_id": { "type": "string" }, "start_date": { "type": "string", "format": "date" }, "end_date": { "type": "string", "format": "date" }, "leave_type_id": { "type": "string" } } },
-      "WebhookSubscriptionRequest": { "type": "object", "properties": { "url": { "type": "string" }, "events": { "type": "array", "items": { "type": "string" } } } },
-      "ErrorResponse": { "type": "object", "properties": { "error": { "type": "string" }, "message": { "type": "string" } } }
+      "Employee": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string",
+            "format": "email"
+          },
+          "hire_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "EmployeeRequest": {
+        "type": "object",
+        "properties": {
+          "first_name": {
+            "type": "string"
+          },
+          "last_name": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "hire_date": {
+            "type": "string",
+            "format": "date"
+          }
+        }
+      },
+      "ShiftRequest": {
+        "type": "object",
+        "properties": {
+          "employee_id": {
+            "type": "string"
+          },
+          "start_time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "end_time": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      },
+      "LeaveRequest": {
+        "type": "object",
+        "properties": {
+          "employee_id": {
+            "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "end_date": {
+            "type": "string",
+            "format": "date"
+          },
+          "leave_type_id": {
+            "type": "string"
+          }
+        }
+      },
+      "WebhookSubscriptionRequest": {
+        "type": "object",
+        "properties": {
+          "url": {
+            "type": "string"
+          },
+          "events": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          },
+          "message": {
+            "type": "string"
+          }
+        }
+      }
     },
     "securitySchemes": {
       "oauth2": {
@@ -89,6 +1196,34 @@
     }
   },
   "security": [
-    { "oauth2": [] }
+    {
+      "oauth2": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "ATS"
+    },
+    {
+      "name": "Attendance"
+    },
+    {
+      "name": "Employees"
+    },
+    {
+      "name": "Finance"
+    },
+    {
+      "name": "System"
+    },
+    {
+      "name": "Tasks"
+    },
+    {
+      "name": "Time Off"
+    },
+    {
+      "name": "Webhooks"
+    }
   ]
 }

--- a/apis/openapi/faktoora.com/faktoora-api/1.0.0/openapi.json
+++ b/apis/openapi/faktoora.com/faktoora-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Faktoora API",
     "description": "E-invoicing platform API for creating and managing electronic invoices in XRechnung and ZUGFeRD formats",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://api.faktoora.com/api/v1/api-docs"
+    "x-jentic-source-url": "https://api.faktoora.com/api/v1/api-docs",
+    "contact": {}
   },
   "servers": [
     {
@@ -30,7 +31,9 @@
   "paths": {
     "/invoices": {
       "get": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "List invoices",
         "description": "Retrieve all invoices",
         "operationId": "listInvoices",
@@ -56,7 +59,12 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["draft", "sent", "paid", "cancelled"]
+              "enum": [
+                "draft",
+                "sent",
+                "paid",
+                "cancelled"
+              ]
             }
           }
         ],
@@ -85,7 +93,9 @@
         }
       },
       "post": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "Create invoice",
         "description": "Create a new electronic invoice",
         "operationId": "createInvoice",
@@ -95,7 +105,12 @@
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["invoice_number", "date", "customer", "items"],
+                "required": [
+                  "invoice_number",
+                  "date",
+                  "customer",
+                  "items"
+                ],
                 "properties": {
                   "invoice_number": {
                     "type": "string"
@@ -115,7 +130,10 @@
                   },
                   "format": {
                     "type": "string",
-                    "enum": ["xrechnung", "zugferd"],
+                    "enum": [
+                      "xrechnung",
+                      "zugferd"
+                    ],
                     "default": "xrechnung"
                   }
                 }
@@ -149,7 +167,9 @@
     },
     "/invoices/{id}": {
       "get": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "Get invoice",
         "description": "Retrieve a specific invoice by ID",
         "operationId": "getInvoice",
@@ -189,7 +209,9 @@
     },
     "/invoices/{id}/validate": {
       "post": {
-        "tags": ["Validation"],
+        "tags": [
+          "Validation"
+        ],
         "summary": "Validate invoice",
         "description": "Validate invoice against EN 16931 standards",
         "operationId": "validateInvoice",
@@ -236,7 +258,9 @@
     },
     "/invoices/{id}/download": {
       "get": {
-        "tags": ["Invoices"],
+        "tags": [
+          "Invoices"
+        ],
         "summary": "Download invoice",
         "description": "Download invoice in specified format",
         "operationId": "downloadInvoice",
@@ -254,7 +278,10 @@
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["xml", "pdf"],
+              "enum": [
+                "xml",
+                "pdf"
+              ],
               "default": "xml"
             }
           }
@@ -306,7 +333,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["draft", "sent", "paid", "cancelled"]
+            "enum": [
+              "draft",
+              "sent",
+              "paid",
+              "cancelled"
+            ]
           },
           "customer": {
             "$ref": "#/components/schemas/Customer"
@@ -323,7 +355,10 @@
           },
           "format": {
             "type": "string",
-            "enum": ["xrechnung", "zugferd"]
+            "enum": [
+              "xrechnung",
+              "zugferd"
+            ]
           },
           "created_at": {
             "type": "string",
@@ -333,7 +368,10 @@
       },
       "Customer": {
         "type": "object",
-        "required": ["name", "email"],
+        "required": [
+          "name",
+          "email"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -352,7 +390,11 @@
       },
       "InvoiceItem": {
         "type": "object",
-        "required": ["description", "quantity", "unit_price"],
+        "required": [
+          "description",
+          "quantity",
+          "unit_price"
+        ],
         "properties": {
           "description": {
             "type": "string"

--- a/apis/openapi/fakturoid.cz/fakturoid-api/3.0.0/openapi.json
+++ b/apis/openapi/fakturoid.cz/fakturoid-api/3.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Fakturoid API",
     "version": "3.0.0",
     "description": "Fakturoid is a Czech online invoicing application. The API v3 allows managing invoices, subjects, expenses, generators, todos, events, bank accounts, and users.",
-    "x-jentic-source-url": "https://www.fakturoid.cz/api/v3"
+    "x-jentic-source-url": "https://www.fakturoid.cz/api/v3",
+    "contact": {}
   },
   "servers": [
     {
@@ -73,7 +74,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get current user"
       }
     },
     "/accounts/{slug}/users.json": {
@@ -111,7 +113,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List account users"
       }
     },
     "/accounts/{slug}/invoices.json": {
@@ -213,7 +216,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List invoices"
       },
       "post": {
         "operationId": "createInvoice",
@@ -265,7 +269,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create invoice"
       }
     },
     "/accounts/{slug}/invoices/search.json": {
@@ -317,7 +322,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Search invoices"
       }
     },
     "/accounts/{slug}/invoices/{id}.json": {
@@ -362,7 +368,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get invoice detail"
       },
       "patch": {
         "operationId": "updateInvoice",
@@ -415,7 +422,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update invoice"
       },
       "delete": {
         "operationId": "deleteInvoice",
@@ -451,7 +459,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete invoice"
       }
     },
     "/accounts/{slug}/invoices/{id}/fire.json": {
@@ -604,7 +613,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List subjects"
       },
       "post": {
         "operationId": "createSubject",
@@ -659,7 +669,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Create subject"
       }
     },
     "/accounts/{slug}/subjects/search.json": {
@@ -711,7 +722,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Search subjects"
       }
     },
     "/accounts/{slug}/subjects/{id}.json": {
@@ -756,7 +768,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get subject detail"
       },
       "patch": {
         "operationId": "updateSubject",
@@ -809,7 +822,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Update subject"
       },
       "delete": {
         "operationId": "deleteSubject",
@@ -845,7 +859,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Delete subject"
       }
     },
     "/accounts/{slug}/expenses.json": {
@@ -931,7 +946,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List expenses"
       }
     },
     "/accounts/{slug}/expenses/{id}.json": {
@@ -976,7 +992,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get expense detail"
       }
     },
     "/accounts/{slug}/generators.json": {
@@ -1043,7 +1060,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List generators"
       }
     },
     "/accounts/{slug}/generators/{id}.json": {
@@ -1085,7 +1103,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get generator detail"
       }
     },
     "/accounts/{slug}/todos.json": {
@@ -1142,7 +1161,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List todos"
       }
     },
     "/accounts/{slug}/todos/{id}/toggle_completion.json": {
@@ -1184,7 +1204,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Toggle todo completion"
       }
     },
     "/accounts/{slug}/events.json": {
@@ -1243,7 +1264,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "List events"
       }
     },
     "/accounts/{slug}/bank_accounts.json": {
@@ -1308,7 +1330,8 @@
           "401": {
             "description": "Unauthorized"
           }
-        }
+        },
+        "description": "Get account info"
       }
     }
   },

--- a/apis/openapi/farmbrite.com/farmbrite-api/1.0.0/openapi.json
+++ b/apis/openapi/farmbrite.com/farmbrite-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Farmbrite API",
     "version": "1.0.0",
     "description": "Farmbrite farm management API for managing animals, livestock, feedings, grazings, measurements, climate gauges, crops, and farm operations.",
-    "x-jentic-source-url": "https://developers.farmbrite.com/"
+    "x-jentic-source-url": "https://developers.farmbrite.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -53,7 +54,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create animal"
       },
       "get": {
         "operationId": "listAnimals",
@@ -103,7 +105,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List animals"
       }
     },
     "/animals/{animal_id}": {
@@ -147,7 +150,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get animal"
       },
       "put": {
         "operationId": "updateAnimal",
@@ -199,7 +203,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update animal"
       },
       "delete": {
         "operationId": "deleteAnimal",
@@ -241,7 +246,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete animal"
       }
     },
     "/animals/{animal_id}/feedings": {
@@ -295,7 +301,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create feeding record"
       },
       "get": {
         "operationId": "listFeedings",
@@ -337,7 +344,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List feedings for animal"
       }
     },
     "/animals/{animal_id}/feedings/{feeding_id}": {
@@ -389,7 +397,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get feeding"
       },
       "put": {
         "operationId": "updateFeeding",
@@ -449,7 +458,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update feeding"
       },
       "delete": {
         "operationId": "deleteFeeding",
@@ -499,7 +509,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete feeding"
       }
     },
     "/animals/{animal_id}/measurements": {
@@ -553,7 +564,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create measurement"
       },
       "get": {
         "operationId": "listMeasurements",
@@ -595,7 +607,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List measurements"
       }
     },
     "/animals/{animal_id}/measurements/{measurement_id}": {
@@ -647,7 +660,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get measurement"
       },
       "put": {
         "operationId": "updateMeasurement",
@@ -707,7 +721,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update measurement"
       },
       "delete": {
         "operationId": "deleteMeasurement",
@@ -757,7 +772,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete measurement"
       }
     },
     "/animals/{animal_id}/set_logs": {
@@ -801,7 +817,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List set logs"
       }
     },
     "/grazings": {
@@ -853,7 +870,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List all grazings"
       }
     },
     "/livestock_groups": {
@@ -905,7 +923,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List livestock groups"
       }
     },
     "/livestock_groups/{livestock_group_id}": {
@@ -949,7 +968,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get livestock group"
       }
     },
     "/climate_gauges": {
@@ -993,7 +1013,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create climate gauge"
       },
       "get": {
         "operationId": "listClimateGauges",
@@ -1043,7 +1064,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List climate gauges"
       }
     },
     "/climate_gauges/{gauge_id}": {
@@ -1087,7 +1109,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get climate gauge"
       },
       "put": {
         "operationId": "updateClimateGauge",
@@ -1139,7 +1162,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update climate gauge"
       },
       "delete": {
         "operationId": "deleteClimateGauge",
@@ -1181,7 +1205,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete climate gauge"
       }
     }
   },

--- a/apis/openapi/fashioncloud.com/fashioncloudv2docsap/1.0.0/openapi.json
+++ b/apis/openapi/fashioncloud.com/fashioncloudv2docsap/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Fashion Cloud API",
     "version": "1.0.0",
     "description": "Fashion B2B platform API",
-    "x-jentic-source-url": "https://fashioncloudv2.docs.apiary.io/"
+    "x-jentic-source-url": "https://fashioncloudv2.docs.apiary.io/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/fashioncloud.com/fashioncloudv2docsap/1.0.0/openapi.json
+++ b/apis/openapi/fashioncloud.com/fashioncloudv2docsap/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/fashn.ai/fashn/1.0.0/openapi.json
+++ b/apis/openapi/fashn.ai/fashn/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "FASHN API",
     "version": "1.0.0",
     "description": "FASHN AI API for virtual try-on, model creation, image editing, and fashion AI. All model endpoints use the universal /v1/run endpoint with model_name selection, and results are retrieved via /v1/status/{id} polling.",
-    "x-jentic-source-url": "https://docs.fashn.ai/"
+    "x-jentic-source-url": "https://docs.fashn.ai/",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/fastmode.ai/fastmode-api/1.0.0/openapi.json
+++ b/apis/openapi/fastmode.ai/fastmode-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "FastMode API",
     "version": "1.0.0",
     "description": "FastMode CMS API for managing collections, items, forms, and media uploads.",
-    "x-jentic-source-url": "https://www.fastmode.ai/docs/api-reference"
+    "x-jentic-source-url": "https://www.fastmode.ai/docs/api-reference",
+    "contact": {}
   },
   "servers": [
     {
@@ -50,7 +51,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all collections"
       }
     },
     "/collections/{collectionSlug}": {
@@ -101,7 +103,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get collection details"
       }
     },
     "/collections/{collectionSlug}/items": {
@@ -161,7 +164,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List items in a collection"
       },
       "post": {
         "operationId": "createCollectionItem",
@@ -220,7 +224,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a collection item"
       }
     },
     "/collections/{collectionSlug}/items/{itemSlug}": {
@@ -279,7 +284,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a single item"
       },
       "put": {
         "operationId": "updateCollectionItem",
@@ -346,7 +352,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a collection item"
       },
       "delete": {
         "operationId": "deleteCollectionItem",
@@ -396,7 +403,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a collection item"
       }
     },
     "/forms/{formName}/submit": {
@@ -458,7 +466,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Submit form data"
       }
     },
     "/forms/submissions": {
@@ -515,7 +524,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List form submissions"
       }
     },
     "/media/upload": {
@@ -572,7 +582,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Upload media file"
       }
     }
   },
@@ -725,6 +736,20 @@
   "security": [
     {
       "apiKeyAuth": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "Collections"
+    },
+    {
+      "name": "Forms"
+    },
+    {
+      "name": "Items"
+    },
+    {
+      "name": "Media"
     }
   ]
 }

--- a/apis/openapi/fattmerchant.com/stax/1.0.0/openapi.json
+++ b/apis/openapi/fattmerchant.com/stax/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Stax API",
     "version": "1.0.0",
     "description": "Stax (formerly Fattmerchant) is a payment processing platform. The API provides access to transactions, customers, payment methods, and merchant operations.",
-    "x-jentic-source-url": "https://fattmerchant.docs.apiary.io/"
+    "x-jentic-source-url": "https://fattmerchant.docs.apiary.io/",
+    "contact": {}
   },
   "servers": [
     {

--- a/apis/openapi/favqs.com/favqs-com/2.0.0/openapi.json
+++ b/apis/openapi/favqs.com/favqs-com/2.0.0/openapi.json
@@ -44,7 +44,9 @@
         "operationId": "getQuoteOfTheDay",
         "summary": "Get Quote of the Day",
         "description": "Returns the current Quote of the Day. No authentication required.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "responses": {
           "200": {
             "description": "Quote of the Day",
@@ -67,7 +69,9 @@
         "operationId": "listQuotes",
         "summary": "List quotes",
         "description": "Retrieve a paginated list of quotes with optional filtering by keyword, tag, author, or other criteria.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "name": "page",
@@ -92,7 +96,11 @@
             "description": "Filter type: tag, author, or user",
             "schema": {
               "type": "string",
-              "enum": ["tag", "author", "user"]
+              "enum": [
+                "tag",
+                "author",
+                "user"
+              ]
             }
           },
           {
@@ -134,7 +142,9 @@
         "operationId": "createQuote",
         "summary": "Add a new quote",
         "description": "Add a new quote. Requires user session token.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -173,7 +183,9 @@
         "operationId": "getQuote",
         "summary": "Get a specific quote",
         "description": "Retrieve a single quote by its ID.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -204,7 +216,9 @@
         "operationId": "updateQuote",
         "summary": "Update a quote",
         "description": "Update a quote. Requires pro user session.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -249,7 +263,9 @@
         "operationId": "deleteQuote",
         "summary": "Delete a quote",
         "description": "Delete a quote. Requires pro user session.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -279,7 +295,9 @@
         "operationId": "favoriteQuote",
         "summary": "Favorite a quote",
         "description": "Mark a quote as a favorite.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -313,7 +331,9 @@
         "operationId": "unfavoriteQuote",
         "summary": "Unfavorite a quote",
         "description": "Remove a quote from favorites.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -346,7 +366,9 @@
       "put": {
         "operationId": "upvoteQuote",
         "summary": "Upvote a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -372,14 +394,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Upvote a quote"
       }
     },
     "/quotes/{quote_id}/downvote": {
       "put": {
         "operationId": "downvoteQuote",
         "summary": "Downvote a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -405,14 +430,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Downvote a quote"
       }
     },
     "/quotes/{quote_id}/clearvote": {
       "put": {
         "operationId": "clearVoteQuote",
         "summary": "Clear vote on a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -438,14 +466,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Clear vote on a quote"
       }
     },
     "/quotes/{quote_id}/tag": {
       "put": {
         "operationId": "tagQuote",
         "summary": "Add personal tags to a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -494,14 +525,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Add personal tags to a quote"
       }
     },
     "/quotes/{quote_id}/hide": {
       "put": {
         "operationId": "hideQuote",
         "summary": "Hide a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -527,14 +561,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Hide a quote"
       }
     },
     "/quotes/{quote_id}/unhide": {
       "put": {
         "operationId": "unhideQuote",
         "summary": "Unhide a quote",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -560,7 +597,8 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Unhide a quote"
       }
     },
     "/quotes/{quote_id}/publicize": {
@@ -568,7 +606,9 @@
         "operationId": "publicizeQuote",
         "summary": "Make a quote public",
         "description": "Make a private quote public. Requires pro user session.",
-        "tags": ["quotes"],
+        "tags": [
+          "quotes"
+        ],
         "parameters": [
           {
             "$ref": "#/components/parameters/QuoteId"
@@ -602,7 +642,9 @@
         "operationId": "createSession",
         "summary": "Create a user session",
         "description": "Authenticate a user and obtain a session token.",
-        "tags": ["sessions"],
+        "tags": [
+          "sessions"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -638,7 +680,9 @@
         "operationId": "destroySession",
         "summary": "Destroy a user session",
         "description": "Logout and invalidate the user session token.",
-        "tags": ["sessions"],
+        "tags": [
+          "sessions"
+        ],
         "responses": {
           "200": {
             "description": "Session destroyed"
@@ -657,7 +701,9 @@
         "operationId": "createUser",
         "summary": "Create a new user",
         "description": "Register a new user account.",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -692,7 +738,9 @@
         "operationId": "getUser",
         "summary": "Get user profile",
         "description": "Retrieve a user's profile by their login name.",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "parameters": [
           {
             "name": "login",
@@ -729,7 +777,9 @@
         "operationId": "updateUser",
         "summary": "Update user profile",
         "description": "Update user details. Requires user session.",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "parameters": [
           {
             "name": "login",
@@ -778,18 +828,24 @@
         "operationId": "forgotPassword",
         "summary": "Request password reset",
         "description": "Send a password reset email to the user.",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user"],
+                "required": [
+                  "user"
+                ],
                 "properties": {
                   "user": {
                     "type": "object",
-                    "required": ["email"],
+                    "required": [
+                      "email"
+                    ],
                     "properties": {
                       "email": {
                         "type": "string",
@@ -819,18 +875,27 @@
         "operationId": "resetPassword",
         "summary": "Reset password",
         "description": "Complete the password reset process with a token from the reset email.",
-        "tags": ["users"],
+        "tags": [
+          "users"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["user"],
+                "required": [
+                  "user"
+                ],
                 "properties": {
                   "user": {
                     "type": "object",
-                    "required": ["email", "reset_password_token", "password", "password_confirmation"],
+                    "required": [
+                      "email",
+                      "reset_password_token",
+                      "password",
+                      "password_confirmation"
+                    ],
                     "properties": {
                       "email": {
                         "type": "string",
@@ -864,12 +929,14 @@
         ]
       }
     },
-    "/activities/": {
+    "/activities": {
       "get": {
         "operationId": "listActivities",
         "summary": "Get activities",
         "description": "Retrieve activity feed for a user, tag, or author.",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "parameters": [
           {
             "name": "type",
@@ -877,7 +944,11 @@
             "description": "Activity type filter",
             "schema": {
               "type": "string",
-              "enum": ["user", "tag", "author"]
+              "enum": [
+                "user",
+                "tag",
+                "author"
+              ]
             }
           },
           {
@@ -934,7 +1005,9 @@
       "delete": {
         "operationId": "deleteActivity",
         "summary": "Delete an activity",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "parameters": [
           {
             "name": "activity_id",
@@ -958,14 +1031,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Delete an activity"
       }
     },
-    "/activities/follow/": {
+    "/activities/follow": {
       "put": {
         "operationId": "follow",
         "summary": "Follow a user, tag, or author",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -975,7 +1051,11 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["user", "tag", "author"]
+                    "enum": [
+                      "user",
+                      "tag",
+                      "author"
+                    ]
                   },
                   "id": {
                     "type": "string",
@@ -999,14 +1079,17 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Follow a user, tag, or author"
       }
     },
-    "/activities/unfollow/": {
+    "/activities/unfollow": {
       "put": {
         "operationId": "unfollow",
         "summary": "Unfollow a user, tag, or author",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -1016,7 +1099,11 @@
                 "properties": {
                   "type": {
                     "type": "string",
-                    "enum": ["user", "tag", "author"]
+                    "enum": [
+                      "user",
+                      "tag",
+                      "author"
+                    ]
                   },
                   "id": {
                     "type": "string"
@@ -1039,21 +1126,28 @@
             "appToken": [],
             "userToken": []
           }
-        ]
+        ],
+        "description": "Unfollow a user, tag, or author"
       }
     },
-    "/activities/followers/": {
+    "/activities/followers": {
       "get": {
         "operationId": "listFollowers",
         "summary": "Get followers",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "parameters": [
           {
             "name": "type",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["user", "tag", "author"]
+              "enum": [
+                "user",
+                "tag",
+                "author"
+              ]
             }
           },
           {
@@ -1088,21 +1182,28 @@
           {
             "appToken": []
           }
-        ]
+        ],
+        "description": "Get followers"
       }
     },
-    "/activities/following/": {
+    "/activities/following": {
       "get": {
         "operationId": "listFollowing",
         "summary": "Get following list",
-        "tags": ["activities"],
+        "tags": [
+          "activities"
+        ],
         "parameters": [
           {
             "name": "type",
             "in": "query",
             "schema": {
               "type": "string",
-              "enum": ["user", "tag", "author"]
+              "enum": [
+                "user",
+                "tag",
+                "author"
+              ]
             }
           },
           {
@@ -1140,7 +1241,8 @@
           {
             "appToken": []
           }
-        ]
+        ],
+        "description": "Get following list"
       }
     },
     "/typeahead": {
@@ -1148,7 +1250,9 @@
         "operationId": "typeahead",
         "summary": "Get autocomplete suggestions",
         "description": "Returns autocomplete suggestions for authors, tags, or users.",
-        "tags": ["typeahead"],
+        "tags": [
+          "typeahead"
+        ],
         "parameters": [
           {
             "name": "filter",
@@ -1165,7 +1269,11 @@
             "description": "Type of suggestions to return",
             "schema": {
               "type": "string",
-              "enum": ["author", "tag", "user"]
+              "enum": [
+                "author",
+                "tag",
+                "user"
+              ]
             }
           }
         ],
@@ -1331,11 +1439,16 @@
       },
       "QuoteCreate": {
         "type": "object",
-        "required": ["quote"],
+        "required": [
+          "quote"
+        ],
         "properties": {
           "quote": {
             "type": "object",
-            "required": ["author", "body"],
+            "required": [
+              "author",
+              "body"
+            ],
             "properties": {
               "author": {
                 "type": "string"
@@ -1368,11 +1481,16 @@
       },
       "SessionCreate": {
         "type": "object",
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "properties": {
           "user": {
             "type": "object",
-            "required": ["login", "password"],
+            "required": [
+              "login",
+              "password"
+            ],
             "properties": {
               "login": {
                 "type": "string"
@@ -1419,11 +1537,17 @@
       },
       "UserCreate": {
         "type": "object",
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "properties": {
           "user": {
             "type": "object",
-            "required": ["login", "email", "password"],
+            "required": [
+              "login",
+              "email",
+              "password"
+            ],
             "properties": {
               "login": {
                 "type": "string"
@@ -1441,7 +1565,9 @@
       },
       "UserUpdate": {
         "type": "object",
-        "required": ["user"],
+        "required": [
+          "user"
+        ],
         "properties": {
           "user": {
             "type": "object",

--- a/apis/openapi/favro.com/favro/1.0.0/openapi.json
+++ b/apis/openapi/favro.com/favro/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Favro API",
     "version": "1.0.0",
     "description": "Favro is a collaborative planning and project management tool. The API provides access to organizations, collections, widgets (boards/backlogs), columns, cards, comments, tags, tasks, task lists, groups, custom fields, webhooks, and card activities/dependencies.",
-    "x-jentic-source-url": "https://favro.com/developer/"
+    "x-jentic-source-url": "https://favro.com/developer/",
+    "contact": {}
   },
   "servers": [
     {
@@ -212,7 +213,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a user"
       }
     },
     "/organizations": {
@@ -263,7 +265,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all organizations"
       },
       "post": {
         "operationId": "createOrganization",
@@ -322,7 +325,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create an organization"
       }
     },
     "/organizations/{organizationId}": {
@@ -392,7 +396,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get an organization"
       },
       "put": {
         "operationId": "updateOrganization",
@@ -470,7 +475,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update an organization"
       }
     },
     "/collections": {
@@ -548,7 +554,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all collections"
       },
       "post": {
         "operationId": "createCollection",
@@ -618,7 +625,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a collection"
       }
     },
     "/collections/{collectionId}": {
@@ -688,7 +696,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a collection"
       },
       "put": {
         "operationId": "updateCollection",
@@ -766,7 +775,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a collection"
       },
       "delete": {
         "operationId": "deleteCollection",
@@ -827,7 +837,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a collection"
       }
     },
     "/widgets": {
@@ -911,7 +922,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all widgets"
       },
       "post": {
         "operationId": "createWidget",
@@ -981,7 +993,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a widget"
       }
     },
     "/widgets/{widgetCommonId}": {
@@ -1051,7 +1064,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a widget"
       },
       "put": {
         "operationId": "updateWidget",
@@ -1129,7 +1143,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a widget"
       },
       "delete": {
         "operationId": "deleteWidget",
@@ -1198,7 +1213,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a widget"
       }
     },
     "/columns": {
@@ -1276,7 +1292,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all columns"
       },
       "post": {
         "operationId": "createColumn",
@@ -1346,7 +1363,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a column"
       }
     },
     "/columns/{columnId}": {
@@ -1416,7 +1434,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a column"
       },
       "put": {
         "operationId": "updateColumn",
@@ -1494,7 +1513,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a column"
       },
       "delete": {
         "operationId": "deleteColumn",
@@ -1555,7 +1575,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a column"
       }
     },
     "/cards": {
@@ -1692,7 +1713,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all cards"
       },
       "post": {
         "operationId": "createCard",
@@ -1762,7 +1784,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a card"
       }
     },
     "/cards/{cardId}": {
@@ -1843,7 +1866,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a card"
       },
       "put": {
         "operationId": "updateCard",
@@ -1921,7 +1945,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a card"
       },
       "delete": {
         "operationId": "deleteCard",
@@ -1990,7 +2015,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a card"
       }
     },
     "/cards/{cardId}/attachment": {
@@ -2076,7 +2102,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add attachment to card"
       }
     },
     "/cards/{cardId}/activities": {
@@ -2154,7 +2181,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get card activities"
       }
     },
     "/cards/{cardId}/dependencies": {
@@ -2227,7 +2255,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get card dependencies"
       },
       "post": {
         "operationId": "addCardDependency",
@@ -2305,7 +2334,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add card dependency"
       },
       "put": {
         "operationId": "updateCardDependencies",
@@ -2397,7 +2427,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update card dependencies"
       },
       "delete": {
         "operationId": "removeAllCardDependencies",
@@ -2458,7 +2489,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove all card dependencies"
       }
     },
     "/cards/{cardId}/dependencies/{dependencyCardId}": {
@@ -2551,7 +2583,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a card dependency"
       },
       "delete": {
         "operationId": "removeCardDependency",
@@ -2620,7 +2653,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Remove a card dependency"
       }
     },
     "/comments": {
@@ -2698,7 +2732,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all comments"
       },
       "post": {
         "operationId": "createComment",
@@ -2768,7 +2803,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a comment"
       }
     },
     "/comments/{commentId}": {
@@ -2838,7 +2874,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a comment"
       },
       "put": {
         "operationId": "updateComment",
@@ -2916,7 +2953,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a comment"
       },
       "delete": {
         "operationId": "deleteComment",
@@ -2977,7 +3015,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a comment"
       }
     },
     "/comments/{commentId}/attachment": {
@@ -3063,7 +3102,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Add attachment to comment"
       }
     },
     "/tags": {
@@ -3141,7 +3181,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all tags"
       },
       "post": {
         "operationId": "createTag",
@@ -3211,7 +3252,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a tag"
       }
     },
     "/tags/{tagId}": {
@@ -3281,7 +3323,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a tag"
       },
       "put": {
         "operationId": "updateTag",
@@ -3359,7 +3402,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a tag"
       },
       "delete": {
         "operationId": "deleteTag",
@@ -3420,7 +3464,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a tag"
       }
     },
     "/tasks": {
@@ -3498,7 +3543,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all tasks"
       },
       "post": {
         "operationId": "createTask",
@@ -3568,7 +3614,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a task"
       }
     },
     "/tasks/{taskId}": {
@@ -3638,7 +3685,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a task"
       },
       "put": {
         "operationId": "updateTask",
@@ -3716,7 +3764,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a task"
       },
       "delete": {
         "operationId": "deleteTask",
@@ -3777,7 +3826,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a task"
       }
     },
     "/tasklists": {
@@ -3855,7 +3905,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all task lists"
       },
       "post": {
         "operationId": "createTaskList",
@@ -3925,7 +3976,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a task list"
       }
     },
     "/tasklists/{taskListId}": {
@@ -3995,7 +4047,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a task list"
       },
       "put": {
         "operationId": "updateTaskList",
@@ -4073,7 +4126,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a task list"
       },
       "delete": {
         "operationId": "deleteTaskList",
@@ -4134,7 +4188,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a task list"
       }
     },
     "/groups": {
@@ -4204,7 +4259,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all groups"
       },
       "post": {
         "operationId": "createGroup",
@@ -4274,7 +4330,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a group"
       }
     },
     "/groups/{groupId}": {
@@ -4344,7 +4401,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a group"
       },
       "put": {
         "operationId": "updateGroup",
@@ -4422,7 +4480,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Update a group"
       },
       "delete": {
         "operationId": "deleteGroup",
@@ -4483,7 +4542,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a group"
       }
     },
     "/customfields": {
@@ -4553,7 +4613,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all custom fields"
       }
     },
     "/customfields/{customfieldId}": {
@@ -4623,7 +4684,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get a custom field"
       }
     },
     "/webhooks": {
@@ -4696,7 +4758,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get all webhooks"
       },
       "post": {
         "operationId": "createWebhook",
@@ -4766,7 +4829,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Create a webhook"
       }
     },
     "/webhooks/{webhookId}": {
@@ -4829,7 +4893,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Delete a webhook"
       }
     }
   },

--- a/apis/openapi/fawrypay.com/fawrypay/1.0.0/openapi.json
+++ b/apis/openapi/fawrypay.com/fawrypay/1.0.0/openapi.json
@@ -159,5 +159,14 @@
         "description": "Get resource"
       }
     }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
+      }
+    }
   }
 }

--- a/apis/openapi/fawrypay.com/fawrypay/1.0.0/openapi.json
+++ b/apis/openapi/fawrypay.com/fawrypay/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "FawryPay API",
     "version": "1.0.0",
     "description": "Egyptian payment gateway",
-    "x-jentic-source-url": "https://developer.fawrypay.com/"
+    "x-jentic-source-url": "https://developer.fawrypay.com/",
+    "contact": {}
   },
   "servers": [
     {
@@ -77,7 +78,8 @@
               }
             }
           }
-        }
+        },
+        "description": "Get access token"
       }
     },
     "/resources": {
@@ -125,7 +127,8 @@
               }
             }
           }
-        }
+        },
+        "description": "List resources"
       }
     },
     "/resources/{id}": {
@@ -152,29 +155,8 @@
           "404": {
             "description": "Not found"
           }
-        }
-      }
-    }
-  },
-  "components": {
-    "securitySchemes": {
-      "ApiKeyAuth": {
-        "type": "apiKey",
-        "in": "header",
-        "name": "Authorization"
-      }
-    },
-    "schemas": {
-      "ErrorResponse": {
-        "type": "object",
-        "properties": {
-          "error": {
-            "type": "string"
-          },
-          "message": {
-            "type": "string"
-          }
-        }
+        },
+        "description": "Get resource"
       }
     }
   }

--- a/apis/openapi/featurebase.com/featurebase-api/1.0.0/openapi.json
+++ b/apis/openapi/featurebase.com/featurebase-api/1.0.0/openapi.json
@@ -4,7 +4,8 @@
     "title": "Featurebase API",
     "description": "Featurebase Zapier API for feedback and roadmap management",
     "version": "1.0.0",
-    "x-jentic-source-url": "https://documenter.getpostman.com/view/23638309/2s83tCKskJ"
+    "x-jentic-source-url": "https://documenter.getpostman.com/view/23638309/2s83tCKskJ",
+    "contact": {}
   },
   "servers": [
     {
@@ -43,7 +44,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/new_posts": {
@@ -75,7 +79,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/new_comment": {
@@ -107,7 +114,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/new_category": {
@@ -139,7 +149,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/create_post": {
@@ -178,7 +191,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/change_post_status": {
@@ -217,7 +233,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     },
     "/zapier/get_changelogs": {
@@ -249,7 +268,10 @@
               }
             }
           }
-        }
+        },
+        "tags": [
+          "zapier"
+        ]
       }
     }
   },
@@ -275,5 +297,10 @@
         }
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "zapier"
+    }
+  ]
 }

--- a/apis/openapi/featurewatch.readme.io/feature-watch/1.0.0/openapi.json
+++ b/apis/openapi/featurewatch.readme.io/feature-watch/1.0.0/openapi.json
@@ -3,7 +3,8 @@
   "info": {
     "title": "Feature Watch API",
     "description": "Feature Watch API for managing boards, features, comments, likes, states, and webhooks",
-    "version": "1.0.0"
+    "version": "1.0.0",
+    "contact": {}
   },
   "servers": [
     {
@@ -73,7 +74,8 @@
             "description": "Authentication successful"
           }
         },
-        "security": []
+        "security": [],
+        "operationId": "post-login"
       }
     },
     "/me": {
@@ -87,7 +89,8 @@
           "200": {
             "description": "User information"
           }
-        }
+        },
+        "operationId": "get-me"
       }
     },
     "/boards": {
@@ -101,7 +104,8 @@
           "200": {
             "description": "List of boards"
           }
-        }
+        },
+        "operationId": "get-boards"
       }
     },
     "/board/{id}": {
@@ -125,7 +129,8 @@
           "200": {
             "description": "Board details"
           }
-        }
+        },
+        "operationId": "get-board-by-id"
       }
     },
     "/board/{id}/features": {
@@ -149,7 +154,8 @@
           "200": {
             "description": "List of features for the board"
           }
-        }
+        },
+        "operationId": "get-board-by-id-features"
       }
     },
     "/features": {
@@ -163,7 +169,8 @@
           "200": {
             "description": "List of features"
           }
-        }
+        },
+        "operationId": "get-features"
       },
       "post": {
         "summary": "Create feature",
@@ -196,7 +203,8 @@
           "201": {
             "description": "Feature created"
           }
-        }
+        },
+        "operationId": "post-features"
       }
     },
     "/feature/{id}": {
@@ -220,7 +228,8 @@
           "200": {
             "description": "Feature details"
           }
-        }
+        },
+        "operationId": "get-feature-by-id"
       }
     },
     "/add_feature": {
@@ -260,7 +269,8 @@
           "201": {
             "description": "Feature added"
           }
-        }
+        },
+        "operationId": "post-add-feature"
       }
     },
     "/comments": {
@@ -274,7 +284,8 @@
           "200": {
             "description": "List of comments"
           }
-        }
+        },
+        "operationId": "get-comments"
       }
     },
     "/likes": {
@@ -288,7 +299,8 @@
           "200": {
             "description": "List of likes"
           }
-        }
+        },
+        "operationId": "get-likes"
       }
     },
     "/states": {
@@ -302,7 +314,8 @@
           "200": {
             "description": "List of states"
           }
-        }
+        },
+        "operationId": "get-states"
       }
     },
     "/statuses": {
@@ -316,7 +329,8 @@
           "200": {
             "description": "List of statuses"
           }
-        }
+        },
+        "operationId": "get-statuses"
       }
     },
     "/status/{id}": {
@@ -340,7 +354,8 @@
           "200": {
             "description": "Status details"
           }
-        }
+        },
+        "operationId": "get-status-by-id"
       }
     },
     "/change_state": {
@@ -376,7 +391,8 @@
           "200": {
             "description": "State changed successfully"
           }
-        }
+        },
+        "operationId": "post-change-state"
       }
     },
     "/hook/subscribe": {
@@ -400,7 +416,8 @@
           "201": {
             "description": "Webhook subscription created"
           }
-        }
+        },
+        "operationId": "post-hook-subscribe"
       }
     },
     "/hook/unsubscribe/{id}": {
@@ -424,8 +441,29 @@
           "200": {
             "description": "Webhook unsubscribed"
           }
-        }
+        },
+        "operationId": "delete-hook-unsubscribe-by-id"
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "Activity"
+    },
+    {
+      "name": "Authentication"
+    },
+    {
+      "name": "Boards"
+    },
+    {
+      "name": "Features"
+    },
+    {
+      "name": "Status Management"
+    },
+    {
+      "name": "Webhooks"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Spectral-lint clean **50** OpenAPI specs. All specs now pass `spectral lint` with the default `spectral:oas` ruleset with zero warnings and zero errors.

### Fixes Applied

| Rule | Specs Fixed |
|------|-------------|
| info-contact | 46 |
| operation-description | 26 |
| operation-tag-defined | 25 |
| unused-components | 8 |
| operation-tags | 4 |
| operation-operationId | 4 |
| path-keys-no-trailing-slash | 3 |
| info-description | 2 |
| no-$ref-siblings | 1 |

### APIs Fixed

- esendex.com/esendex
- esendex.com/messaging-api
- esewa.com.np/esewa-epay-api
- esgenterprise.com/esg-rating-data
- espocrm.com/crm-api
- ethereum.org/json-rpc-api
- etherpad.org/etherpad-http-api
- etmdb.com/etmdb-rest-api-v1
- etrigue.com/etrigue
- etrusted.com/reviews-api
- evalumo.com/evalumo-api
- evemarketer.com/evemarketer-api
- evemarketer.com/evemarketer-marketstat-api
- eventcinch.com/e-cinch-api
- eventleaf.com/eventleaf-api
- eventmaker.io/eventmaker
- eventscase.com/eventscase
- everflow.io/everflow-affiliate-api
- everhour.com/time-tracking-api
- everlytic.com/everlytic-api
- eversign.com/xodo-sign
- evervault.com/encryption-api
- evervault.com/evervault-api
- exa.ai/search-api
- exchangeratesapi.io/exchangeratesapi-io
- exist.io/exist-api
- exotel.com/exotel-api
- experian.com/experian-data-quality-api
- extensis.com/extensis-portfolio-api
- extensiv.com/extensiv-integration-manager-api
- eyefinity.com/eyefinity-ehr-fhir-api
- eyefinity.com/eyefinity-fhir-api
- ezeep.com/ezeep-blue-api
- ezfiledrop.com/ez-file-drop-api
- ezidox.com/ezidox-api
- eztexting.com/eztexting-api
- ezus.io/ezus-api
- factorialhr.com/factorial-api
- faktoora.com/faktoora-api
- fakturoid.cz/fakturoid-api
- farmbrite.com/farmbrite-api
- fashioncloud.com/fashioncloudv2docsap
- fashn.ai/fashn
- fastmode.ai/fastmode-api
- fattmerchant.com/stax
- favqs.com/favqs-com
- favro.com/favro
- fawrypay.com/fawrypay
- featurebase.com/featurebase-api
- featurewatch.readme.io/feature-watch

## Test plan
- [x] All 50 specs pass `spectral lint` after fixes
