### PR TITLE
feat: Re-score sentry.io/main@v0

### DIFF
--- a/apis/openapi/sentry.io/main/v0/meta/diagnostics.json
+++ b/apis/openapi/sentry.io/main/v0/meta/diagnostics.json
@@ -34,7 +34,7 @@
         "character": 0
       }
     },
-    "message": "Security scheme 'auth_token' is defined in components.securitySchemes but not used in any security requirement.",
+    "message": "Security scheme 'dsn' is defined in components.securitySchemes but not used in any security requirement.",
     "severity": 2,
     "code": "UNUSED_SECURITY_SCHEME_DEFINED",
     "code_description": null,
@@ -46,7 +46,7 @@
       "path": [
         "components",
         "securitySchemes",
-        "auth_token"
+        "dsn"
       ],
       "target": "bundled-spec"
     }
@@ -62,7 +62,7 @@
         "character": 0
       }
     },
-    "message": "Security scheme 'dsn' is defined in components.securitySchemes but not used in any security requirement.",
+    "message": "Security scheme 'auth_token' is defined in components.securitySchemes but not used in any security requirement.",
     "severity": 2,
     "code": "UNUSED_SECURITY_SCHEME_DEFINED",
     "code_description": null,
@@ -74,7 +74,7 @@
       "path": [
         "components",
         "securitySchemes",
-        "dsn"
+        "auth_token"
       ],
       "target": "bundled-spec"
     }
@@ -109,11 +109,686 @@
   {
     "range": {
       "start": {
-        "line": 31,
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/organizations/repos.json' [path: paths./api/0/organizations/{organization_id_or_slug}/repos/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/repos/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/dsyms.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/users.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/tag-values.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/stats.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/user-feedback.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/service-hooks.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/service-hook-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/project-event-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/project-issues.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/tag-values.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/issue-hashes.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/issue-details.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-releases.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/releases/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/release-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-files.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/release-file.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-file.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-release-commits.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-commits.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-release-commit-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-installations.json' [path: paths./api/0/organizations/{organization_id_or_slug}/sentry-app-installations/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/sentry-app-installations/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issues.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/sentry-app-installations/{uuid}/external-issues/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issue-details.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 0,
+        "character": 0
+      },
+      "end": {
+        "line": 0,
+        "character": 0
+      }
+    },
+    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/spike-protection.json' [path: paths./api/0/organizations/{organization_id_or_slug}/spike-protections/]",
+    "severity": 1,
+    "code": "no-unresolved-refs",
+    "code_description": null,
+    "source": "redocly-validator",
+    "tags": null,
+    "related_information": null,
+    "data": {
+      "fixable": true,
+      "path": [
+        "paths",
+        "/api/0/organizations/{organization_id_or_slug}/spike-protections/"
+      ],
+      "target": "bundled-spec"
+    }
+  },
+  {
+    "range": {
+      "start": {
+        "line": 99,
         "character": 10
       },
       "end": {
-        "line": 105,
+        "line": 173,
         "character": 52
       }
     },
@@ -135,11 +810,11 @@
   {
     "range": {
       "start": {
-        "line": 32,
+        "line": 100,
         "character": 60
       },
       "end": {
-        "line": 33,
+        "line": 101,
         "character": 46
       }
     },
@@ -162,15 +837,15 @@
   {
     "range": {
       "start": {
-        "line": 33,
+        "line": 101,
         "character": 14
       },
       "end": {
-        "line": 33,
+        "line": 101,
         "character": 46
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/organizations/repos.json' [path: paths./api/0/organizations/{organization_id_or_slug}/repos/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/organizations/repos.json' [path: paths./api/0/organizations/{organization_id_or_slug}/repos/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -190,11 +865,11 @@
   {
     "range": {
       "start": {
-        "line": 35,
+        "line": 103,
         "character": 82
       },
       "end": {
-        "line": 36,
+        "line": 104,
         "character": 41
       }
     },
@@ -217,15 +892,15 @@
   {
     "range": {
       "start": {
-        "line": 36,
+        "line": 104,
         "character": 14
       },
       "end": {
-        "line": 36,
+        "line": 104,
         "character": 41
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/dsyms.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/dsyms.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -245,11 +920,11 @@
   {
     "range": {
       "start": {
-        "line": 38,
+        "line": 106,
         "character": 76
       },
       "end": {
-        "line": 39,
+        "line": 107,
         "character": 41
       }
     },
@@ -272,15 +947,15 @@
   {
     "range": {
       "start": {
-        "line": 39,
+        "line": 107,
         "character": 14
       },
       "end": {
-        "line": 39,
+        "line": 107,
         "character": 41
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/users.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/users.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -300,11 +975,11 @@
   {
     "range": {
       "start": {
-        "line": 41,
+        "line": 109,
         "character": 88
       },
       "end": {
-        "line": 42,
+        "line": 110,
         "character": 46
       }
     },
@@ -327,15 +1002,15 @@
   {
     "range": {
       "start": {
-        "line": 42,
+        "line": 110,
         "character": 14
       },
       "end": {
-        "line": 42,
+        "line": 110,
         "character": 46
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/tag-values.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/tag-values.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -355,11 +1030,11 @@
   {
     "range": {
       "start": {
-        "line": 44,
+        "line": 112,
         "character": 76
       },
       "end": {
-        "line": 45,
+        "line": 113,
         "character": 41
       }
     },
@@ -382,15 +1057,15 @@
   {
     "range": {
       "start": {
-        "line": 45,
+        "line": 113,
         "character": 14
       },
       "end": {
-        "line": 45,
+        "line": 113,
         "character": 41
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/stats.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/stats.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -410,11 +1085,11 @@
   {
     "range": {
       "start": {
-        "line": 47,
+        "line": 115,
         "character": 84
       },
       "end": {
-        "line": 48,
+        "line": 116,
         "character": 49
       }
     },
@@ -437,15 +1112,15 @@
   {
     "range": {
       "start": {
-        "line": 48,
+        "line": 116,
         "character": 14
       },
       "end": {
-        "line": 48,
+        "line": 116,
         "character": 49
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/user-feedback.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/user-feedback.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -465,11 +1140,11 @@
   {
     "range": {
       "start": {
-        "line": 50,
+        "line": 118,
         "character": 76
       },
       "end": {
-        "line": 51,
+        "line": 119,
         "character": 49
       }
     },
@@ -492,15 +1167,15 @@
   {
     "range": {
       "start": {
-        "line": 51,
+        "line": 119,
         "character": 14
       },
       "end": {
-        "line": 51,
+        "line": 119,
         "character": 49
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/service-hooks.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/service-hooks.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -520,11 +1195,11 @@
   {
     "range": {
       "start": {
-        "line": 53,
+        "line": 121,
         "character": 86
       },
       "end": {
-        "line": 54,
+        "line": 122,
         "character": 56
       }
     },
@@ -547,15 +1222,15 @@
   {
     "range": {
       "start": {
-        "line": 54,
+        "line": 122,
         "character": 14
       },
       "end": {
-        "line": 54,
+        "line": 122,
         "character": 56
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/service-hook-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/service-hook-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -575,11 +1250,11 @@
   {
     "range": {
       "start": {
-        "line": 56,
+        "line": 124,
         "character": 88
       },
       "end": {
-        "line": 57,
+        "line": 125,
         "character": 55
       }
     },
@@ -602,15 +1277,15 @@
   {
     "range": {
       "start": {
-        "line": 57,
+        "line": 125,
         "character": 14
       },
       "end": {
-        "line": 57,
+        "line": 125,
         "character": 55
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/project-event-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/project-event-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -630,11 +1305,11 @@
   {
     "range": {
       "start": {
-        "line": 59,
+        "line": 127,
         "character": 77
       },
       "end": {
-        "line": 60,
+        "line": 128,
         "character": 48
       }
     },
@@ -657,15 +1332,15 @@
   {
     "range": {
       "start": {
-        "line": 60,
+        "line": 128,
         "character": 14
       },
       "end": {
-        "line": 60,
+        "line": 128,
         "character": 48
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/project-issues.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/project-issues.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -685,11 +1360,11 @@
   {
     "range": {
       "start": {
-        "line": 62,
+        "line": 130,
         "character": 90
       },
       "end": {
-        "line": 63,
+        "line": 131,
         "character": 44
       }
     },
@@ -712,15 +1387,15 @@
   {
     "range": {
       "start": {
-        "line": 63,
+        "line": 131,
         "character": 14
       },
       "end": {
-        "line": 63,
+        "line": 131,
         "character": 44
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/tag-values.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/tag-values.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -740,11 +1415,11 @@
   {
     "range": {
       "start": {
-        "line": 65,
+        "line": 133,
         "character": 79
       },
       "end": {
-        "line": 66,
+        "line": 134,
         "character": 46
       }
     },
@@ -767,15 +1442,15 @@
   {
     "range": {
       "start": {
-        "line": 66,
+        "line": 134,
         "character": 14
       },
       "end": {
-        "line": 66,
+        "line": 134,
         "character": 46
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/issue-hashes.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/issue-hashes.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -795,11 +1470,11 @@
   {
     "range": {
       "start": {
-        "line": 68,
+        "line": 136,
         "character": 72
       },
       "end": {
-        "line": 69,
+        "line": 137,
         "character": 47
       }
     },
@@ -822,15 +1497,15 @@
   {
     "range": {
       "start": {
-        "line": 69,
+        "line": 137,
         "character": 14
       },
       "end": {
-        "line": 69,
+        "line": 137,
         "character": 47
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/issue-details.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/events/issue-details.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -850,11 +1525,11 @@
   {
     "range": {
       "start": {
-        "line": 71,
+        "line": 139,
         "character": 63
       },
       "end": {
-        "line": 72,
+        "line": 140,
         "character": 57
       }
     },
@@ -877,15 +1552,15 @@
   {
     "range": {
       "start": {
-        "line": 72,
+        "line": 140,
         "character": 14
       },
       "end": {
-        "line": 72,
+        "line": 140,
         "character": 57
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-releases.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-releases.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -905,11 +1580,11 @@
   {
     "range": {
       "start": {
-        "line": 74,
+        "line": 142,
         "character": 79
       },
       "end": {
-        "line": 75,
+        "line": 143,
         "character": 49
       }
     },
@@ -932,15 +1607,15 @@
   {
     "range": {
       "start": {
-        "line": 75,
+        "line": 143,
         "character": 14
       },
       "end": {
-        "line": 75,
+        "line": 143,
         "character": 49
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/release-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/release-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -960,11 +1635,11 @@
   {
     "range": {
       "start": {
-        "line": 77,
+        "line": 145,
         "character": 95
       },
       "end": {
-        "line": 78,
+        "line": 146,
         "character": 57
       }
     },
@@ -987,15 +1662,15 @@
   {
     "range": {
       "start": {
-        "line": 78,
+        "line": 146,
         "character": 14
       },
       "end": {
-        "line": 78,
+        "line": 146,
         "character": 57
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-files.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-files.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1015,11 +1690,11 @@
   {
     "range": {
       "start": {
-        "line": 80,
+        "line": 148,
         "character": 89
       },
       "end": {
-        "line": 81,
+        "line": 149,
         "character": 48
       }
     },
@@ -1042,15 +1717,15 @@
   {
     "range": {
       "start": {
-        "line": 81,
+        "line": 149,
         "character": 14
       },
       "end": {
-        "line": 81,
+        "line": 149,
         "character": 48
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/release-file.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/release-file.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1070,11 +1745,11 @@
   {
     "range": {
       "start": {
-        "line": 83,
+        "line": 151,
         "character": 105
       },
       "end": {
-        "line": 84,
+        "line": 152,
         "character": 56
       }
     },
@@ -1097,15 +1772,15 @@
   {
     "range": {
       "start": {
-        "line": 84,
+        "line": 152,
         "character": 14
       },
       "end": {
-        "line": 84,
+        "line": 152,
         "character": 56
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-file.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-file.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1125,11 +1800,11 @@
   {
     "range": {
       "start": {
-        "line": 86,
+        "line": 154,
         "character": 81
       },
       "end": {
-        "line": 87,
+        "line": 155,
         "character": 64
       }
     },
@@ -1152,15 +1827,15 @@
   {
     "range": {
       "start": {
-        "line": 87,
+        "line": 155,
         "character": 14
       },
       "end": {
-        "line": 87,
+        "line": 155,
         "character": 64
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-release-commits.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-release-commits.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1180,11 +1855,11 @@
   {
     "range": {
       "start": {
-        "line": 89,
+        "line": 157,
         "character": 97
       },
       "end": {
-        "line": 90,
+        "line": 158,
         "character": 59
       }
     },
@@ -1207,15 +1882,15 @@
   {
     "range": {
       "start": {
-        "line": 90,
+        "line": 158,
         "character": 14
       },
       "end": {
-        "line": 90,
+        "line": 158,
         "character": 59
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-commits.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/project-release-commits.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1235,11 +1910,11 @@
   {
     "range": {
       "start": {
-        "line": 92,
+        "line": 160,
         "character": 85
       },
       "end": {
-        "line": 93,
+        "line": 161,
         "character": 69
       }
     },
@@ -1262,15 +1937,15 @@
   {
     "range": {
       "start": {
-        "line": 93,
+        "line": 161,
         "character": 14
       },
       "end": {
-        "line": 93,
+        "line": 161,
         "character": 69
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-release-commit-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/releases/organization-release-commit-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1290,11 +1965,11 @@
   {
     "range": {
       "start": {
-        "line": 95,
+        "line": 163,
         "character": 79
       },
       "end": {
-        "line": 96,
+        "line": 164,
         "character": 72
       }
     },
@@ -1317,15 +1992,15 @@
   {
     "range": {
       "start": {
-        "line": 96,
+        "line": 164,
         "character": 14
       },
       "end": {
-        "line": 96,
+        "line": 164,
         "character": 72
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-installations.json' [path: paths./api/0/organizations/{organization_id_or_slug}/sentry-app-installations/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-installations.json' [path: paths./api/0/organizations/{organization_id_or_slug}/sentry-app-installations/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1345,11 +2020,11 @@
   {
     "range": {
       "start": {
-        "line": 98,
+        "line": 166,
         "character": 62
       },
       "end": {
-        "line": 99,
+        "line": 167,
         "character": 74
       }
     },
@@ -1372,15 +2047,15 @@
   {
     "range": {
       "start": {
-        "line": 99,
+        "line": 167,
         "character": 14
       },
       "end": {
-        "line": 99,
+        "line": 167,
         "character": 74
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issues.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issues.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1400,11 +2075,11 @@
   {
     "range": {
       "start": {
-        "line": 101,
+        "line": 169,
         "character": 82
       },
       "end": {
-        "line": 102,
+        "line": 170,
         "character": 81
       }
     },
@@ -1427,15 +2102,15 @@
   {
     "range": {
       "start": {
-        "line": 102,
+        "line": 170,
         "character": 14
       },
       "end": {
-        "line": 102,
+        "line": 170,
         "character": 81
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issue-details.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issue-details.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1455,11 +2130,11 @@
   {
     "range": {
       "start": {
-        "line": 104,
+        "line": 172,
         "character": 72
       },
       "end": {
-        "line": 105,
+        "line": 173,
         "character": 52
       }
     },
@@ -1482,15 +2157,15 @@
   {
     "range": {
       "start": {
-        "line": 105,
+        "line": 173,
         "character": 14
       },
       "end": {
-        "line": 105,
+        "line": 173,
         "character": 52
       }
     },
-    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/spike-protection.json' [path: paths./api/0/organizations/{organization_id_or_slug}/spike-protections/.$ref]",
+    "message": "ENOENT: no such file or directory, open '/tmp/jentic.apitools_import_8uei5kr4/sentry.io/main/v0/meta/import/paths/projects/spike-protection.json' [path: paths./api/0/organizations/{organization_id_or_slug}/spike-protections/.$ref]",
     "severity": 1,
     "code": "invalid-ref",
     "code_description": null,
@@ -1503,681 +2178,6 @@
         "paths",
         "/api/0/organizations/{organization_id_or_slug}/spike-protections/",
         "$ref"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/organizations/repos.json' [path: paths./api/0/organizations/{organization_id_or_slug}/repos/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/repos/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/dsyms.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/files/dsyms/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/users.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/users/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/tag-values.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/tags/{key}/values/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/stats.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/stats/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/user-feedback.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/user-feedback/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/service-hooks.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/service-hook-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/hooks/{hook_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/project-event-details.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/events/{event_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/project-issues.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/issues/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/tag-values.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/tags/{key}/values/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/issue-hashes.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/hashes/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/events/issue-details.json' [path: paths./api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-releases.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/releases/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/release-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-files.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/release-file.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/files/{file_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-file.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/files/{file_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-release-commits.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/commits/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/project-release-commits.json' [path: paths./api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/projects/{organization_id_or_slug}/{project_id_or_slug}/releases/{version}/commits/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/releases/organization-release-commit-files.json' [path: paths./api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/releases/{version}/commitfiles/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-installations.json' [path: paths./api/0/organizations/{organization_id_or_slug}/sentry-app-installations/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/sentry-app-installations/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issues.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/sentry-app-installations/{uuid}/external-issues/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/integration-platform/sentry-app-external-issue-details.json' [path: paths./api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/sentry-app-installations/{uuid}/external-issues/{external_issue_id}/"
-      ],
-      "target": "bundled-spec"
-    }
-  },
-  {
-    "range": {
-      "start": {
-        "line": 0,
-        "character": 0
-      },
-      "end": {
-        "line": 0,
-        "character": 0
-      }
-    },
-    "message": "Can't resolve $ref: ENOENT: no such file or directory '/tmp/jentic.apitools_import_1ple5yvn/sentry.io/main/v0/meta/import/paths/projects/spike-protection.json' [path: paths./api/0/organizations/{organization_id_or_slug}/spike-protections/]",
-    "severity": 1,
-    "code": "no-unresolved-refs",
-    "code_description": null,
-    "source": "redocly-validator",
-    "tags": null,
-    "related_information": null,
-    "data": {
-      "fixable": true,
-      "path": [
-        "paths",
-        "/api/0/organizations/{organization_id_or_slug}/spike-protections/"
       ],
       "target": "bundled-spec"
     }
@@ -2373,6 +2373,69 @@
           "region"
         ],
         [
+          "tags",
+          0
+        ],
+        [
+          "tags",
+          0,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          1
+        ],
+        [
+          "tags",
+          1,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          2
+        ],
+        [
+          "tags",
+          2,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          3
+        ],
+        [
+          "tags",
+          3,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          4
+        ],
+        [
+          "tags",
+          4,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          5
+        ],
+        [
+          "tags",
+          5,
+          "externalDocs"
+        ],
+        [
+          "tags",
+          6
+        ],
+        [
+          "tags",
+          6,
+          "externalDocs"
+        ],
+        [
           "paths",
           "/api/0/organizations/{organization_id_or_slug}/repos/"
         ],
@@ -2481,69 +2544,6 @@
           "components",
           "securitySchemes",
           "dsn"
-        ],
-        [
-          "tags",
-          0
-        ],
-        [
-          "tags",
-          0,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          1
-        ],
-        [
-          "tags",
-          1,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          2
-        ],
-        [
-          "tags",
-          2,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          3
-        ],
-        [
-          "tags",
-          3,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          4
-        ],
-        [
-          "tags",
-          4,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          5
-        ],
-        [
-          "tags",
-          5,
-          "externalDocs"
-        ],
-        [
-          "tags",
-          6
-        ],
-        [
-          "tags",
-          6,
-          "externalDocs"
         ]
       ]
     }
@@ -2889,7 +2889,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/organizations/repos.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/organizations/repos.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/organizations/repos.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/organizations/repos.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -2900,7 +2900,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1repos~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/organizations/repos.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/organizations/repos.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/organizations/repos.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/organizations/repos.json\""
     }
   },
   {
@@ -2914,7 +2914,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/dsyms.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/dsyms.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/dsyms.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/dsyms.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -2925,7 +2925,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1files~1dsyms~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/dsyms.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/dsyms.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/dsyms.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/dsyms.json\""
     }
   },
   {
@@ -2939,7 +2939,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/users.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/users.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/users.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/users.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -2950,7 +2950,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1users~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/users.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/users.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/users.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/users.json\""
     }
   },
   {
@@ -2964,7 +2964,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/tag-values.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/tag-values.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -2975,7 +2975,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1tags~1{key}~1values~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/tag-values.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/tag-values.json\""
     }
   },
   {
@@ -2989,7 +2989,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/stats.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/stats.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/stats.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/stats.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3000,7 +3000,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1stats~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/stats.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/stats.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/stats.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/stats.json\""
     }
   },
   {
@@ -3014,7 +3014,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/user-feedback.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/user-feedback.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/user-feedback.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/user-feedback.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3025,7 +3025,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1user-feedback~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/user-feedback.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/user-feedback.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/user-feedback.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/user-feedback.json\""
     }
   },
   {
@@ -3039,7 +3039,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hooks.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/service-hooks.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hooks.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/service-hooks.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3050,7 +3050,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1hooks~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hooks.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/service-hooks.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hooks.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/service-hooks.json\""
     }
   },
   {
@@ -3064,7 +3064,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hook-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/service-hook-details.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hook-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/service-hook-details.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3075,7 +3075,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1hooks~1{hook_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hook-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/service-hook-details.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/service-hook-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/service-hook-details.json\""
     }
   },
   {
@@ -3089,7 +3089,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-event-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/project-event-details.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-event-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/project-event-details.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3100,7 +3100,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1events~1{event_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-event-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/project-event-details.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-event-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/project-event-details.json\""
     }
   },
   {
@@ -3114,7 +3114,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-issues.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/project-issues.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-issues.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/project-issues.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3125,7 +3125,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1issues~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-issues.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/project-issues.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/project-issues.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/project-issues.json\""
     }
   },
   {
@@ -3139,7 +3139,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/tag-values.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/tag-values.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3150,7 +3150,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1issues~1{issue_id}~1tags~1{key}~1values~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/tag-values.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/tag-values.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/tag-values.json\""
     }
   },
   {
@@ -3164,7 +3164,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-hashes.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/issue-hashes.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-hashes.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/issue-hashes.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3175,7 +3175,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1issues~1{issue_id}~1hashes~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-hashes.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/issue-hashes.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-hashes.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/issue-hashes.json\""
     }
   },
   {
@@ -3189,7 +3189,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/issue-details.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/issue-details.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3200,7 +3200,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1issues~1{issue_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/events/issue-details.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/events/issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/events/issue-details.json\""
     }
   },
   {
@@ -3214,7 +3214,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-releases.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-releases.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-releases.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-releases.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3225,7 +3225,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1releases~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-releases.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-releases.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-releases.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-releases.json\""
     }
   },
   {
@@ -3239,7 +3239,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/release-files.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/release-files.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3250,7 +3250,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1releases~1{version}~1files~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/release-files.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/release-files.json\""
     }
   },
   {
@@ -3264,7 +3264,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-files.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-files.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3275,7 +3275,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1releases~1{version}~1files~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-files.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-files.json\""
     }
   },
   {
@@ -3289,7 +3289,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-file.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/release-file.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-file.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/release-file.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3300,7 +3300,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1releases~1{version}~1files~1{file_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-file.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/release-file.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/release-file.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/release-file.json\""
     }
   },
   {
@@ -3314,7 +3314,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-file.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-file.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-file.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-file.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3325,7 +3325,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1releases~1{version}~1files~1{file_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-file.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-file.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-file.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-file.json\""
     }
   },
   {
@@ -3339,7 +3339,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-release-commits.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-release-commits.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3350,7 +3350,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1releases~1{version}~1commits~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-release-commits.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-release-commits.json\""
     }
   },
   {
@@ -3364,7 +3364,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-commits.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-commits.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3375,7 +3375,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1projects~1{organization_id_or_slug}~1{project_id_or_slug}~1releases~1{version}~1commits~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/project-release-commits.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/project-release-commits.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/project-release-commits.json\""
     }
   },
   {
@@ -3389,7 +3389,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commit-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-release-commit-files.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commit-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-release-commit-files.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3400,7 +3400,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1releases~1{version}~1commitfiles~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commit-files.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/releases/organization-release-commit-files.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/releases/organization-release-commit-files.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/releases/organization-release-commit-files.json\""
     }
   },
   {
@@ -3414,7 +3414,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-installations.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-installations.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-installations.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-installations.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3425,7 +3425,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1sentry-app-installations~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-installations.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-installations.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-installations.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-installations.json\""
     }
   },
   {
@@ -3439,7 +3439,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issues.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-external-issues.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issues.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-external-issues.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3450,7 +3450,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1sentry-app-installations~1{uuid}~1external-issues~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issues.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-external-issues.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issues.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-external-issues.json\""
     }
   },
   {
@@ -3464,7 +3464,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-external-issue-details.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-external-issue-details.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3475,7 +3475,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1sentry-app-installations~1{uuid}~1external-issues~1{external_issue_id}~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/integration-platform/sentry-app-external-issue-details.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/integration-platform/sentry-app-external-issue-details.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/integration-platform/sentry-app-external-issue-details.json\""
     }
   },
   {
@@ -3489,7 +3489,7 @@
         "character": 0
       }
     },
-    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/spike-protection.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/spike-protection.json\"",
+    "message": "Dereference error: Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/spike-protection.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/spike-protection.json\"",
     "severity": 1,
     "code": "dereference_error",
     "code_description": null,
@@ -3500,7 +3500,7 @@
       "fixable": true,
       "path": "/paths/~1api~10~1organizations~1{organization_id_or_slug}~1spike-protections~1",
       "target": "bundled-spec",
-      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/spike-protection.json\": Error while reading file \"https://raw.githubusercontent.com/sophie-jentic/openapi-specs/refs/heads/import-jentic-pr-specs/sentry.io/sentry-public-api/v0/paths/projects/spike-protection.json\""
+      "error": "Error while dereferencing Path Item Object. Cannot resolve $ref \"paths/projects/spike-protection.json\": Error while reading file \"https://raw.githubusercontent.com/jentic/jentic-public-apis/refs/heads/main/apis/openapi/sentry.io/main/v0/paths/projects/spike-protection.json\""
     }
   },
   {

--- a/apis/openapi/sentry.io/main/v0/meta/meta.json
+++ b/apis/openapi/sentry.io/main/v0/meta/meta.json
@@ -17,7 +17,7 @@
   "meta": {
     "timestamps": {
       "added": "2026-04-02T00:33:02+00:00",
-      "updated": "2026-04-02T00:33:02+00:00"
+      "updated": "2026-04-29T15:53:23Z"
     },
     "diagnostics": {
       "severity": {

--- a/apis/openapi/sentry.io/main/v0/scorecard.json
+++ b/apis/openapi/sentry.io/main/v0/scorecard.json
@@ -4,7 +4,7 @@
     "releaseDate": null,
     "engine": {
       "name": "Jentic API Scoring Framework",
-      "version": "0.4.0+jairf.1.0.0"
+      "version": "0.4.1+jairf.1.0.0"
     },
     "disclaimer": "Scores are indicative and opinion biased based on Jentic's view of what is important to deliver APIs which higher levels of interpretability for AI systems."
   },
@@ -32,7 +32,7 @@
     "tagCount": 7
   },
   "summary": {
-    "scoringDate": "2026-04-02T00:33:02Z",
+    "scoringDate": "2026-04-29T15:53:23Z",
     "score": 59.67,
     "level": "foundational",
     "grade": "C+",


### PR DESCRIPTION
This PR updates the scoring artifacts for `sentry.io/main@v0` with a fresh re-score.

Updated files:
- `apis/openapi/sentry.io/main/v0/scorecard.json`
- `apis/openapi/sentry.io/main/v0/meta/meta.json`
- `apis/openapi/sentry.io/main/v0/meta/diagnostics.json`
