### PR TITLE
improve(newsapi-org): reconcile spec against live API responses

### DIFF
--- a/apis/openapi/newsapi.org/main/1.0.0/openapi.json
+++ b/apis/openapi/newsapi.org/main/1.0.0/openapi.json
@@ -15,6 +15,7 @@
     "/everything": {
       "get": {
         "operationId": "getEverything",
+        "tags": ["Articles"],
         "summary": "Search news articles",
         "description": "Search through millions of articles from over 150,000 large and small news sources and blogs",
         "parameters": [
@@ -173,6 +174,7 @@
     "/top-headlines": {
       "get": {
         "operationId": "getTopHeadlines",
+        "tags": ["Headlines"],
         "summary": "Get breaking news headlines",
         "description": "Returns live top and breaking headlines for a country, category, or source",
         "parameters": [
@@ -182,10 +184,7 @@
             "description": "2-letter ISO 3166-1 country code",
             "required": true,
             "schema": {
-              "type": "string",
-              "enum": [
-                "us"
-              ]
+              "type": "string"
             }
           },
           {
@@ -256,6 +255,26 @@
                 }
               }
             }
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -263,6 +282,7 @@
     "/top-headlines/sources": {
       "get": {
         "operationId": "getSources",
+        "tags": ["Sources"],
         "summary": "Get news sources",
         "description": "Returns the subset of news publishers that top headlines are available from. It's mainly a convenience endpoint that you can use to keep track of the publishers available on the API.",
         "parameters": [
@@ -440,7 +460,8 @@
             "type": "object",
             "properties": {
               "id": {
-                "type": "string"
+                "type": "string",
+                "nullable": true
               },
               "name": {
                 "type": "string"
@@ -448,7 +469,8 @@
             }
           },
           "author": {
-            "type": "string"
+            "type": "string",
+            "nullable": true
           },
           "title": {
             "type": "string"

--- a/apis/openapi/newsapi.org/main/1.0.0/overlay.yaml
+++ b/apis/openapi/newsapi.org/main/1.0.0/overlay.yaml
@@ -1,0 +1,55 @@
+overlay: 1.1.0
+info:
+  title: "Reconcile newsapi.org main 1.0.0 spec against live API responses"
+  version: "1.0.0"
+actions:
+  - target: "$.paths['/everything'].get"
+    description: "Add 'Articles' tag to getEverything for Jentic discoverability (INGEST-005)"
+    update:
+      tags:
+        - Articles
+
+  - target: "$.paths['/top-headlines'].get"
+    description: "Add 'Headlines' tag to getTopHeadlines for Jentic discoverability (INGEST-005)"
+    update:
+      tags:
+        - Headlines
+
+  - target: "$.paths['/top-headlines/sources'].get"
+    description: "Add 'Sources' tag to getSources for Jentic discoverability (INGEST-005)"
+    update:
+      tags:
+        - Sources
+
+  - target: "$.components.schemas.Article.properties.source.properties.id"
+    description: "Mark source.id as nullable — real API returns null for sources without a canonical ID (e.g. BBC News, NPR, TMZ)"
+    update:
+      type: string
+      nullable: true
+
+  - target: "$.components.schemas.Article.properties.author"
+    description: "Mark author as nullable — real API returns null when article author is unknown (e.g. Bloomberg wire stories)"
+    update:
+      type: string
+      nullable: true
+
+  - target: "$.paths['/top-headlines'].get.parameters[?(@.name=='country')].schema"
+    description: "Remove overly restrictive enum ['us'] from country parameter — real API accepts all ISO 3166-1 codes (confirmed with country=gb returning 200)"
+    update:
+      type: string
+
+  - target: "$.paths['/top-headlines'].get.responses"
+    description: "Add missing 400 and 401 response codes to getTopHeadlines — observed when required country param is omitted; consistent with getEverything and getSources"
+    update:
+      "400":
+        description: "Bad request"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"
+      "401":
+        description: "Unauthorized"
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ErrorResponse"


### PR DESCRIPTION
## Summary

- **Spec:** `apis/openapi/newsapi.org/main/1.0.0/openapi.json` (updated in-place)
- **Overlay:** `apis/openapi/newsapi.org/main/1.0.0/overlay.yaml` (new — documents all changes as idempotent v1.1.0 actions)
- **Endpoint coverage:** 3 of 3 endpoints had Jentic coverage (all tested)
- **Validation method:** Real Jentic API calls; responses compared directly against spec

## Discrepancies fixed

### Critical (4 fixed)

| Category | Endpoint | Finding |
|---|---|---|
| `field_types` | `getEverything`, `getTopHeadlines` | `Article.source.id` declared `string` but real API returns `null` for sources without canonical IDs (BBC News, NPR, TMZ) — fixed with `nullable: true` |
| `field_types` | `getTopHeadlines` | `Article.author` declared `string` but real API returns `null` for wire stories without a byline (Bloomberg) — fixed with `nullable: true` |
| `request_params` | `getTopHeadlines` | `country` parameter enum was `["us"]` — real API accepts all ISO 3166-1 codes (probe with `country=gb` returned 200) — enum removed |
| `status_codes` | `getTopHeadlines` | Only `200` was documented; `400` observed when required `country` param is omitted — added `400` and `401` responses |

### Non-critical (logged, not blocked)

None.

## Jentic lint rules checked

| Rule | Check | Result |
|------|-------|--------|
| INGEST-001 | `openapi` field present | ✓ Pass |
| INGEST-002 | `info.description` populated | ✓ Pass |
| INGEST-003 | `x-jentic-source-url` present | ✓ Pass |
| INGEST-004 | No duplicate `operationId` values | ✓ Pass |
| INGEST-005 | All operations have `tags` | ✗ Fixed — added `Articles`, `Headlines`, `Sources` tags |
| INGEST-006 | All `summary` fields ≤ 255 chars | ✓ Pass |
| INGEST-007 | `servers` array present | ✓ Pass |
| INGEST-008 | `securitySchemes` well-formed | ✓ Pass |

🤖 Generated with [Claude Code](https://claude.ai/claude-code)