### PR TITLE
improve(github-com-api-github-com-1-1-4): reconcile spec against live API responses

### DIFF
--- a/apis/openapi/github.com/api.github.com/1.1.4/overlay.yaml
+++ b/apis/openapi/github.com/api.github.com/1.1.4/overlay.yaml
@@ -1,0 +1,18 @@
+overlay: 1.1.0
+info:
+  title: "Reconcile github.com api.github.com 1.1.4 spec against live API responses"
+  version: "1.0.0"
+actions:
+  - target: "$.components.schemas['full-repository'].properties"
+    description: "Add missing 'has_pull_requests' boolean field observed in real GET /repos/{owner}/{repo} response"
+    update:
+      has_pull_requests:
+        type: "boolean"
+        description: "Whether the repository has pull requests enabled."
+  - target: "$.components.schemas['full-repository'].properties"
+    description: "Add missing 'pull_request_creation_policy' string field observed in real GET /repos/{owner}/{repo} response"
+    update:
+      pull_request_creation_policy:
+        type: "string"
+        description: "Controls who can create pull requests for the repository."
+        example: "all"


### PR DESCRIPTION
## Summary

- **API:** github.com api.github.com 1.1.4
- **Spec:** `apis/openapi/github.com/api.github.com/1.1.4/openapi.json`
- **Files changed:** `openapi.json` (updated in-place), `overlay.yaml` (new — documents all changes as idempotent v1.1.0 actions)

## Discrepancies found and fixed

### Pass 1 — field_presence (GET /repos/{owner}/{repo})
- Added missing `has_pull_requests` (boolean) to `full-repository` schema — field present in live API response but absent from spec
- Added missing `pull_request_creation_policy` (string) to `full-repository` schema — value `"all"` observed in live API response for `octocat/Hello-World`

## Endpoint coverage

5 of 1,021 endpoints tested with Jentic coverage (5/5 = 100% of tested endpoints):
- `repos/get` — GET /repos/{owner}/{repo} ✓ (2 fixes)
- `issues/list-for-repo` — GET /repos/{owner}/{repo}/issues ✓ (clean)
- `repos/list-public` — GET /repositories ✓ (clean)
- `repos/get-commit` — GET /repos/{owner}/{repo}/commits/{ref} ✓ (clean)
- `repos/get-content` — GET /repos/{owner}/{repo}/contents/{path} ✓ (clean)

## Validation method

Real Jentic API calls against `octocat/Hello-World`, response compared directly against spec schemas using field-by-field property enumeration.

## Non-critical discrepancies

None logged.

## Jentic lint rules checked

| Rule | Check | Result |
|------|-------|--------|
| INGEST-001 | `openapi` field present | ✓ Pass |
| INGEST-002 | `info.description` populated | ✓ Pass |
| INGEST-003 | `x-jentic-source-url` present | ✓ Pass |
| INGEST-004 | No duplicate `operationId` values | ✓ Pass |
| INGEST-005 | All operations have `tags` | ✓ Pass |
| INGEST-006 | All `summary` fields ≤ 255 chars | ✓ Pass |
| INGEST-007 | `servers` array present | ✓ Pass |
| INGEST-008 | `securitySchemes` well-formed | ✓ Pass |

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via `improve-openapi-spec` skill