### PR TITLE
fix: use valid OpenAPI 3.0 server variable syntax in Workday spec

### DIFF
--- a/apis/openapi/workday.com/main/v2/openapi.json
+++ b/apis/openapi/workday.com/main/v2/openapi.json
@@ -12,7 +12,13 @@
   },
   "servers": [
     {
-      "url": "https://<tenantHostname>/absenceManagement/v2"
+      "url": "https://{tenantHostname}/absenceManagement/v2",
+      "variables": {
+        "tenantHostname": {
+          "default": "impl.workday.com",
+          "description": "The tenant-specific hostname for the Workday instance"
+        }
+      }
     }
   ],
   "paths": {


### PR DESCRIPTION
## Summary
- The Workday absenceManagement/v2 spec used `<tenantHostname>` (angle brackets) in the server URL, which is not valid OpenAPI 3.0 syntax
- Changed to `{tenantHostname}` (curly braces) with a proper `variables` object containing a default value
- Left `orig/workday.com.yaml` unchanged as historical source record

## Context
OpenAPI 3.0 requires server variables to use `{variableName}` syntax ([spec ref](https://spec.openapis.org/oas/v3.0.3#server-variable-object)). The angle bracket syntax is not recognized by any OpenAPI tooling (openapi-core, swagger-ui, etc.), causing `ServerNotFound` errors during validation.

Closes #21328