### PR TITLE
Security: Fix 3 findings in GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-arazzo.yaml
+++ b/.github/workflows/auto-arazzo.yaml
@@ -19,9 +19,11 @@
 
         - name: Extract OpenAPI URL and Details from issue body
           id: extract_info
+          env:
+              ISSUE_BODY: ${{ github.event.issue.body }}
           run: |
             echo "Parsing OpenAPI URL and details from issue..."
-            BODY="${{ github.event.issue.body }}"
+            BODY="$ISSUE_BODY"
             URL=$(echo "$BODY" | grep -oP '(?<=openapi_url:).*' | head -n 1 | xargs)
             # Attempt to extract vendor and api_name from URL structure
             # Example: .../apis/openapi/vendor.com/api_name/version/openapi.json

--- a/.github/workflows/import-openapi-to-oak.yaml
+++ b/.github/workflows/import-openapi-to-oak.yaml
@@ -21,11 +21,13 @@ jobs:
 
       - name: Extract Info from Issue
         id: extract_info
+        env:
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           # set -x # Enable debugging output
 
           echo "Parsing REQUIRED OpenAPI URL and Vendor Name from issue..."
-          BODY="${{ github.event.issue.body }}"
+          BODY="$ISSUE_BODY"
           BODY=$(echo "$BODY" | tr -d '\r')
 
           # Extract URL (Required)

--- a/.github/workflows/import-openapi.yaml
+++ b/.github/workflows/import-openapi.yaml
@@ -90,11 +90,13 @@ jobs:
         # Only run if the issue body contains the trigger string
         if: contains(github.event.issue.body, 'import_oas_url:')
         id: extract_info_from_issue
+        env:
+            ISSUE_BODY: ${{ github.event.issue.body }}
         run: |
           # set -x # Enable debugging output
 
           echo "Parsing REQUIRED OpenAPI URL and Vendor Name from issue..."
-          BODY="${{ github.event.issue.body }}"
+          BODY="$ISSUE_BODY"
           BODY=$(echo "$BODY" | tr -d '\r')
           # Strip leading whitespace from each line to allow indented fields
           BODY_STRIPPED=$(echo "$BODY" | sed 's/^[[:space:]]*//')


### PR DESCRIPTION
## Security: 3 findings across 1 rule

### Fixed (deterministic, no AI)

**shell-injection-expr** — [What is this?](https://sentinel-bot.copilotkit.dev/rules/shell-injection-expr)
- `auto-arazzo.yaml` line 24: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk
- `import-openapi-to-oak.yaml` line 28: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk
- `import-openapi.yaml` line 97: Attacker-controllable expression ${{ github.event.issue.body }} in run: block — shell injection risk

### How this was detected

This finding was identified by deterministic pattern matching — no AI or machine learning was used in the detection. Sentinel uses static analysis rules that match known-vulnerable YAML patterns against a database of documented exploit vectors. Every finding maps to a specific, reproducible pattern. [Source code](https://github.com/jpr5/sentinel) is open for inspection.

---
<sub>&#x1f6e1;&#xfe0f; This PR was generated by [Sentinel](https://sentinel.copilotkit.dev), an open-source security scanner. [Why this PR?](https://medium.com/@jordanritter/security-hardening-github-workflows-at-scale-d291a33774e1) · Free, no tracking</sub>

[&#x2705; Add Sentinel to this repo](https://sentinel-bot.copilotkit.dev/adopt?repo=jentic%2Fjentic-public-apis&token=793036dd-9b9f-436b-bf43-e32679c56f45) · [&#x1f6ab; Opt out of future PRs](https://sentinel-bot.copilotkit.dev/opt-out?repo=jentic%2Fjentic-public-apis&token=33fec8d2-6a52-48bb-b0ad-35cf56b8f441)
