### PR TITLE
improve(nytimes.com/article_search): reconcile spec against live API responses

### DIFF
--- a/apis/openapi/nytimes.com/article_search/1.0.0/openapi.json
+++ b/apis/openapi/nytimes.com/article_search/1.0.0/openapi.json
@@ -132,7 +132,7 @@
                           },
                           "type": "array"
                         },
-                        "meta": {
+                        "metadata": {
                           "properties": {
                             "hits": {
                               "type": "integer"
@@ -207,53 +207,63 @@
             "type": "object"
           },
           "keywords": {
-            "properties": {
-              "name": {
-                "type": "string"
-              },
-              "rank": {
-                "type": "string"
-              },
-              "value": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "lead_paragraph": {
-            "type": "string"
-          },
-          "multimedia": {
             "items": {
               "properties": {
-                "caption": {
+                "name": {
                   "type": "string"
                 },
-                "copyright": {
-                  "type": "string"
-                },
-                "format": {
-                  "type": "string"
-                },
-                "height": {
+                "rank": {
                   "type": "integer"
                 },
-                "subtype": {
+                "value": {
                   "type": "string"
-                },
-                "type": {
-                  "type": "string"
-                },
-                "url": {
-                  "type": "string"
-                },
-                "width": {
-                  "type": "integer"
                 }
               },
               "type": "object"
             },
             "type": "array"
+          },
+          "lead_paragraph": {
+            "type": "string"
+          },
+          "multimedia": {
+            "properties": {
+              "caption": {
+                "type": "string"
+              },
+              "credit": {
+                "type": "string"
+              },
+              "default": {
+                "properties": {
+                  "height": {
+                    "type": "integer"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              },
+              "thumbnail": {
+                "properties": {
+                  "height": {
+                    "type": "integer"
+                  },
+                  "url": {
+                    "type": "string"
+                  },
+                  "width": {
+                    "type": "integer"
+                  }
+                },
+                "type": "object"
+              }
+            },
+            "type": "object"
           },
           "news_desk": {
             "type": "string"
@@ -286,7 +296,7 @@
             "type": "string"
           },
           "word_count": {
-            "type": "string"
+            "type": "integer"
           }
         },
         "type": "object"

--- a/apis/openapi/nytimes.com/article_search/1.0.0/overlay.yaml
+++ b/apis/openapi/nytimes.com/article_search/1.0.0/overlay.yaml
@@ -1,0 +1,69 @@
+overlay: 1.1.0
+info:
+  title: "Reconcile nytimes.com article_search 1.0.0 spec against live API responses"
+  version: "1.0.0"
+actions:
+  - target: "$.paths['/articlesearch.json'].get.responses['200'].content['application/json'].schema.properties.response.properties"
+    description: "Remove stale 'response' properties (had wrong key 'meta' instead of 'metadata')"
+    remove: true
+  - target: "$.paths['/articlesearch.json'].get.responses['200'].content['application/json'].schema.properties.response"
+    description: "Set response properties with correct 'metadata' key matching real API response"
+    update:
+      properties:
+        docs:
+          type: array
+          items:
+            $ref: "#/components/schemas/Doc"
+        metadata:
+          type: object
+          properties:
+            hits:
+              type: integer
+            offset:
+              type: integer
+            time:
+              type: integer
+  - target: "$.components.schemas.Doc.properties.keywords"
+    description: "Fix 'keywords' from single object to array of keyword objects; fix 'rank' type from string to integer"
+    update:
+      type: array
+      items:
+        type: object
+        properties:
+          name:
+            type: string
+          rank:
+            type: integer
+          value:
+            type: string
+  - target: "$.components.schemas.Doc.properties.multimedia"
+    description: "Fix 'multimedia' from array of flat image items to object with 'default' and 'thumbnail' sub-objects matching real API structure"
+    update:
+      type: object
+      properties:
+        caption:
+          type: string
+        credit:
+          type: string
+        default:
+          type: object
+          properties:
+            url:
+              type: string
+            height:
+              type: integer
+            width:
+              type: integer
+        thumbnail:
+          type: object
+          properties:
+            url:
+              type: string
+            height:
+              type: integer
+            width:
+              type: integer
+  - target: "$.components.schemas.Doc.properties.word_count"
+    description: "Fix 'word_count' type from string to integer — real API returns numeric value (e.g. 1113)"
+    update:
+      type: integer


### PR DESCRIPTION
## Summary

- **API:** nytimes.com article_search 1.0.0
- **Spec:** `apis/openapi/nytimes.com/article_search/1.0.0/openapi.json`
- **Files changed:** `openapi.json` (updated in-place), `overlay.yaml` (new — documents all changes as idempotent v1.1.0 actions)
- **Endpoint coverage:** 1/1 endpoints had Jentic coverage

## Discrepancies Fixed (5 critical)

| Field | Spec had | Real API returns | Fix |
|-------|----------|-----------------|-----|
| `response.meta` | object `{hits, offset, time}` | **absent** | Renamed to `metadata` |
| `response.metadata` | absent | object `{hits, offset, time}` | Added under correct name |
| `Doc.keywords` | single `object {name, rank, value}` | `array [{name, value, rank}]` | Changed to array type |
| `Doc.keywords[].rank` | `string` | `integer` (e.g. 1, 2, 3) | Changed type to integer |
| `Doc.multimedia` | `array` of flat image objects | `object {caption, credit, default: {url,h,w}, thumbnail: {url,h,w}}` | Replaced with correct object schema |
| `Doc.word_count` | `string` | `integer` (e.g. 1113) | Changed type to integer |

## Non-critical discrepancies logged but not fixed

These are extra fields present in real responses but absent from the spec (undocumented optional extras). Not fixing to minimize churn:
- `$.response.docs[].print_section` — returns `"A"` etc.
- `$.response.docs[].uri` — returns `"nyt://article/..."` internal URI
- `$.response.docs[].headline.print_headline` — print edition headline
- `$.status` — top-level `"OK"` status string
- `$.copyright` — top-level copyright notice

## Jentic lint rules checked

| Rule | Check | Result |
|------|-------|--------|
| INGEST-001 | `openapi` field present | ✓ Pass |
| INGEST-002 | `info.description` populated | ✓ Pass |
| INGEST-003 | `x-jentic-source-url` present | ✓ Pass |
| INGEST-004 | No duplicate `operationId` values | ✓ Pass |
| INGEST-005 | All operations have `tags` | ✓ Pass |
| INGEST-006 | All `summary` fields ≤ 255 chars | ✓ Pass |
| INGEST-007 | `servers` array present | ✓ Pass |
| INGEST-008 | `securitySchemes` well-formed | ✓ Pass |

## Validation method

All fixes validated against real NYT Article Search API calls via Jentic (operation `op_547ccd0951635e3b`). Responses compared directly against spec schemas.