### PR TITLE
improve(discord-com-main-10): add missing asset field to StandardStickerResponse

### DIFF
--- a/apis/openapi/discord.com/main/10/openapi.json
+++ b/apis/openapi/discord.com/main/10/openapi.json
@@ -29406,6 +29406,9 @@
           "sort_value": {
             "type": "integer",
             "format": "int32"
+          },
+          "asset": {
+            "type": "string"
           }
         },
         "required": [

--- a/apis/openapi/discord.com/main/10/overlay.yaml
+++ b/apis/openapi/discord.com/main/10/overlay.yaml
@@ -1,0 +1,10 @@
+overlay: 1.1.0
+info:
+  title: "Reconcile discord.com main 10 spec against live API responses"
+  version: "1.0.0"
+actions:
+  - target: "$.components.schemas.StandardStickerResponse.properties"
+    description: "Add missing 'asset' field observed in real API response (deprecated sticker hash, always empty string, returned for backward compatibility across all 361 stickers in 14 packs)"
+    update:
+      asset:
+        type: "string"


### PR DESCRIPTION
## Summary

- **API:** discord.com main (v10)
- **Spec:** `apis/openapi/discord.com/main/10/openapi.json`
- **Files changed:** `openapi.json` (updated in-place), `overlay.yaml` (new — documents all changes as idempotent v1.1.0 actions)

## Discrepancies found and fixed

| Category | Severity | Field | Description |
|----------|----------|-------|-------------|
| `field_presence` | critical | `StandardStickerResponse.asset` | Field present in all real API sticker responses but absent from spec |

**Fix:** Added `asset: { type: string }` to `components.schemas.StandardStickerResponse.properties`. Verified across 361 stickers in 14 packs — `asset` is always an empty string. Discord deprecated this field (it was formerly the sticker's CDN hash) but continues returning it for backward compatibility.

## Endpoint coverage

| Endpoint | Coverage | Notes |
|----------|----------|-------|
| `GET /gateway` | ✓ Tested | No discrepancies |
| `GET /sticker-packs` | ✓ Tested | 1 critical discrepancy fixed |
| `GET /users/@me` | ✗ No coverage | 401 — BotToken not configured for testJentic@jentic.net |
| `GET /users/@me/guilds` | ✗ No coverage | 401 — BotToken not configured |
| `GET /guilds/{guild_id}/channels` | ✗ No coverage | 401 — BotToken not configured |

**2 of 5** selected endpoints had Jentic coverage (the 2 publicly accessible endpoints).

## Validation method

Real Jentic API calls (`execute`), response compared directly against spec schemas. Sticker pack response was verified across all 14 sticker packs and 361 individual stickers.

## Non-critical discrepancies

None found.

## Jentic lint rules checked

| Rule | Check | Result |
|------|-------|--------|
| INGEST-001 | `openapi` field present | ✓ Pass |
| INGEST-002 | `info.description` populated | ✓ Pass |
| INGEST-003 | `x-jentic-source-url` present | ✓ Pass |
| INGEST-004 | No duplicate `operationId` values | ✓ Pass |
| INGEST-005 | All `summary` fields ≤ 255 chars | ✓ Pass |
| INGEST-006 | `servers` array present | ✓ Pass |
| INGEST-007 | `securitySchemes` well-formed | ✓ Pass |

🤖 Generated with [Claude Code](https://claude.ai/claude-code) via the `improve-openapi-spec` skill