### PR TITLE
Add Bearer auth to Github API

### DIFF
--- a/apis/openapi/api.github.com/main/1.1.4/meta/overlay.json
+++ b/apis/openapi/api.github.com/main/1.1.4/meta/overlay.json
@@ -1,0 +1,35 @@
+{
+    "overlay": "1.0.0",
+    "info": {
+      "title": "GitHub REST API — bearer authentication",
+      "version": "1.0.0",
+      "description": "Declares HTTP bearer auth (PAT)"
+    },
+    "actions": [
+      {
+        "description": "Merge bearerAuth into components.securitySchemes (creates the map if absent).",
+        "target": "$.components",
+        "update": {
+          "securitySchemes": {
+            "bearerAuth": {
+              "type": "http",
+              "scheme": "bearer",
+              "bearerFormat": "token",
+              "description": "GitHub personal access token. Header: Authorization: Bearer <PAT>"
+            }
+          }
+        }
+      },
+      {
+        "description": "Set the default security requirement to bearerAuth",
+        "target": "$",
+        "update": {
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      }
+    ]
+  }

--- a/apis/openapi/github.com/api.github.com/1.1.4/meta/overlay.json
+++ b/apis/openapi/github.com/api.github.com/1.1.4/meta/overlay.json
@@ -1,0 +1,35 @@
+{
+    "overlay": "1.0.0",
+    "info": {
+      "title": "GitHub REST API — bearer authentication",
+      "version": "1.0.0",
+      "description": "Declares HTTP bearer auth (PAT)"
+    },
+    "actions": [
+      {
+        "description": "Merge bearerAuth into components.securitySchemes (creates the map if absent).",
+        "target": "$.components",
+        "update": {
+          "securitySchemes": {
+            "bearerAuth": {
+              "type": "http",
+              "scheme": "bearer",
+              "bearerFormat": "token",
+              "description": "GitHub personal access token. Header: Authorization: Bearer <PAT>"
+            }
+          }
+        }
+      },
+      {
+        "description": "Set the default security requirement to bearerAuth",
+        "target": "$",
+        "update": {
+          "security": [
+            {
+              "bearerAuth": []
+            }
+          ]
+        }
+      }
+    ]
+  }


### PR DESCRIPTION
## Add missing Bearer Auth 

### Summary 

- Added Bearer Authentication to the newly imported Github Web App OpenAPI document at `apis/openapi/api.github.com/main/1.1.4/openapi.json`.
-  Added `overlay.json` to both the old and new Github Web APIs. 
- The old Github Web App OpenAPI document at `apis/openapi/github.com/api.github.com/1.1.4/openapi.json` already has Bearer Authentication so no changes to `openapi.json` were needed. 