### PR TITLE
improve(googleapis-com-gmail-v1): reconcile spec against live API responses

### DIFF
--- a/apis/openapi/googleapis.com/gmail/v1/openapi.json
+++ b/apis/openapi/googleapis.com/gmail/v1/openapi.json
@@ -118,6 +118,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -224,6 +227,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -314,6 +320,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Users"
         ]
       }
     },
@@ -412,6 +421,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       },
       "get": {
@@ -487,6 +499,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       },
       "put": {
@@ -564,6 +579,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       }
     },
@@ -670,6 +688,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       },
       "get": {
@@ -759,6 +780,9 @@
               "type": "boolean"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       }
     },
@@ -865,6 +889,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Drafts"
         ]
       }
     },
@@ -999,6 +1026,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "History"
         ]
       }
     },
@@ -1089,7 +1119,10 @@
             }
           }
         ],
-        "summary": "Trash email"
+        "summary": "Trash email",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/{id}/untrash": {
@@ -1179,7 +1212,10 @@
             }
           }
         ],
-        "summary": "Restore email"
+        "summary": "Restore email",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/{id}": {
@@ -1254,7 +1290,10 @@
             }
           }
         ],
-        "summary": "Delete email permanently"
+        "summary": "Delete email permanently",
+        "tags": [
+          "Messages"
+        ]
       },
       "get": {
         "description": "Gets the specified message. Retrieve, read, open, fetch, view, or access a specific email from the user's mailbox. Returns message content, headers, and metadata.",
@@ -1357,11 +1396,19 @@
             "in": "query",
             "name": "metadataHeaders",
             "schema": {
-              "type": "string"
-            }
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           }
         ],
-        "summary": "Read email"
+        "summary": "Read email",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/batchDelete": {
@@ -1436,6 +1483,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -1562,6 +1612,9 @@
               "type": "boolean"
             }
           }
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -1674,6 +1727,9 @@
               "type": "boolean"
             }
           }
+        ],
+        "tags": [
+          "Messages"
         ]
       },
       "get": {
@@ -1760,8 +1816,13 @@
             "in": "query",
             "name": "labelIds",
             "schema": {
-              "type": "string"
-            }
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           },
           {
             "in": "query",
@@ -1771,7 +1832,10 @@
             }
           }
         ],
-        "summary": "List emails"
+        "summary": "List emails",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/send": {
@@ -1886,7 +1950,10 @@
             }
           }
         ],
-        "summary": "Send email"
+        "summary": "Send email",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/{id}/modify": {
@@ -1985,7 +2052,10 @@
             }
           }
         ],
-        "summary": "Modify email labels"
+        "summary": "Modify email labels",
+        "tags": [
+          "Messages"
+        ]
       }
     },
     "/gmail/v1/users/{userId}/messages/batchModify": {
@@ -2068,6 +2138,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -2189,6 +2262,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Messages"
         ]
       }
     },
@@ -2287,6 +2363,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       },
       "get": {
@@ -2355,6 +2434,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       }
     },
@@ -2445,6 +2527,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       },
       "get": {
@@ -2521,6 +2606,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       },
       "put": {
@@ -2590,6 +2678,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       },
       "patch": {
@@ -2659,6 +2750,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Labels"
         ]
       }
     },
@@ -2748,6 +2842,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       }
     },
@@ -2837,6 +2934,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       }
     },
@@ -2911,6 +3011,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       },
       "get": {
@@ -3017,6 +3120,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       }
     },
@@ -3140,8 +3246,13 @@
             "in": "query",
             "name": "labelIds",
             "schema": {
-              "type": "string"
-            }
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": "form",
+            "explode": true
           },
           {
             "in": "query",
@@ -3150,6 +3261,9 @@
               "type": "boolean"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       }
     },
@@ -3248,6 +3362,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Threads"
         ]
       }
     },
@@ -3345,6 +3462,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -3390,6 +3510,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -3487,6 +3610,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -3532,6 +3658,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -3629,6 +3758,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -3674,6 +3806,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -3771,6 +3906,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -3816,6 +3954,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -3913,6 +4054,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -3958,6 +4102,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4055,6 +4202,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -4100,6 +4250,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4205,6 +4358,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "put": {
@@ -4266,6 +4422,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "patch": {
@@ -4327,6 +4486,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "delete": {
@@ -4364,6 +4526,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4438,6 +4603,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4551,6 +4719,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -4612,6 +4783,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4733,6 +4907,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "delete": {
@@ -4786,6 +4963,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4876,6 +5056,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -4966,6 +5149,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "get": {
@@ -5049,6 +5235,9 @@
               "format": "int32"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5131,6 +5320,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "get": {
@@ -5207,6 +5399,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5305,6 +5500,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5395,6 +5593,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "get": {
@@ -5478,6 +5679,9 @@
               "format": "int32"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5576,6 +5780,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5674,6 +5881,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5787,6 +5997,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5878,6 +6091,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -5975,6 +6191,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -6020,6 +6239,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -6125,6 +6347,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "delete": {
@@ -6162,6 +6387,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -6259,6 +6487,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -6304,6 +6535,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -6409,6 +6643,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "delete": {
@@ -6446,6 +6683,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -6543,6 +6783,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "post": {
@@ -6588,6 +6831,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     },
@@ -6693,6 +6939,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       },
       "delete": {
@@ -6730,6 +6979,9 @@
               "type": "string"
             }
           }
+        ],
+        "tags": [
+          "Settings"
         ]
       }
     }

--- a/apis/openapi/googleapis.com/gmail/v1/overlay.yaml
+++ b/apis/openapi/googleapis.com/gmail/v1/overlay.yaml
@@ -1,0 +1,497 @@
+overlay: 1.1.0
+info:
+  title: "Reconcile googleapis.com gmail v1 spec against live API responses"
+  version: "1.0.0"
+actions:
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].get.parameters[?(@.name=='labelIds')]"
+    description: "Fix labelIds: remove old string-typed entry before re-adding as array"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].get"
+    description: "Fix labelIds in messages.list: was type:string, corrected to type:array (repeatable query param)"
+    update: {"parameters":[{"name":"labelIds","in":"query","schema":{"type":"array","items":{"type":"string"}},"style":"form","explode":true,"description":"Only return messages with labels that match all of the specified label IDs. Repeatable."}]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads'].get.parameters[?(@.name=='labelIds')]"
+    description: "Fix labelIds: remove old string-typed entry before re-adding as array"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads'].get"
+    description: "Fix labelIds in threads.list: was type:string, corrected to type:array (repeatable query param)"
+    update: {"parameters":[{"name":"labelIds","in":"query","schema":{"type":"array","items":{"type":"string"}},"style":"form","explode":true,"description":"Only return threads with labels that match all of the specified label IDs. Repeatable."}]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].get.parameters[?(@.name=='metadataHeaders')]"
+    description: "Fix metadataHeaders: remove old string-typed entry before re-adding as array"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].get"
+    description: "Fix metadataHeaders in messages.get: was type:string, corrected to type:array (repeatable query param)"
+    update: {"parameters":[{"name":"metadataHeaders","in":"query","schema":{"type":"array","items":{"type":"string"}},"style":"form","explode":true,"description":"When format is METADATA, only include headers specified. Repeatable."}]}
+  - target: "$.paths['/gmail/v1/users/{userId}/profile'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/profile before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/profile'].get"
+    description: "INGEST-005: Add tag [\"Users\"] to gmail.users.getProfile"
+    update: {"tags":["Users"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/watch'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/watch before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/watch'].post"
+    description: "INGEST-005: Add tag [\"Users\"] to gmail.users.watch"
+    update: {"tags":["Users"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/stop'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/stop before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/stop'].post"
+    description: "INGEST-005: Add tag [\"Users\"] to gmail.users.stop"
+    update: {"tags":["Users"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/drafts/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.delete"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/drafts/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].get"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.get"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/drafts/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/{id}'].put"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.update"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/drafts before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts'].post"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.create"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/drafts before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts'].get"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.list"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/send'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/drafts/send before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/drafts/send'].post"
+    description: "INGEST-005: Add tag [\"Drafts\"] to gmail.users.drafts.send"
+    update: {"tags":["Drafts"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/history'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/history before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/history'].get"
+    description: "INGEST-005: Add tag [\"History\"] to gmail.users.history.list"
+    update: {"tags":["History"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/trash'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/{id}/trash before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/trash'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.trash"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/untrash'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/{id}/untrash before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/untrash'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.untrash"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/messages/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.delete"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/messages/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}'].get"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.get"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/batchDelete'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/batchDelete before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/batchDelete'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.batchDelete"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/import'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/import before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/import'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.import"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.insert"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/messages before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages'].get"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.list"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/send'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/send before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/send'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.send"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/modify'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/{id}/modify before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{id}/modify'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.modify"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/batchModify'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/messages/batchModify before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/batchModify'].post"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.batchModify"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{messageId}/attachments/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/messages/{messageId}/attachments/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/messages/{messageId}/attachments/{id}'].get"
+    description: "INGEST-005: Add tag [\"Messages\"] to gmail.users.messages.attachments.get"
+    update: {"tags":["Messages"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/labels before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels'].post"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.create"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/labels before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels'].get"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.list"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/labels/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.delete"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/labels/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].get"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.get"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/labels/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].put"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.update"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].patch.tags"
+    description: "Remove existing tags on PATCH /gmail/v1/users/{userId}/labels/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/labels/{id}'].patch"
+    description: "INGEST-005: Add tag [\"Labels\"] to gmail.users.labels.patch"
+    update: {"tags":["Labels"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/trash'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/threads/{id}/trash before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/trash'].post"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.trash"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/untrash'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/threads/{id}/untrash before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/untrash'].post"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.untrash"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/threads/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.delete"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/threads/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}'].get"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.get"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/threads before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads'].get"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.list"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/modify'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/threads/{id}/modify before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/threads/{id}/modify'].post"
+    description: "INGEST-005: Add tag [\"Threads\"] to gmail.users.threads.modify"
+    update: {"tags":["Threads"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/imap'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/imap before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/imap'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.getImap"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/imap'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/imap before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/imap'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.updateImap"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/pop'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/pop before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/pop'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.getPop"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/pop'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/pop before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/pop'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.updatePop"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/vacation'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/vacation before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/vacation'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.getVacation"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/vacation'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/vacation before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/vacation'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.updateVacation"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/language'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/language before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/language'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.getLanguage"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/language'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/language before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/language'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.updateLanguage"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/autoForwarding'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/autoForwarding before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/autoForwarding'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.getAutoForwarding"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/autoForwarding'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/autoForwarding before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/autoForwarding'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.updateAutoForwarding"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/sendAs before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/sendAs before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].put.tags"
+    description: "Remove existing tags on PUT /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].put"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.update"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].patch.tags"
+    description: "Remove existing tags on PATCH /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].patch"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.patch"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.delete"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/verify'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.verify"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.smimeInfo.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.smimeInfo.insert"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.smimeInfo.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.smimeInfo.delete"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/sendAs/{sendAsEmail}/smimeInfo/{id}/setDefault'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.sendAs.smimeInfo.setDefault"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/cse/identities before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.identities.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/cse/identities before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.identities.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.identities.delete"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{cseEmailAddress}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.identities.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{emailAddress}'].patch.tags"
+    description: "Remove existing tags on PATCH /gmail/v1/users/{userId}/settings/cse/identities/{emailAddress} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/identities/{emailAddress}'].patch"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.identities.patch"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/cse/keypairs before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/cse/keypairs before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:disable'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.disable"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:enable'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.enable"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/cse/keypairs/{keyPairId}:obliterate'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.cse.keypairs.obliterate"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/filters before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.filters.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/filters before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.filters.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters/{id}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/filters/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters/{id}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.filters.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters/{id}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/filters/{id} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/filters/{id}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.filters.delete"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/forwardingAddresses before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.forwardingAddresses.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/forwardingAddresses before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.forwardingAddresses.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.forwardingAddresses.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/forwardingAddresses/{forwardingEmail}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.forwardingAddresses.delete"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/delegates before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.delegates.list"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates'].post.tags"
+    description: "Remove existing tags on POST /gmail/v1/users/{userId}/settings/delegates before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates'].post"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.delegates.create"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates/{delegateEmail}'].get.tags"
+    description: "Remove existing tags on GET /gmail/v1/users/{userId}/settings/delegates/{delegateEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates/{delegateEmail}'].get"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.delegates.get"
+    update: {"tags":["Settings"]}
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates/{delegateEmail}'].delete.tags"
+    description: "Remove existing tags on DELETE /gmail/v1/users/{userId}/settings/delegates/{delegateEmail} before re-setting"
+    remove: true
+  - target: "$.paths['/gmail/v1/users/{userId}/settings/delegates/{delegateEmail}'].delete"
+    description: "INGEST-005: Add tag [\"Settings\"] to gmail.users.settings.delegates.delete"
+    update: {"tags":["Settings"]}


### PR DESCRIPTION
## Summary

- **API:** googleapis.com gmail v1
- **Spec:** `apis/openapi/googleapis.com/gmail/v1/openapi.json` (updated in-place)
- **Overlay:** `apis/openapi/googleapis.com/gmail/v1/overlay.yaml` (new — documents all changes as idempotent v1.1.0 actions)

## Discrepancies Fixed

### Critical — request_params (Pass 1)

| Endpoint | Parameter | Issue | Fix |
|----------|-----------|-------|-----|
| `GET /gmail/v1/users/{userId}/messages` | `labelIds` | `type: string` — but this is a repeatable query param | Changed to `type: array, items: {type: string}, style: form, explode: true` |
| `GET /gmail/v1/users/{userId}/threads` | `labelIds` | Same as above | Same fix |
| `GET /gmail/v1/users/{userId}/messages/{id}` | `metadataHeaders` | `type: string` — but this is a repeatable query param | Changed to `type: array, items: {type: string}, style: form, explode: true` |

These are Google-generated spec artifacts where repeated query parameters were incorrectly documented as single `string` values instead of arrays. Clients relying on the spec would not know they can pass multiple label IDs in a single request.

### Quality — INGEST-005 (Pass 2)

All 79 operations were missing `tags`, causing them to default to `["foo"]` in Jentic's index (unsearchable by category). Added resource-group tags from operationId:

| Tag | Count |
|-----|-------|
| Settings | 45 |
| Messages | 12 |
| Drafts | 6 |
| Labels | 6 |
| Threads | 6 |
| Users | 3 |
| History | 1 |

## Non-Critical Issues (logged, not fixed)

- `format` parameter on `messages.get` is `type: string` with no enum — the real API only accepts `minimal`, `full`, `raw`, `metadata`. Not fixed as it's non-critical (API still works without the constraint).

## Endpoint Coverage

**5/79** endpoints had Jentic coverage (real API calls made):
- `gmail.users.getProfile` — ✅ clean
- `gmail.users.messages.list` — 🔧 fixed (labelIds type)
- `gmail.users.messages.get` — 🔧 fixed (metadataHeaders type)
- `gmail.users.labels.list` — ✅ clean
- `gmail.users.threads.list` — 🔧 fixed (labelIds type)

## Validation Method

All fixes were validated against real Jentic API calls using the `testJentic@jentic.net` account. Response fields, types, and status codes were compared directly against the spec schemas.

## Jentic Lint Rules Checked

| Rule | Check | Result |
|------|-------|--------|
| INGEST-001 | `openapi` field present | ✓ Pass |
| INGEST-002 | `info.description` populated | ✓ Pass |
| INGEST-003 | `x-jentic-source-url` present | ✓ Pass |
| INGEST-004 | No duplicate `operationId` values | ✓ Pass |
| INGEST-005 | All operations have `tags` | ✗ Fixed (79 ops tagged) |
| INGEST-006 | All `summary` fields ≤ 255 chars | ✓ Pass |
| INGEST-007 | `servers` array present | ✓ Pass |
| INGEST-008 | `securitySchemes` well-formed | ✓ Pass |