### PR TITLE
fix: correct HubSpot CRM-contacts/v3 server URL from QA to production

### DIFF
--- a/apis/openapi/hubspot.com/CRM-contacts/v3/apis.json
+++ b/apis/openapi/hubspot.com/CRM-contacts/v3/apis.json
@@ -9,7 +9,7 @@
     "CRM-contacts",
     "published"
   ],
-  "baseUrl": "https://api.hubapiqa.com",
+  "baseUrl": "https://api.hubapi.com",
   "created": "2025-12-17",
   "modified": "2025-12-17",
   "specificationVersion": "0.19",

--- a/apis/openapi/hubspot.com/CRM-contacts/v3/meta/import/output-bundled.json
+++ b/apis/openapi/hubspot.com/CRM-contacts/v3/meta/import/output-bundled.json
@@ -23,7 +23,7 @@
   },
   "servers": [
     {
-      "url": "https://api.hubapiqa.com"
+      "url": "https://api.hubapi.com"
     }
   ],
   "paths": {

--- a/apis/openapi/hubspot.com/CRM-contacts/v3/meta/import/output-entry.json
+++ b/apis/openapi/hubspot.com/CRM-contacts/v3/meta/import/output-entry.json
@@ -23,7 +23,7 @@
   },
   "servers": [
     {
-      "url": "https://api.hubapiqa.com"
+      "url": "https://api.hubapi.com"
     }
   ],
   "paths": {

--- a/apis/openapi/hubspot.com/CRM-contacts/v3/openapi.json
+++ b/apis/openapi/hubspot.com/CRM-contacts/v3/openapi.json
@@ -23,7 +23,7 @@
   },
   "servers": [
     {
-      "url": "https://api.hubapiqa.com"
+      "url": "https://api.hubapi.com"
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary
- The HubSpot CRM Contacts spec was imported with a QA server URL (`https://api.hubapiqa.com`) instead of production (`https://api.hubapi.com`)
- Updated `openapi.json`, `apis.json`, and output meta files to use the production URL
- Left `input-*` and `source.dat` files unchanged as historical import records

## Context
The upstream source spec from HubSpot's public spec collection was published from their QA environment. The Deals spec (`CRM-deals/v3`) already has the correct production URL.

Closes #21327